### PR TITLE
Mirror of apache flink#8523

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -337,7 +337,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 				ThreadFactory timerThreadFactory = new DispatcherThreadFactory(TRIGGER_THREAD_GROUP,
 					"Time Trigger for " + getName(), getUserCodeClassLoader());
 
-				timerService = new SystemProcessingTimeService(this, getCheckpointLock(), timerThreadFactory);
+				timerService = new SystemProcessingTimeService(new TimerInvocationContext(), timerThreadFactory);
 			}
 
 			operatorChain = new OperatorChain<>(this, recordWriters);
@@ -1356,6 +1356,19 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 		 */
 		public void actionsUnavailable() throws InterruptedException {
 			mailbox.putMail(actionUnavailableLetter);
+		}
+	}
+
+	private class TimerInvocationContext implements SystemProcessingTimeService.ScheduledCallbackExecutionContext {
+		@Override
+		public void invoke(ProcessingTimeCallback callback, long timestamp) {
+			synchronized (getCheckpointLock()) {
+				try {
+					callback.onProcessingTime(timestamp);
+				} catch (Throwable t) {
+					handleAsyncException("Caught exception while processing timer.", new TimerException(t));
+				}
+			}
 		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeService.java
@@ -54,29 +54,21 @@ public class SystemProcessingTimeService extends ProcessingTimeService {
 
 	// ------------------------------------------------------------------------
 
-	/** The containing task that owns this time service provider. */
-	private final AsyncExceptionHandler task;
-
-	/** The lock that timers acquire upon triggering. */
-	private final Object checkpointLock;
-
 	/** The executor service that schedules and calls the triggers of this task. */
 	private final ScheduledThreadPoolExecutor timerService;
 
+	private final ScheduledCallbackExecutionContext callbackExecutionContext;
 	private final AtomicInteger status;
 
-	public SystemProcessingTimeService(AsyncExceptionHandler failureHandler, Object checkpointLock) {
-		this(failureHandler, checkpointLock, null);
+	@VisibleForTesting
+	SystemProcessingTimeService(ScheduledCallbackExecutionContext callbackExecutionContext) {
+		this(callbackExecutionContext, null);
 	}
 
 	public SystemProcessingTimeService(
-			AsyncExceptionHandler task,
-			Object checkpointLock,
-			ThreadFactory threadFactory) {
+		ScheduledCallbackExecutionContext callbackExecutionContext, ThreadFactory threadFactory) {
 
-		this.task = checkNotNull(task);
-		this.checkpointLock = checkNotNull(checkpointLock);
-
+		this.callbackExecutionContext = checkNotNull(callbackExecutionContext);
 		this.status = new AtomicInteger(STATUS_ALIVE);
 
 		if (threadFactory == null) {
@@ -103,12 +95,12 @@ public class SystemProcessingTimeService extends ProcessingTimeService {
 	 * guarantees of order.
 	 *
 	 * @param timestamp Time when the task is to be enabled (in processing time)
-	 * @param target    The task to be executed
+	 * @param callback    The task to be executed
 	 * @return The future that represents the scheduled task. This always returns some future,
 	 *         even if the timer was shut down
 	 */
 	@Override
-	public ScheduledFuture<?> registerTimer(long timestamp, ProcessingTimeCallback target) {
+	public ScheduledFuture<?> registerTimer(long timestamp, ProcessingTimeCallback callback) {
 
 		// delay the firing of the timer by 1 ms to align the semantics with watermark. A watermark
 		// T says we won't see elements in the future with a timestamp smaller or equal to T.
@@ -118,8 +110,7 @@ public class SystemProcessingTimeService extends ProcessingTimeService {
 		// we directly try to register the timer and only react to the status on exception
 		// that way we save unnecessary volatile accesses for each timer
 		try {
-			return timerService.schedule(
-					new TriggerTask(status, task, checkpointLock, target, timestamp), delay, TimeUnit.MILLISECONDS);
+			return timerService.schedule(wrapOnTimerCallback(callback, timestamp), delay, TimeUnit.MILLISECONDS);
 		}
 		catch (RejectedExecutionException e) {
 			final int status = this.status.get();
@@ -143,8 +134,7 @@ public class SystemProcessingTimeService extends ProcessingTimeService {
 		// we directly try to register the timer and only react to the status on exception
 		// that way we save unnecessary volatile accesses for each timer
 		try {
-			return timerService.scheduleAtFixedRate(
-				new RepeatedTriggerTask(status, task, checkpointLock, callback, nextTimestamp, period),
+			return timerService.scheduleAtFixedRate(wrapOnTimerCallback(callback, nextTimestamp, period),
 				initialDelay,
 				period,
 				TimeUnit.MILLISECONDS);
@@ -253,89 +243,53 @@ public class SystemProcessingTimeService extends ProcessingTimeService {
 	// ------------------------------------------------------------------------
 
 	/**
-	 * Internal task that is invoked by the timer service and triggers the target.
+	 * A context to which {@link ProcessingTimeCallback} would be passed to be invoked when a timer is up.
 	 */
-	private static final class TriggerTask implements Runnable {
+	public interface ScheduledCallbackExecutionContext {
 
-		private final AtomicInteger serviceStatus;
-		private final Object lock;
-		private final ProcessingTimeCallback target;
-		private final long timestamp;
-		private final AsyncExceptionHandler exceptionHandler;
-
-		private TriggerTask(
-				final AtomicInteger serviceStatus,
-				final AsyncExceptionHandler exceptionHandler,
-				final Object lock,
-				final ProcessingTimeCallback target,
-				final long timestamp) {
-
-			this.serviceStatus = Preconditions.checkNotNull(serviceStatus);
-			this.exceptionHandler = Preconditions.checkNotNull(exceptionHandler);
-			this.lock = Preconditions.checkNotNull(lock);
-			this.target = Preconditions.checkNotNull(target);
-			this.timestamp = timestamp;
-		}
-
-		@Override
-		public void run() {
-			synchronized (lock) {
-				try {
-					if (serviceStatus.get() == STATUS_ALIVE) {
-						target.onProcessingTime(timestamp);
-					}
-				} catch (Throwable t) {
-					TimerException asyncException = new TimerException(t);
-					exceptionHandler.handleAsyncException("Caught exception while processing timer.", asyncException);
-				}
-			}
-		}
+		void invoke(ProcessingTimeCallback callback, long timestamp) throws InterruptedException;
 	}
 
-	/**
-	 * Internal task which is repeatedly called by the processing time service.
-	 */
-	private static final class RepeatedTriggerTask implements Runnable {
+	private Runnable wrapOnTimerCallback(ProcessingTimeCallback callback, long timestamp) {
+		return new TimeTrackingDelegate(status, callbackExecutionContext, callback, timestamp, 0);
+	}
 
+	private Runnable wrapOnTimerCallback(ProcessingTimeCallback callback, long nextTimestamp, long period) {
+		return new TimeTrackingDelegate(status, callbackExecutionContext, callback, nextTimestamp, period);
+	}
+
+	private static final class TimeTrackingDelegate implements Runnable {
 		private final AtomicInteger serviceStatus;
-		private final Object lock;
-		private final ProcessingTimeCallback target;
-		private final long period;
-		private final AsyncExceptionHandler exceptionHandler;
+		private final ScheduledCallbackExecutionContext callbackExecutionContext;
+		private final ProcessingTimeCallback callback;
 
 		private long nextTimestamp;
+		private final long period;
 
-		private RepeatedTriggerTask(
-				final AtomicInteger serviceStatus,
-				final AsyncExceptionHandler exceptionHandler,
-				final Object lock,
-				final ProcessingTimeCallback target,
-				final long nextTimestamp,
-				final long period) {
-
-			this.serviceStatus = Preconditions.checkNotNull(serviceStatus);
-			this.lock = Preconditions.checkNotNull(lock);
-			this.target = Preconditions.checkNotNull(target);
+		TimeTrackingDelegate(
+				AtomicInteger serviceStatus,
+				ScheduledCallbackExecutionContext callbackExecutionContext,
+				ProcessingTimeCallback callback,
+				long timestamp,
+				long period) {
+			this.serviceStatus = serviceStatus;
+			this.callbackExecutionContext = callbackExecutionContext;
+			this.callback = callback;
+			this.nextTimestamp = timestamp;
 			this.period = period;
-			this.exceptionHandler = Preconditions.checkNotNull(exceptionHandler);
-
-			this.nextTimestamp = nextTimestamp;
 		}
 
 		@Override
 		public void run() {
-			synchronized (lock) {
-				try {
-					if (serviceStatus.get() == STATUS_ALIVE) {
-						target.onProcessingTime(nextTimestamp);
-					}
-
-					nextTimestamp += period;
-				} catch (Throwable t) {
-					TimerException asyncException = new TimerException(t);
-					exceptionHandler.handleAsyncException("Caught exception while processing repeated timer task.", asyncException);
-				}
+			if (serviceStatus.get() != STATUS_ALIVE) {
+				return;
 			}
+			try {
+				callbackExecutionContext.invoke(callback, nextTimestamp);
+			} catch (InterruptedException ex) {
+				Thread.currentThread().interrupt();
+			}
+			nextTimestamp += period;
 		}
 	}
 


### PR DESCRIPTION
Mirror of apache flink#8523
## What is the purpose of the change

This PR moves invocation of timer callback (`ProcessingTimeCallback`) from `SystemProcessingTimeService` execution thread pool into `StreamTask`'s main thread (passing callback via mailbox introduced in [[FLINK-12480]](https://issues.apache.org/jira/browse/FLINK-12480)).

This is a sub-task of general effort of moving away from using concurrent access to `StreamTask`'s state.

## Brief change log

  - The `checkpointLock` and `AsyncExceptionHandler` are moved out of `SystemProcessingTimeService` as abstract invocation context (`ScheduledCallbackExecutionContext`). So the service is abstracted and is not concerned about `StreamTask`'s use case.
  - The implementation of `ScheduledCallbackExecutionContext` for `StreamTask` uses mailbox (instead of locking on `checkpointLock`) to delegate timer callback invocation in main task's thread.

## Verifying this change

This change added tests and can be verified as follows:

  - A test in `StreamTaskTest` has been modified to verify new runtime invariant;

Note: `StreamTaskTimerTest` fails (regression) due to blocking in `inputProcessor.processInput()`. In both tests the task thread get interrupted, without peeking any mailbox messages (timer callbacks in those tests are already in mailbox queue).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no / **don't know**)
  - The runtime per-record code paths (performance sensitive): (yes / no / **don't know**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / no / **don't know**)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

