### PR TITLE
Mirror of apache flink#8485

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/InputChannelMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/InputChannelMetrics.java
@@ -32,13 +32,8 @@ public class InputChannelMetrics {
 
 	private static final String IO_NUM_BYTES_IN_LOCAL = MetricNames.IO_NUM_BYTES_IN + "Local";
 	private static final String IO_NUM_BYTES_IN_REMOTE = MetricNames.IO_NUM_BYTES_IN + "Remote";
-	private static final String IO_NUM_BYTES_IN_LOCAL_RATE = IO_NUM_BYTES_IN_LOCAL + MetricNames.SUFFIX_RATE;
-	private static final String IO_NUM_BYTES_IN_REMOTE_RATE = IO_NUM_BYTES_IN_REMOTE + MetricNames.SUFFIX_RATE;
-
 	private static final String IO_NUM_BUFFERS_IN_LOCAL = MetricNames.IO_NUM_BUFFERS_IN + "Local";
 	private static final String IO_NUM_BUFFERS_IN_REMOTE = MetricNames.IO_NUM_BUFFERS_IN + "Remote";
-	private static final String IO_NUM_BUFFERS_IN_LOCAL_RATE = IO_NUM_BUFFERS_IN_LOCAL + MetricNames.SUFFIX_RATE;
-	private static final String IO_NUM_BUFFERS_IN_REMOTE_RATE = IO_NUM_BUFFERS_IN_REMOTE + MetricNames.SUFFIX_RATE;
 
 	private final Counter numBytesInLocal;
 	private final Counter numBytesInRemote;
@@ -46,30 +41,70 @@ public class InputChannelMetrics {
 	private final Counter numBuffersInRemote;
 
 	public InputChannelMetrics(MetricGroup parent) {
-		this.numBytesInLocal = parent.counter(IO_NUM_BYTES_IN_LOCAL);
-		this.numBytesInRemote = parent.counter(IO_NUM_BYTES_IN_REMOTE);
-		parent.meter(IO_NUM_BYTES_IN_LOCAL_RATE, new MeterView(numBytesInLocal, 60));
-		parent.meter(IO_NUM_BYTES_IN_REMOTE_RATE, new MeterView(numBytesInRemote, 60));
-
-		this.numBuffersInLocal = parent.counter(IO_NUM_BUFFERS_IN_LOCAL);
-		this.numBuffersInRemote = parent.counter(IO_NUM_BUFFERS_IN_REMOTE);
-		parent.meter(IO_NUM_BUFFERS_IN_LOCAL_RATE, new MeterView(numBuffersInLocal, 60));
-		parent.meter(IO_NUM_BUFFERS_IN_REMOTE_RATE, new MeterView(numBuffersInRemote, 60));
+		this.numBytesInLocal = createCounter(parent, IO_NUM_BYTES_IN_LOCAL);
+		this.numBytesInRemote = createCounter(parent, IO_NUM_BYTES_IN_REMOTE);
+		this.numBuffersInLocal = createCounter(parent, IO_NUM_BUFFERS_IN_LOCAL);
+		this.numBuffersInRemote = createCounter(parent, IO_NUM_BUFFERS_IN_REMOTE);
 	}
 
-	public Counter getNumBytesInLocalCounter() {
-		return numBytesInLocal;
+	private static Counter createCounter(MetricGroup parent, String name) {
+		Counter counter = parent.counter(name);
+		parent.meter(name + MetricNames.SUFFIX_RATE, new MeterView(counter, 60));
+		return counter;
 	}
 
-	public Counter getNumBytesInRemoteCounter() {
-		return numBytesInRemote;
+	public void incNumBytesInLocalCounter(long inc) {
+		numBytesInLocal.inc(inc);
 	}
 
-	public Counter getNumBuffersInLocalCounter() {
-		return numBuffersInLocal;
+	public void incNumBytesInRemoteCounter(long inc) {
+		numBytesInRemote.inc(inc);
 	}
 
-	public Counter getNumBuffersInRemoteCounter() {
-		return numBuffersInRemote;
+	public void incNumBuffersInLocalCounter(long inc) {
+		numBuffersInLocal.inc(inc);
+	}
+
+	public void incNumBuffersInRemoteCounter(long inc) {
+		numBuffersInRemote.inc(inc);
+	}
+
+	/**
+	 * Wraps {@link InputChannelMetrics} with legacy metrics.
+	 * @deprecated eventually should be removed in favour of normal {@link InputChannelMetrics}.
+	 */
+	@SuppressWarnings("DeprecatedIsStillUsed")
+	@Deprecated
+	public static class InputChannelMetricsWithLegacy extends InputChannelMetrics {
+		private final InputChannelMetrics legacyMetrics;
+
+		public InputChannelMetricsWithLegacy(MetricGroup parent, MetricGroup legacyParent) {
+			super(parent);
+			legacyMetrics = new InputChannelMetrics(legacyParent);
+		}
+
+		@Override
+		public void incNumBytesInLocalCounter(long inc) {
+			super.incNumBytesInLocalCounter(inc);
+			legacyMetrics.incNumBytesInLocalCounter(inc);
+		}
+
+		@Override
+		public void incNumBytesInRemoteCounter(long inc) {
+			super.incNumBytesInRemoteCounter(inc);
+			legacyMetrics.incNumBytesInRemoteCounter(inc);
+		}
+
+		@Override
+		public void incNumBuffersInLocalCounter(long inc) {
+			super.incNumBuffersInLocalCounter(inc);
+			legacyMetrics.incNumBuffersInLocalCounter(inc);
+		}
+
+		@Override
+		public void incNumBuffersInRemoteCounter(long inc) {
+			super.incNumBuffersInRemoteCounter(inc);
+			legacyMetrics.incNumBuffersInRemoteCounter(inc);
+		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
-import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
@@ -28,6 +27,7 @@ import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -62,9 +62,9 @@ public abstract class InputChannel {
 	/** The maximum backoff (in ms). */
 	private final int maxBackoff;
 
-	protected final Counter numBytesIn;
+	final Consumer<Long> numBytesIn;
 
-	protected final Counter numBuffersIn;
+	final Consumer<Long> numBuffersIn;
 
 	/** The current backoff (in ms). */
 	private int currentBackoff;
@@ -75,8 +75,8 @@ public abstract class InputChannel {
 			ResultPartitionID partitionId,
 			int initialBackoff,
 			int maxBackoff,
-			Counter numBytesIn,
-			Counter numBuffersIn) {
+			Consumer<Long> numBytesIn,
+			Consumer<Long> numBuffersIn) {
 
 		checkArgument(channelIndex >= 0);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -84,7 +84,14 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 		int maxBackoff,
 		InputChannelMetrics metrics) {
 
-		super(inputGate, channelIndex, partitionId, initialBackoff, maxBackoff, metrics.getNumBytesInLocalCounter(), metrics.getNumBuffersInLocalCounter());
+		super(
+			inputGate,
+			channelIndex,
+			partitionId,
+			initialBackoff,
+			maxBackoff,
+			metrics::incNumBytesInLocalCounter,
+			metrics::incNumBuffersInLocalCounter);
 
 		this.partitionManager = checkNotNull(partitionManager);
 		this.taskEventPublisher = checkNotNull(taskEventPublisher);
@@ -193,8 +200,8 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 			}
 		}
 
-		numBytesIn.inc(next.buffer().getSizeUnsafe());
-		numBuffersIn.inc();
+		numBytesIn.accept((long) next.buffer().getSizeUnsafe());
+		numBuffersIn.accept(1L);
 		return Optional.of(new BufferAndAvailability(next.buffer(), next.isMoreAvailable(), next.buffersInBacklog()));
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -123,7 +123,14 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 		int maxBackoff,
 		InputChannelMetrics metrics) {
 
-		super(inputGate, channelIndex, partitionId, initialBackOff, maxBackoff, metrics.getNumBytesInRemoteCounter(), metrics.getNumBuffersInRemoteCounter());
+		super(
+			inputGate,
+			channelIndex,
+			partitionId,
+			initialBackOff,
+			maxBackoff,
+			metrics::incNumBytesInRemoteCounter,
+			metrics::incNumBuffersInRemoteCounter);
 
 		this.connectionId = checkNotNull(connectionId);
 		this.connectionManager = checkNotNull(connectionManager);
@@ -198,8 +205,8 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 			moreAvailable = !receivedBuffers.isEmpty();
 		}
 
-		numBytesIn.inc(next.getSizeUnsafe());
-		numBuffersIn.inc();
+		numBytesIn.accept((long) next.getSizeUnsafe());
+		numBuffersIn.accept(1L);
 		return Optional.of(new BufferAndAvailability(next, moreAvailable, getSenderBacklog()));
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
-import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 
@@ -124,7 +123,7 @@ public class InputChannelTest {
 			int initialBackoff,
 			int maxBackoff) {
 
-			super(inputGate, channelIndex, partitionId, initialBackoff, maxBackoff, new SimpleCounter(), new SimpleCounter());
+			super(inputGate, channelIndex, partitionId, initialBackoff, maxBackoff, m -> {}, m -> {});
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestInputChannel.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestInputChannel.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
-import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
@@ -53,7 +52,7 @@ public class TestInputChannel extends InputChannel {
 	private boolean isReleased = false;
 
 	TestInputChannel(SingleInputGate inputGate, int channelIndex) {
-		super(inputGate, channelIndex, new ResultPartitionID(), 0, 0, new SimpleCounter(), new SimpleCounter());
+		super(inputGate, channelIndex, new ResultPartitionID(), 0, 0, m -> {}, m -> {});
 	}
 
 	public TestInputChannel read(Buffer buffer) throws IOException, InterruptedException {


### PR DESCRIPTION
Mirror of apache flink#8485
## What is the purpose of the change

At the moment, partition/gate create methods in NetworkEnvironment have a lot of metrics arguments to maintain original layout for metric groups. This approach is not quite encapsulated and clean for shuffle API. We can have just one parent group for shuffle metrics. The old layout can be still maintained in parallel and deprecated. At the moment we can do it with a couple of casts (if shuffle implementation is NetworkEnvironment) and adding an additional legacy metric registration which can be removed later.

## Brief change log

  - Change `NetworkEnvironment.createResultPartitionWriters/createInputGates` to have only one parent metric group argument.
  - Add InputChannelMetricsWithLegacy to increment input metrics from the legacy group as well
  - Move legacy metric group creation to deprecated `NetworkEnvironment.registerLegacyNetworkMetrics`
  - clean `Task` of legacy code but add call to `NetworkEnvironment.registerLegacyNetworkMetrics` after creation of partitions and gates (later needs instanceOf check for actual ShuffleService)

## Verifying this change

simple refactoring, existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

