### PR TITLE
Mirror of apache flink#8539

### DIFF
--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfigurationParserFactoryTest.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfigurationParserFactoryTest.java
@@ -19,14 +19,21 @@
 package org.apache.flink.container.entrypoint;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.runtime.entrypoint.FlinkParseException;
 import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -47,9 +54,21 @@ import static org.junit.Assert.fail;
  */
 public class StandaloneJobClusterConfigurationParserFactoryTest extends TestLogger {
 
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
+	private File confFile;
+	private String confDirPath;
+
+	@Before
+	public void createEmptyFlinkConfiguration() throws IOException {
+		File confDir = tempFolder.getRoot();
+		confDirPath = confDir.getAbsolutePath();
+		confFile = new File(confDir, GlobalConfiguration.FLINK_CONF_FILENAME);
+		new FileOutputStream(confFile).close();
+	}
+
 	private static final CommandLineParser<StandaloneJobClusterConfiguration> commandLineParser = new CommandLineParser<>(new StandaloneJobClusterConfigurationParserFactory());
 	private static final String JOB_CLASS_NAME = "foobar";
-	private static final String CONFIG_DIR = "/foo/bar";
 
 	@Test
 	public void testEntrypointClusterConfigurationParsing() throws FlinkParseException {
@@ -58,11 +77,11 @@ public class StandaloneJobClusterConfigurationParserFactoryTest extends TestLogg
 		final int restPort = 1234;
 		final String arg1 = "arg1";
 		final String arg2 = "arg2";
-		final String[] args = {"--configDir", CONFIG_DIR, "--webui-port", String.valueOf(restPort), "--job-classname", JOB_CLASS_NAME, String.format("-D%s=%s", key, value), arg1, arg2};
+		final String[] args = {"--configDir", confDirPath, "--webui-port", String.valueOf(restPort), "--job-classname", JOB_CLASS_NAME, String.format("-D%s=%s", key, value), arg1, arg2};
 
 		final StandaloneJobClusterConfiguration clusterConfiguration = commandLineParser.parse(args);
 
-		assertThat(clusterConfiguration.getConfigDir(), is(equalTo(CONFIG_DIR)));
+		assertThat(clusterConfiguration.getConfigDir(), is(equalTo(confDirPath)));
 		assertThat(clusterConfiguration.getJobClassName(), is(equalTo(JOB_CLASS_NAME)));
 		assertThat(clusterConfiguration.getRestPort(), is(equalTo(restPort)));
 		final Properties dynamicProperties = clusterConfiguration.getDynamicProperties();
@@ -78,12 +97,11 @@ public class StandaloneJobClusterConfigurationParserFactoryTest extends TestLogg
 
 	@Test
 	public void testOnlyRequiredArguments() throws FlinkParseException {
-		final String configDir = "/foo/bar";
-		final String[] args = {"--configDir", configDir};
+		final String[] args = {"--configDir", confDirPath};
 
 		final StandaloneJobClusterConfiguration clusterConfiguration = commandLineParser.parse(args);
 
-		assertThat(clusterConfiguration.getConfigDir(), is(equalTo(configDir)));
+		assertThat(clusterConfiguration.getConfigDir(), is(equalTo(confDirPath)));
 		assertThat(clusterConfiguration.getDynamicProperties(), is(equalTo(new Properties())));
 		assertThat(clusterConfiguration.getArgs(), is(new String[0]));
 		assertThat(clusterConfiguration.getRestPort(), is(equalTo(-1)));
@@ -103,7 +121,7 @@ public class StandaloneJobClusterConfigurationParserFactoryTest extends TestLogg
 	@Test
 	public void testSavepointRestoreSettingsParsing() throws FlinkParseException {
 		final String restorePath = "foobar";
-		final String[] args = {"-c", CONFIG_DIR, "-j", JOB_CLASS_NAME, "-s", restorePath, "-n"};
+		final String[] args = {"-c", confDirPath, "-j", JOB_CLASS_NAME, "-s", restorePath, "-n"};
 		final StandaloneJobClusterConfiguration standaloneJobClusterConfiguration = commandLineParser.parse(args);
 
 		final SavepointRestoreSettings savepointRestoreSettings = standaloneJobClusterConfiguration.getSavepointRestoreSettings();
@@ -116,7 +134,7 @@ public class StandaloneJobClusterConfigurationParserFactoryTest extends TestLogg
 	@Test
 	public void testSetJobIdManually() throws FlinkParseException {
 		final JobID jobId = new JobID();
-		final String[] args = {"--configDir", "/foo/bar", "--job-classname", "foobar", "--job-id", jobId.toString()};
+		final String[] args = {"--configDir", confDirPath, "--job-classname", "foobar", "--job-id", jobId.toString()};
 
 		final StandaloneJobClusterConfiguration standaloneJobClusterConfiguration = commandLineParser.parse(args);
 
@@ -126,7 +144,7 @@ public class StandaloneJobClusterConfigurationParserFactoryTest extends TestLogg
 	@Test
 	public void testInvalidJobIdThrows() {
 		final String invalidJobId = "0xINVALID";
-		final String[] args = {"--configDir", "/foo/bar", "--job-classname", "foobar", "--job-id", invalidJobId};
+		final String[] args = {"--configDir", confDirPath, "--job-classname", "foobar", "--job-id", invalidJobId};
 
 		try {
 			commandLineParser.parse(args);
@@ -140,13 +158,12 @@ public class StandaloneJobClusterConfigurationParserFactoryTest extends TestLogg
 
 	@Test
 	public void testShortOptions() throws FlinkParseException {
-		final String configDir = "/foo/bar";
 		final String jobClassName = "foobar";
 		final JobID jobId = new JobID();
 		final String savepointRestorePath = "s3://foo/bar";
 
 		final String[] args = {
-			"-c", configDir,
+			"-c", confDirPath,
 			"-j", jobClassName,
 			"-jid", jobId.toString(),
 			"-s", savepointRestorePath,
@@ -154,7 +171,7 @@ public class StandaloneJobClusterConfigurationParserFactoryTest extends TestLogg
 
 		final StandaloneJobClusterConfiguration clusterConfiguration = commandLineParser.parse(args);
 
-		assertThat(clusterConfiguration.getConfigDir(), is(equalTo(configDir)));
+		assertThat(clusterConfiguration.getConfigDir(), is(equalTo(confDirPath)));
 		assertThat(clusterConfiguration.getJobClassName(), is(equalTo(jobClassName)));
 		assertThat(clusterConfiguration.getJobId(), is(equalTo(jobId)));
 


### PR DESCRIPTION
Mirror of apache flink#8539
## What is the purpose of the change

## Brief change log

* StandaloneJobClusterEntrypoint defaults to random JobID for non-HA setups
* refactor StandaloneJobClusterConfigurationParserFactoryTest to use temporary folder for global Flink configuration

## Verifying this change
  - run unit tests in flink-container to check the correct defaults are 
  - build Flink locally, build job-cluster image
  -  run a job without HA and check that JobID is random
```
./build.sh --job-jar ../../flink-examples/flink-examples-streaming/target/flink-examples-streaming_2.11-1.9-SNAPSHOT-TopSpeedWindowing.jar --from-local-dist
FLINK_JOB=org.apache.flink.streaming.examples.windowing.TopSpeedWindowing docker-compose up
```
  - run a job without HA and explicit JobID and check that parameter takes precedence
```
FLINK_JOB_ARGUMENTS="--job-id 00000000000000000000000000000000" FLINK_JOB=org.apache.flink.streaming.examples.windowing.TopSpeedWindowing docker-compose up
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

