### PR TITLE
Mirror of apache flink#8486

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -84,7 +84,7 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 
 	private static final Logger LOG = ExecutionGraph.LOG;
 
-	private static final int MAX_DISTINCT_LOCATIONS_TO_CONSIDER = 8;
+	public static final int MAX_DISTINCT_LOCATIONS_TO_CONSIDER = 8;
 
 	// --------------------------------------------------------------------------------------------
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocator.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.SlotProfile;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.executiongraph.ExecutionEdge;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
+import org.apache.flink.runtime.jobmanager.scheduler.ScheduledUnit;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.jobmaster.slotpool.Scheduler;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.runtime.executiongraph.ExecutionVertex.MAX_DISTINCT_LOCATIONS_TO_CONSIDER;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Default {@link ExecutionSlotAllocator} which will use {@link SlotProvider} to allocate slots and
+ * keep the unfulfilled requests for further cancellation.
+ */
+public class DefaultExecutionSlotAllocator implements ExecutionSlotAllocator {
+
+	static final Logger LOG = LoggerFactory.getLogger(DefaultExecutionSlotAllocator.class);
+
+	/**
+	 * Store the uncompleted slot assignments.
+	 */
+	private final Map<ExecutionVertexID, SlotExecutionVertexAssignment> pendingSlotAssignments;
+
+	private final SlotProvider slotProvider;
+
+	private final ExecutionGraph executionGraph;
+
+	public DefaultExecutionSlotAllocator(SlotProvider slotProvider, ExecutionGraph executionGraph) {
+		this.slotProvider = checkNotNull(slotProvider);
+		this.executionGraph = checkNotNull(executionGraph);
+
+		pendingSlotAssignments = new HashMap<>();
+	}
+
+	@Override
+	public Collection<SlotExecutionVertexAssignment> allocateSlotsFor(
+			Collection<ExecutionVertexSchedulingRequirements> executionVertexSchedulingRequirements) {
+
+		List<SlotExecutionVertexAssignment> slotExecutionVertexAssignments =
+				new ArrayList<>(executionVertexSchedulingRequirements.size());
+
+		Set<AllocationID> allPreviousAllocationIds =
+				computeAllPriorAllocationIdsIfRequiredByScheduling(executionVertexSchedulingRequirements);
+
+		Set<ExecutionVertexID> verticesScheduledTogether = getAllExecutionVerticesId(executionVertexSchedulingRequirements);
+
+		for (ExecutionVertexSchedulingRequirements schedulingRequirements : executionVertexSchedulingRequirements) {
+			final ExecutionVertexID executionVertexId = schedulingRequirements.getExecutionVertexId();
+			final SlotRequestId slotRequestId = new SlotRequestId();
+			final SlotSharingGroupId slotSharingGroupId = schedulingRequirements.getSlotSharingGroupId();
+
+			Execution execution = null;
+			ExecutionJobVertex ejv = executionGraph.getJobVertex(executionVertexId.getJobVertexId());
+			if (ejv != null && ejv.getParallelism() > executionVertexId.getSubtaskIndex()) {
+				execution = ejv.getTaskVertices()[executionVertexId.getSubtaskIndex()].getCurrentExecutionAttempt();
+
+			}
+			if (execution == null) {
+				throw new IllegalArgumentException("Fail to get execution for vertex id " + executionVertexId);
+			}
+
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("Allocate slot with id {} for execution {}", slotRequestId, executionVertexId);
+			}
+
+			// TODO: the calculation of preferred location should be refined so we can use the preferredLocations
+			// in ExecutionVertexSchedulingRequirements instead of calculating it here
+			CompletableFuture<LogicalSlot> slotFuture =
+					calculatePreferredLocations(execution, verticesScheduledTogether).thenCompose(
+							(Collection<TaskManagerLocation> preferredLocations) ->
+								slotProvider.allocateSlot(
+									slotRequestId,
+									new ScheduledUnit(
+											null,
+											executionVertexId.getJobVertexId(),
+											slotSharingGroupId,
+											schedulingRequirements.getCoLocationConstraint()),
+									new SlotProfile(
+											schedulingRequirements.getResourceProfile(),
+											preferredLocations,
+											Arrays.asList(schedulingRequirements.getPreviousAllocationId()),
+											allPreviousAllocationIds),
+									executionGraph.isQueuedSchedulingAllowed(),
+									executionGraph.getAllocationTimeout()));
+
+			SlotExecutionVertexAssignment slotExecutionVertexAssignment =
+					new SlotExecutionVertexAssignment(executionVertexId, slotFuture);
+			// add to map first to avoid the future completed before added.
+			pendingSlotAssignments.put(executionVertexId, slotExecutionVertexAssignment);
+
+			slotFuture.whenComplete(
+					(ignored, throwable) -> {
+						pendingSlotAssignments.remove(executionVertexId);
+						if (throwable != null) {
+							slotProvider.cancelSlotRequest(slotRequestId, slotSharingGroupId, throwable);
+						}
+					});
+
+			slotExecutionVertexAssignments.add(slotExecutionVertexAssignment);
+		}
+
+		return slotExecutionVertexAssignments;
+	}
+
+	@Override
+	public void cancel(ExecutionVertexID executionVertexId) {
+		SlotExecutionVertexAssignment slotExecutionVertexAssignment = pendingSlotAssignments.get(executionVertexId);
+		if (slotExecutionVertexAssignment != null) {
+			slotExecutionVertexAssignment.getLogicalSlotFuture().cancel(false);
+		}
+	}
+
+	@Override
+	public CompletableFuture<Void> stop() {
+		List<ExecutionVertexID> executionVertexIds = new ArrayList<>(pendingSlotAssignments.keySet());
+		executionVertexIds.stream().forEach(executionVertexID -> cancel(executionVertexID));
+
+		return CompletableFuture.completedFuture(null);
+	}
+
+	private static Set<ExecutionVertexID> getAllExecutionVerticesId(
+			Collection<ExecutionVertexSchedulingRequirements> executionVertexSchedulingRequirements) {
+		Set<ExecutionVertexID> executionVertexIds = new HashSet<>(executionVertexSchedulingRequirements.size());
+		for (ExecutionVertexSchedulingRequirements schedulingRequirements : executionVertexSchedulingRequirements) {
+			executionVertexIds.add(schedulingRequirements.getExecutionVertexId());
+		}
+		return executionVertexIds;
+	}
+
+	/**
+	 * Calculates the preferred locations for an execution.
+	 * It will first try to use preferred locations based on state,
+	 * if null, will use the preferred locations based on inputs.
+	 */
+	private static CompletableFuture<Collection<TaskManagerLocation>> calculatePreferredLocations(
+			Execution execution,
+			Collection<ExecutionVertexID> verticesScheduledTogether) {
+
+		Collection<CompletableFuture<TaskManagerLocation>> preferredLocations =
+				execution.getVertex().getPreferredLocationsBasedOnState();
+
+		if (preferredLocations == null) {
+			preferredLocations = getPreferredLocationsBasedOnInputs(execution, verticesScheduledTogether);
+		}
+		return FutureUtils.combineAll(preferredLocations);
+	}
+
+	/**
+	 * Gets the location preferences of the execution, as determined by the locations
+	 * of the predecessors from which it receives input data.
+	 * If there are more than {@link MAX_DISTINCT_LOCATIONS_TO_CONSIDER} different locations of source data,
+	 * or neither the sources have not been started nor will be started with the execution together,
+	 * this method returns an empty collection to indicate no location preference.
+	 *
+	 * @return The preferred locations based in input streams, or an empty iterable,
+	 *         if there is no input-based preference.
+	 */
+	@VisibleForTesting
+	static Collection<CompletableFuture<TaskManagerLocation>> getPreferredLocationsBasedOnInputs(
+			Execution execution,
+			Collection<ExecutionVertexID> verticesScheduledTogether) {
+		Collection<CompletableFuture<TaskManagerLocation>> preferredLocations = new HashSet<>();
+
+		Set<CompletableFuture<TaskManagerLocation>> inputLocations = new HashSet<>();
+		for (int i = 0; i < execution.getVertex().getNumberOfInputs(); i++) {
+			ExecutionEdge[] inputEdges = execution.getVertex().getInputEdges(i);
+			if (inputEdges.length <= MAX_DISTINCT_LOCATIONS_TO_CONSIDER) {
+				for (ExecutionEdge inputEdge : inputEdges) {
+					ExecutionVertex producer = inputEdge.getSource().getProducer();
+					if (verticesScheduledTogether.contains(
+							new ExecutionVertexID(producer.getJobvertexId(), producer.getParallelSubtaskIndex()))
+							|| producer.getExecutionState() != ExecutionState.CREATED) {
+						inputLocations.add(producer.getCurrentTaskManagerLocationFuture());
+					} else {
+						inputLocations.clear();
+						break;
+					}
+				}
+				if (preferredLocations.isEmpty() ||
+						(!inputLocations.isEmpty() && inputLocations.size() < preferredLocations.size())) {
+					preferredLocations.clear();
+					preferredLocations.addAll(inputLocations);
+				}
+				inputLocations.clear();
+			}
+		}
+		return preferredLocations;
+	}
+
+	/**
+	 * Returns the result of {@link #computeAllPriorAllocationIds}, but only if the scheduling really requires it.
+	 * Otherwise this method simply returns an empty set.
+	 */
+	private Set<AllocationID> computeAllPriorAllocationIdsIfRequiredByScheduling(
+			Collection<ExecutionVertexSchedulingRequirements> executionVertexSchedulingRequirements) {
+		// This is a temporary optimization to avoid computing all previous allocations if not required
+		// This can go away when we progress with the implementation of the Scheduler.
+		if (slotProvider instanceof Scheduler && ((Scheduler) slotProvider).requiresPreviousExecutionGraphAllocations()) {
+			return computeAllPriorAllocationIds(executionVertexSchedulingRequirements);
+		} else {
+			return Collections.emptySet();
+		}
+	}
+
+	/**
+	 * Computes and returns a set with the prior allocation ids from all execution vertices scheduled together.
+	 *
+	 * @param executionVertexSchedulingRequirements contains the execution vertices which are scheduled together
+	 */
+	@VisibleForTesting
+	static Set<AllocationID> computeAllPriorAllocationIds(
+			Collection<ExecutionVertexSchedulingRequirements> executionVertexSchedulingRequirements) {
+		HashSet<AllocationID> allPreviousAllocationIds = new HashSet<>(executionVertexSchedulingRequirements.size());
+		for (ExecutionVertexSchedulingRequirements schedulingRequirements : executionVertexSchedulingRequirements) {
+			AllocationID priorAllocation = schedulingRequirements.getPreviousAllocationId();
+			if (priorAllocation != null) {
+				allPreviousAllocationIds.add(priorAllocation);
+			}
+		}
+		return allPreviousAllocationIds;
+	}
+
+	@VisibleForTesting
+	Map<ExecutionVertexID, SlotExecutionVertexAssignment> getPendingSlotAssignments() {
+		return Collections.unmodifiableMap(pendingSlotAssignments);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotAllocator.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Component responsible for assigning slots to a collection of {@link Execution}.
+ */
+public interface ExecutionSlotAllocator {
+
+	/**
+	 * Allocates slots for the given executions.
+	 *
+	 * @param executionVertexSchedulingRequirements The requirements for scheduling the executions.
+	 */
+	Collection<SlotExecutionVertexAssignment> allocateSlotsFor(
+			Collection<ExecutionVertexSchedulingRequirements> executionVertexSchedulingRequirements);
+
+	/**
+	 * Cancel an ongoing slot request.
+	 *
+	 * @param executionVertexId identifying which slot request should be canceled.
+	 */
+	void cancel(ExecutionVertexID executionVertexId);
+
+	/**
+	 * Stop the allocator.
+	 */
+	CompletableFuture<Void> stop();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexSchedulingRequirements.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexSchedulingRequirements.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
+import org.apache.flink.runtime.jobmanager.scheduler.CoLocationConstraint;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.util.AbstractID;
+
+import java.util.Collection;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The requirements for scheduling a {@link ExecutionVertex}.
+ */
+public class ExecutionVertexSchedulingRequirements {
+
+	private final ExecutionVertexID executionVertexId;
+
+	private final AllocationID previousAllocationId;
+
+	private final ResourceProfile resourceProfile;
+
+	private final SlotSharingGroupId slotSharingGroupId;
+
+	private final CoLocationConstraint coLocationConstraint;
+
+	private final AbstractID groupId;
+
+	private final Collection<TaskManagerLocation> preferredLocations;
+
+	public ExecutionVertexSchedulingRequirements(
+			ExecutionVertexID executionVertexId,
+			AllocationID previousAllocationId,
+			ResourceProfile resourceProfile,
+			SlotSharingGroupId slotSharingGroupId,
+			CoLocationConstraint coLocationConstraint,
+			AbstractID groupId,
+			Collection<TaskManagerLocation> preferredLocations) {
+		this.executionVertexId = checkNotNull(executionVertexId);
+		this.previousAllocationId = previousAllocationId;
+		this.resourceProfile = checkNotNull(resourceProfile);
+		this.slotSharingGroupId = slotSharingGroupId;
+		this.coLocationConstraint = coLocationConstraint;
+		this.groupId = groupId;
+		this.preferredLocations = preferredLocations;
+	}
+
+	public ExecutionVertexID getExecutionVertexId() {
+		return executionVertexId;
+	}
+
+	public AllocationID getPreviousAllocationId() {
+		return previousAllocationId;
+	}
+
+	public ResourceProfile getResourceProfile() {
+		return resourceProfile;
+	}
+
+	public SlotSharingGroupId getSlotSharingGroupId() {
+		return slotSharingGroupId;
+	}
+
+	public CoLocationConstraint getCoLocationConstraint() {
+		return coLocationConstraint;
+	}
+
+	public AbstractID getGroupId() {
+		return groupId;
+	}
+
+	public Collection<TaskManagerLocation> getPreferredLocations() {
+		return preferredLocations;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SlotExecutionVertexAssignment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SlotExecutionVertexAssignment.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The slot assignment for a {@link ExecutionVertex}.
+ */
+public class SlotExecutionVertexAssignment {
+
+	private final ExecutionVertexID executionVertexId;
+
+	private final CompletableFuture<LogicalSlot> logicalSlotFuture;
+
+	public SlotExecutionVertexAssignment(
+			ExecutionVertexID executionVertexId,
+			CompletableFuture<LogicalSlot> logicalSlotFuture) {
+		this.executionVertexId = checkNotNull(executionVertexId);
+		this.logicalSlotFuture = checkNotNull(logicalSlotFuture);
+	}
+
+	public ExecutionVertexID getExecutionVertexId() {
+		return executionVertexId;
+	}
+
+	public CompletableFuture<LogicalSlot> getLogicalSlotFuture() {
+		return logicalSlotFuture;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocatorTest.java
@@ -1,0 +1,338 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.TestingSlotProvider;
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobmanager.scheduler.LocationPreferenceConstraint;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.jobmaster.TestingLogicalSlot;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link DefaultExecutionSlotAllocator}.
+ */
+public class DefaultExecutionSlotAllocatorTest extends TestLogger {
+
+	private DefaultExecutionSlotAllocator executionSlotAllocator;
+
+	private TestingSlotProvider slotProvider;
+
+	private ExecutionGraph executionGraph;
+
+	private List<ExecutionVertexSchedulingRequirements> schedulingRequirements;
+
+	private Queue<CompletableFuture<LogicalSlot>> slotFutures;
+
+	private List<SlotRequestId> receivedSlotRequestIds;
+
+	private List<SlotRequestId> cancelledSlotRequestIds;
+
+	private List<ExecutionVertexID> executionVertexIds;
+
+	private int executionVerticesNum;
+
+	@Before
+	public void setUp() throws Exception {
+		executionGraph = createSimpleProducerConsumerGraph();
+
+		executionVerticesNum = executionGraph.getTotalNumberOfVertices();
+		receivedSlotRequestIds = new ArrayList<>(executionVerticesNum);
+		cancelledSlotRequestIds = new ArrayList<>(executionVerticesNum);
+		slotFutures = new ArrayDeque<>(executionVerticesNum);
+
+		slotProvider = new TestingSlotProvider(slotRequestId -> {
+			receivedSlotRequestIds.add(slotRequestId);
+			return slotFutures.poll();
+		});
+		slotProvider.setSlotCanceller(slotRequestId -> cancelledSlotRequestIds.add(slotRequestId));
+
+		executionSlotAllocator = new DefaultExecutionSlotAllocator(slotProvider, executionGraph);
+
+		schedulingRequirements = new ArrayList<>(executionVerticesNum);
+		executionVertexIds = new ArrayList<>(executionVerticesNum);
+
+		for (ExecutionVertex executionVertex : executionGraph.getAllExecutionVertices()) {
+			ExecutionVertexID executionVertexId =
+					new ExecutionVertexID(executionVertex.getJobvertexId(), executionVertex.getParallelSubtaskIndex());
+			schedulingRequirements.add(new ExecutionVertexSchedulingRequirements(
+					executionVertexId,
+					null,
+					ResourceProfile.UNKNOWN,
+					new SlotSharingGroupId(),
+					null,
+					null,
+					null
+			));
+			executionVertexIds.add(executionVertexId);
+			slotFutures.add(new CompletableFuture<>());
+		}
+	}
+
+	/**
+	 * Tests that it will allocate slots from slot provider and remove the slot assignments when request are fulfilled.
+	 */
+	@Test
+	public void testAllocateSlotsFor() {
+		List<CompletableFuture<LogicalSlot>> backupSlotFutures = new ArrayList<>(slotFutures);
+
+		executionSlotAllocator.allocateSlotsFor(schedulingRequirements);
+
+		assertThat(receivedSlotRequestIds, hasSize(executionVerticesNum / 2));
+		assertThat(executionSlotAllocator.getPendingSlotAssignments().keySet(), containsInAnyOrder(executionVertexIds.toArray()));
+
+		completeProducerSlotRequest(backupSlotFutures);
+
+		assertThat(receivedSlotRequestIds, hasSize(executionVerticesNum));
+	}
+
+	/**
+	 * Tests that when cancelling a slot request, the request to slot provider should also be cancelled.
+	 */
+	@Test
+	public void testCancel() {
+		List<CompletableFuture<LogicalSlot>> backupSlotFutures = new ArrayList<>(slotFutures);
+
+		executionSlotAllocator.allocateSlotsFor(schedulingRequirements);
+
+		// cancel a non-existing execution vertex
+		ExecutionVertexID inValidExecutionVertexId = new ExecutionVertexID(new JobVertexID(), 0);
+		executionSlotAllocator.cancel(inValidExecutionVertexId);
+		assertThat(cancelledSlotRequestIds, hasSize(0));
+
+		assertThat(receivedSlotRequestIds, hasSize(executionVerticesNum / 2));
+
+		completeProducerSlotRequest(backupSlotFutures);
+
+		for (ExecutionVertexID executionVertexId : executionVertexIds) {
+			executionSlotAllocator.cancel(executionVertexId);
+		}
+
+		// only the consumers slot request will be cancelled
+		List<SlotRequestId> expectCancelledSlotRequestIds =
+				receivedSlotRequestIds.subList(executionVerticesNum / 2, executionVerticesNum);
+		assertThat(cancelledSlotRequestIds, containsInAnyOrder(expectCancelledSlotRequestIds.toArray()));
+	}
+
+	/**
+	 * Tests that all unfulfilled slot requests will be cancelled when stopped.
+	 */
+	@Test
+	public void testStop() {
+		executionSlotAllocator.allocateSlotsFor(schedulingRequirements);
+
+		// only the producers will ask for slots as the preferred location futures of consumers are not fulfilled.
+		assertThat(executionSlotAllocator.getPendingSlotAssignments().keySet(), hasSize(executionVerticesNum));
+		assertThat(receivedSlotRequestIds, hasSize(executionVerticesNum / 2));
+
+		executionSlotAllocator.stop().getNow(null);
+
+		assertThat(cancelledSlotRequestIds, hasSize(executionVerticesNum / 2));
+		assertThat(cancelledSlotRequestIds, containsInAnyOrder(receivedSlotRequestIds.toArray()));
+		assertThat(executionSlotAllocator.getPendingSlotAssignments().keySet(), hasSize(0));
+	}
+
+	/**
+	 * Tests that all prior allocation ids are computed by union all previous allocation ids in scheduling requirements.
+	 */
+	@Test
+	public void testComputeAllPriorAllocationIds() {
+		List<AllocationID> expectAllocationIds = Arrays.asList(new AllocationID(), new AllocationID());
+		List<ExecutionVertexSchedulingRequirements> testSchedulingRequirements = Arrays.asList(
+				new ExecutionVertexSchedulingRequirements(
+						executionVertexIds.get(0),
+						expectAllocationIds.get(0),
+						ResourceProfile.UNKNOWN,
+						null,
+						null,
+						null,
+						null),
+				new ExecutionVertexSchedulingRequirements(
+						executionVertexIds.get(1),
+						expectAllocationIds.get(0),
+						ResourceProfile.UNKNOWN,
+						null,
+						null,
+						null,
+						null),
+				new ExecutionVertexSchedulingRequirements(
+						executionVertexIds.get(2),
+						expectAllocationIds.get(1),
+						ResourceProfile.UNKNOWN,
+						null,
+						null,
+						null,
+						null),
+				new ExecutionVertexSchedulingRequirements(
+						executionVertexIds.get(3),
+						null,
+						ResourceProfile.UNKNOWN,
+						null,
+						null,
+						null,
+						null)
+		);
+
+		Set<AllocationID> allPriorAllocationIds = executionSlotAllocator.computeAllPriorAllocationIds(testSchedulingRequirements);
+		assertThat(allPriorAllocationIds, containsInAnyOrder(expectAllocationIds.toArray()));
+	}
+
+	/**
+	 * Tests the calculation of preferred locations based on inputs for an execution.
+	 */
+	@Test
+	public void testGetPreferredLocationsBasedOnInputs() throws Exception {
+		TestingSlotProvider testingSlotProvider = new TestingSlotProvider((slotRequestId) -> new CompletableFuture<>());
+
+		JobVertex producer1 = new JobVertex("producer1");
+		producer1.setInvokableClass(NoOpInvokable.class);
+		producer1.setParallelism(10);
+
+		JobVertex producer2 = new JobVertex("producer2");
+		producer2.setInvokableClass(NoOpInvokable.class);
+		producer2.setParallelism(5);
+
+		JobVertex producer3 = new JobVertex("producer3");
+		producer3.setInvokableClass(NoOpInvokable.class);
+		producer3.setParallelism(3);
+
+		JobVertex consumer = new JobVertex("consumer");
+		consumer.setInvokableClass(NoOpInvokable.class);
+		consumer.setParallelism(1);
+
+		consumer.connectNewDataSetAsInput(producer1, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
+		consumer.connectNewDataSetAsInput(producer2, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
+		consumer.connectNewDataSetAsInput(producer3, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
+		ExecutionGraph eg = ExecutionGraphTestUtils.createSimpleTestGraph(new JobID(), producer1, producer2, producer3, consumer);
+
+		Set<ExecutionVertexID> executionVertexIds = new HashSet<>(eg.getTotalNumberOfVertices());
+		for (ExecutionVertex ev : eg.getAllExecutionVertices()) {
+			executionVertexIds.add(new ExecutionVertexID(ev.getJobvertexId(), ev.getParallelSubtaskIndex()));
+		}
+		Execution execution = eg.getJobVertex(consumer.getID()).getTaskVertices()[0].getCurrentExecutionAttempt();
+
+		// all producers have not been started.
+		Collection<CompletableFuture<TaskManagerLocation>> preferredLocations1 =
+				DefaultExecutionSlotAllocator.getPreferredLocationsBasedOnInputs(execution, Collections.emptySet());
+		assertThat(preferredLocations1, hasSize(0));
+
+		// all producers scheduled together, will use the locations of the inputs whose parallelism is smallest.
+		Collection<CompletableFuture<TaskManagerLocation>> preferredLocations2 =
+				DefaultExecutionSlotAllocator.getPreferredLocationsBasedOnInputs(execution, executionVertexIds);
+		assertThat(preferredLocations2, hasSize(3));
+
+		for (ExecutionVertex ev : eg.getJobVertex(producer1.getID()).getTaskVertices()) {
+			ev.scheduleForExecution(testingSlotProvider, true, LocationPreferenceConstraint.ALL, Collections.EMPTY_SET);
+		}
+
+		// if source have too many different locations, it will be ignored
+		Collection<CompletableFuture<TaskManagerLocation>> preferredLocations3 =
+				DefaultExecutionSlotAllocator.getPreferredLocationsBasedOnInputs(execution, Collections.EMPTY_SET);
+		assertThat(preferredLocations3, hasSize(0));
+
+		List<TaskManagerLocation> locationsForProducer2 = new ArrayList<>(producer2.getParallelism());
+		for (ExecutionVertex ev : eg.getJobVertex(producer2.getID()).getTaskVertices()) {
+			ev.scheduleForExecution(testingSlotProvider, true, LocationPreferenceConstraint.ALL, Collections.EMPTY_SET);
+			TaskManagerLocation location = new LocalTaskManagerLocation();
+			ev.getCurrentTaskManagerLocationFuture().complete(location);
+			locationsForProducer2.add(location);
+		}
+
+		// use the locations of input that have been stated
+		Collection<CompletableFuture<TaskManagerLocation>> preferredLocations4 =
+				DefaultExecutionSlotAllocator.getPreferredLocationsBasedOnInputs(execution, Collections.EMPTY_SET);
+		assertThat(FutureUtils.combineAll(preferredLocations4).getNow(null), containsInAnyOrder(locationsForProducer2.toArray()));
+
+		List<TaskManagerLocation> locationsForProducer3 = new ArrayList<>(producer3.getParallelism());
+		for (ExecutionVertex ev : eg.getJobVertex(producer3.getID()).getTaskVertices()) {
+			ev.scheduleForExecution(testingSlotProvider, true, LocationPreferenceConstraint.ALL, Collections.EMPTY_SET);
+			TaskManagerLocation location = new LocalTaskManagerLocation();
+			ev.getCurrentTaskManagerLocationFuture().complete(location);
+			locationsForProducer3.add(location);
+		}
+
+		// use the locations of input whose parallelism is smaller
+		Collection<CompletableFuture<TaskManagerLocation>> preferredLocations5 =
+				DefaultExecutionSlotAllocator.getPreferredLocationsBasedOnInputs(execution, Collections.EMPTY_SET);
+		assertThat(FutureUtils.combineAll(preferredLocations5).getNow(null), containsInAnyOrder(locationsForProducer3.toArray()));
+	}
+
+	private void completeProducerSlotRequest(List<CompletableFuture<LogicalSlot>> totalSlotFutures) {
+		// fulfill the producers and the location preferences of consumers, so the consumers will allocate slots
+		for (int i = 0; i < executionVerticesNum / 2; i++) {
+			LogicalSlot slot = new TestingLogicalSlot();
+			totalSlotFutures.get(i).complete(slot);
+			ExecutionJobVertex ejv = executionGraph.getJobVertex(executionVertexIds.get(i).getJobVertexId());
+			Execution execution = ejv.getTaskVertices()[executionVertexIds.get(i).getSubtaskIndex()].getCurrentExecutionAttempt();
+			execution.getTaskManagerLocationFuture().complete(slot.getTaskManagerLocation());
+		}
+	}
+
+	static ExecutionGraph createSimpleProducerConsumerGraph() throws Exception {
+		int parallelism = 3;
+
+		JobVertex producer = new JobVertex("producer");
+		producer.setInvokableClass(NoOpInvokable.class);
+		producer.setParallelism(parallelism);
+
+		JobVertex consumer = new JobVertex("consumer");
+		consumer.setInvokableClass(NoOpInvokable.class);
+		consumer.setParallelism(parallelism);
+
+		consumer.connectNewDataSetAsInput(producer, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
+
+		return ExecutionGraphTestUtils.createSimpleTestGraph(new JobID(), producer, consumer);
+	}
+}


### PR DESCRIPTION
Mirror of apache flink#8486

## What is the purpose of the change

*This pull request introduces the ExecutionSlotAllocator interface related classes and a default implementation. The implementation of ExecutionSlotAllocator will first calculate the preferred locations for the executions and then allocate slots for them. In the future, the calculation of preferred locations will be removed from here to make the ExecutionSlotAllocator more clean.*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit tests in DefaultExecutionSlotAllocatorTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)

