### PR TITLE
Mirror of apache flink#8479

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ConfigurableStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ConfigurableStateBackend.java
@@ -45,4 +45,9 @@ public interface ConfigurableStateBackend {
 	 * @throws IllegalConfigurationException Thrown if the configuration contained invalid entries.
 	 */
 	StateBackend configure(Configuration config, ClassLoader classLoader) throws IllegalConfigurationException;
+
+	/**
+	 * @return The configuration which configured this state backend.
+	 */
+	Configuration getConfigure();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
@@ -171,6 +171,7 @@ public class StateBackendLoader {
 	 * <p>Refer to {@link #loadStateBackendFromConfig(Configuration, ClassLoader, Logger)} for details on
 	 * how the state backend is loaded from the configuration.
 	 *
+	 * @param fromApplication The state backend defined in user code
 	 * @param config The configuration to load the state backend from
 	 * @param classLoader The class loader that should be used to load the state backend
 	 * @param logger Optionally, a logger to log actions to (may be null)
@@ -208,6 +209,11 @@ public class StateBackendLoader {
 				// needs to pick up configuration
 				if (logger != null) {
 					logger.info("Configuring application-defined state backend with job/cluster config");
+				}
+
+				Configuration configurationFromApplication = ((ConfigurableStateBackend) fromApplication).getConfigure();
+				if (null != configurationFromApplication) {
+					config.addAll(configurationFromApplication);
 				}
 
 				backend = ((ConfigurableStateBackend) fromApplication).configure(config, classLoader);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
@@ -109,6 +109,9 @@ public class FsStateBackend extends AbstractFileStateBackend implements Configur
 	 * A value of '-1' means not yet configured, in which case the default will be used. */
 	private final int fileStateThreshold;
 
+	/** This backend associated configuration. */
+	private Configuration configuration;
+
 	/** Switch to chose between synchronous and asynchronous snapshots.
 	 * A value of 'undefined' means not yet configured, in which case the default will be used. */
 	private final TernaryBoolean asynchronousSnapshots;
@@ -343,6 +346,7 @@ public class FsStateBackend extends AbstractFileStateBackend implements Configur
 	private FsStateBackend(FsStateBackend original, Configuration configuration, ClassLoader classLoader) {
 		super(original.getCheckpointPath(), original.getSavepointPath(), configuration);
 
+		this.configuration = configuration;
 		// if asynchronous snapshots were configured, use that setting,
 		// else check the configuration
 		this.asynchronousSnapshots = original.asynchronousSnapshots.resolveUndefined(
@@ -438,6 +442,11 @@ public class FsStateBackend extends AbstractFileStateBackend implements Configur
 	@Override
 	public FsStateBackend configure(Configuration config, ClassLoader classLoader) {
 		return new FsStateBackend(this, config, classLoader);
+	}
+
+	@Override
+	public Configuration getConfigure() {
+		return this.configuration;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
@@ -113,6 +113,9 @@ public class MemoryStateBackend extends AbstractFileStateBackend implements Conf
 	/** The maximal size that the snapshotted memory state may have. */
 	private final int maxStateSize;
 
+	/** This backend associated configuration. */
+	private Configuration configuration;
+
 	/** Switch to chose between synchronous and asynchronous snapshots.
 	 * A value of 'UNDEFINED' means not yet configured, in which case the default will be used. */
 	private final TernaryBoolean asynchronousSnapshots;
@@ -236,6 +239,7 @@ public class MemoryStateBackend extends AbstractFileStateBackend implements Conf
 	 */
 	private MemoryStateBackend(MemoryStateBackend original, Configuration configuration, ClassLoader classLoader) {
 		super(original.getCheckpointPath(), original.getSavepointPath(), configuration);
+		this.configuration = configuration;
 
 		this.maxStateSize = original.maxStateSize;
 
@@ -284,6 +288,11 @@ public class MemoryStateBackend extends AbstractFileStateBackend implements Conf
 	@Override
 	public MemoryStateBackend configure(Configuration config, ClassLoader classLoader) {
 		return new MemoryStateBackend(this, config, classLoader);
+	}
+
+	@Override
+	public Configuration getConfigure() {
+		return this.configuration;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendLoadingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendLoadingTest.java
@@ -67,16 +67,6 @@ public class StateBackendLoadingTest {
 	}
 
 	@Test
-	public void testJira() throws Exception {
-		Configuration configuration = new Configuration();
-		configuration.setString(backendKey, "rocksdb");
-
-		assertNull(StateBackendLoader.loadStateBackendFromConfig(configuration, cl, null));
-
-
-	}
-
-	@Test
 	public void testInstantiateMemoryBackendByDefault() throws Exception {
 		StateBackend backend =
 				StateBackendLoader.fromApplicationOrConfigOrDefault(null, new Configuration(), cl, null);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -114,6 +114,8 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 	// ------------------------------------------------------------------------
 
 	// -- configuration values, set in the application / configuration
+	/** This backend associated configuration. */
+	private Configuration configuration;
 
 	/** The state backend that we use for creating checkpoint streams. */
 	private final StateBackend checkpointStreamBackend;
@@ -295,6 +297,7 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 	 * @param classLoader The class loader.
 	 */
 	private RocksDBStateBackend(RocksDBStateBackend original, Configuration config, ClassLoader classLoader) {
+		this.configuration = config;
 		// reconfigure the state backend backing the streams
 		final StateBackend originalStreamBackend = original.checkpointStreamBackend;
 		this.checkpointStreamBackend = originalStreamBackend instanceof ConfigurableStateBackend ?
@@ -373,6 +376,11 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 	@Override
 	public RocksDBStateBackend configure(Configuration config, ClassLoader classLoader) {
 		return new RocksDBStateBackend(this, config, classLoader);
+	}
+
+	@Override
+	public Configuration getConfigure() {
+		return this.configuration;
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
Mirror of apache flink#8479
## What is the purpose of the change

As described in the [jira](https://issues.apache.org/jira/browse/FLINK-11193), User's customize configuration which is configured by `backend.configure()` method will be override by the configuration loading from flink-conf.yaml. I think the config in the code should has a higher priority than the default file configuration.

## Brief change log

Merge configuration before create the new state backend.


## Verifying this change

Adding a test case to verify.

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

