### PR TITLE
Mirror of apache flink#8530

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/sql/ProctimeSqlFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/functions/sql/ProctimeSqlFunction.java
@@ -20,14 +20,12 @@ package org.apache.flink.table.functions.sql;
 
 import org.apache.flink.table.calcite.FlinkTypeFactory;
 
-import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rel.type.RelDataTypeFactory;
-import org.apache.calcite.rel.type.RelProtoDataType;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeTransforms;
 
 /**
  * Function used to access a proctime attribute.
@@ -37,16 +35,11 @@ public class ProctimeSqlFunction extends SqlFunction {
 		super(
 				"PROCTIME",
 				SqlKind.OTHER_FUNCTION,
-				ReturnTypes.explicit(new ProctimeRelProtoDataType()),
-				null,
+				ReturnTypes.cascade(ReturnTypes.explicit(
+						factory -> ((FlinkTypeFactory) factory).createProctimeIndicatorType(false)),
+						SqlTypeTransforms.TO_NULLABLE),
+		null,
 				OperandTypes.NILADIC,
 				SqlFunctionCategory.TIMEDATE);
-	}
-
-	private static class ProctimeRelProtoDataType implements RelProtoDataType {
-		@Override
-		public RelDataType apply(RelDataTypeFactory factory) {
-			return ((FlinkTypeFactory) factory).createProctimeIndicatorType();
-		}
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/calcite/WatermarkAssigner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/calcite/WatermarkAssigner.scala
@@ -44,7 +44,7 @@ abstract class WatermarkAssigner(
     val newFieldList = inputRowType.getFieldList.map { f =>
       rowtimeFieldIndex match {
         case Some(index) if f.getIndex == index =>
-          val rowtimeIndicatorType = typeFactory.createRowtimeIndicatorType()
+          val rowtimeIndicatorType = typeFactory.createRowtimeIndicatorType(f.getType.isNullable)
           new RelDataTypeFieldImpl(f.getName, f.getIndex, rowtimeIndicatorType)
         case _ => f
       }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/schema/TimeIndicatorRelDataTypeTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/schema/TimeIndicatorRelDataTypeTest.scala
@@ -33,10 +33,10 @@ class TimeIndicatorRelDataTypeTest {
     val typeFactory = new FlinkTypeFactory(new FlinkTypeSystem)
     assertEquals(
       "TIME ATTRIBUTE(PROCTIME) NOT NULL",
-      typeFactory.createProctimeIndicatorType().getFullTypeString)
+      typeFactory.createProctimeIndicatorType(false).getFullTypeString)
     assertEquals(
       "TIME ATTRIBUTE(ROWTIME) NOT NULL",
-      typeFactory.createRowtimeIndicatorType().getFullTypeString)
+      typeFactory.createRowtimeIndicatorType(false).getFullTypeString)
   }
 
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/stream/sql/TimeAttributesITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/stream/sql/TimeAttributesITCase.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.stream.sql
+
+import org.apache.flink.api.scala._
+import org.apache.flink.streaming.api.TimeCharacteristic
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.runtime.utils.TimeTestUtil.TimestampAndWatermarkWithOffset
+import org.apache.flink.table.runtime.utils.{StreamingTestBase, TestingRetractSink}
+import org.apache.flink.types.Row
+
+import org.junit.{Assert, Test}
+
+class TimeAttributesITCase extends StreamingTestBase {
+
+  @Test
+  def testAggregationOnTimeAttribute(): Unit = {
+    val data: Seq[(Long, Int)] = Seq(
+      (1L, 1),
+      (2L, 2),
+      (3L, 3)
+    )
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    val t = env.fromCollection(data)
+        .assignTimestampsAndWatermarks(new TimestampAndWatermarkWithOffset[(Long, Int)](0))
+        .toTable(tEnv, 'rowtime, 'a)
+    tEnv.registerTable("T", t)
+    val t1 = tEnv.sqlQuery(
+      "select max(rowtime), count(a) from T")
+    val sink = new TestingRetractSink
+    t1.toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+    val expected = Seq("1970-01-01 00:00:00.003,3")
+    Assert.assertEquals(expected, sink.getRetractResults)
+  }
+}


### PR DESCRIPTION
Mirror of apache flink#8530
## What is the purpose of the change

Make time indicator nullable in blink to support agg on TimeIndicator

## Verifying this change

ut

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
