### PR TITLE
Mirror of apache flink#8519

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,6 +6,6 @@ To make the process smooth for the project *committers* (those who review and ac
 
 ## Contribution Guidelines
 
-Please check out the [How to Contribute guide](http://flink.apache.org/how-to-contribute.html) to understand how contributions are made. 
-A detailed explanation can be found in our [Contribute Code Guide](http://flink.apache.org/contribute-code.html) which also contains a list of coding guidelines that you should follow.
+Please check out the [How to Contribute guide](https://flink.apache.org/how-to-contribute.html) to understand how contributions are made.
+A detailed explanation can be found in our [Contribute Code Guide](https://flink.apache.org/contribute-code.html) which also contains a list of coding guidelines that you should follow.
 For pull requests, there is a [check list](PULL_REQUEST_TEMPLATE.md) with criteria taken from the How to Contribute Guide and the Coding Guidelines.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 
   - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
   
-  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).
+  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contribute-code.html#best-practices).
 
   - Each pull request should address only one issue, not mix up code from multiple issues.
   

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Apache Flink is an open source stream processing framework with powerful stream- and batch-processing capabilities.
 
-Learn more about Flink at [http://flink.apache.org/](http://flink.apache.org/)
+Learn more about Flink at [https://flink.apache.org/](https://flink.apache.org/)
 
 
 ### Features
@@ -98,7 +98,7 @@ Minimal requirements for an IDE are:
 The IntelliJ IDE supports Maven out of the box and offers a plugin for Scala development.
 
 * IntelliJ download: [https://www.jetbrains.com/idea/](https://www.jetbrains.com/idea/)
-* IntelliJ Scala Plugin: [http://plugins.jetbrains.com/plugin/?id=1347](http://plugins.jetbrains.com/plugin/?id=1347)
+* IntelliJ Scala Plugin: [https://plugins.jetbrains.com/plugin/?id=1347](https://plugins.jetbrains.com/plugin/?id=1347)
 
 Check out our [Setting up IntelliJ](https://ci.apache.org/projects/flink/flink-docs-master/flinkDev/ide_setup.html#intellij-idea) guide for details.
 
@@ -114,14 +114,14 @@ due to version incompatibilities with the bundled Scala version in Scala IDE 4.4
 
 Don’t hesitate to ask!
 
-Contact the developers and community on the [mailing lists](http://flink.apache.org/community.html#mailing-lists) if you need any help.
+Contact the developers and community on the [mailing lists](https://flink.apache.org/community.html#mailing-lists) if you need any help.
 
 [Open an issue](https://issues.apache.org/jira/browse/FLINK) if you found a bug in Flink.
 
 
 ## Documentation
 
-The documentation of Apache Flink is located on the website: [http://flink.apache.org](http://flink.apache.org)
+The documentation of Apache Flink is located on the website: [https://flink.apache.org](https://flink.apache.org)
 or in the `docs/` directory of the source code.
 
 
@@ -129,10 +129,10 @@ or in the `docs/` directory of the source code.
 
 This is an active open-source project. We are always open to people who want to use the system or contribute to it.
 Contact us if you are looking for implementation tasks that fit your skills.
-This article describes [how to contribute to Apache Flink](http://flink.apache.org/how-to-contribute.html).
+This article describes [how to contribute to Apache Flink](https://flink.apache.org/how-to-contribute.html).
 
 
 ## About
 
 Apache Flink is an open source project of The Apache Software Foundation (ASF).
-The Apache Flink project originated from the [Stratosphere](http://stratosphere.eu) research project.
+The Apache Flink project originated from the [Stratosphere](https://stratosphere.eu) research project.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@ This README gives an overview of how to build and contribute to the documentatio
 
 The documentation is included with the source of Apache Flink in order to ensure that you always
 have docs corresponding to your checked out version. The online documentation at
-http://flink.apache.org/ is also generated from the files found here.
+https://flink.apache.org/ is also generated from the files found here.
 
 # Requirements
 
@@ -76,7 +76,7 @@ These tables can be directly included into the documentation:
 
 ## Markdown
 
-The documentation pages are written in [Markdown](http://daringfireball.net/projects/markdown/syntax). It is possible to use [GitHub flavored syntax](http://github.github.com/github-flavored-markdown) and intermix plain html.
+The documentation pages are written in [Markdown](https://daringfireball.net/projects/markdown/syntax). It is possible to use [GitHub flavored syntax](https://github.github.com/github-flavored-markdown) and intermix plain html.
 
 ## Front matter
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -41,10 +41,10 @@ scala_version_suffix: "_2.11"
 
 # Some commonly linked pages (this was more important to have as a variable
 # during incubator; by now it should also be fine to hardcode these.)
-website_url: "http://flink.apache.org"
+website_url: "https://flink.apache.org"
 jira_url: "https://issues.apache.org/jira/browse/FLINK"
 github_url: "https://github.com/apache/flink"
-download_url: "http://flink.apache.org/downloads.html"
+download_url: "https://flink.apache.org/downloads.html"
 
 # please use a protocol relative URL here
 baseurl: //ci.apache.org/projects/flink/flink-docs-master
@@ -59,15 +59,15 @@ is_stable: false
 show_outdated_warning: false
 
 previous_docs:
-  1.8: http://ci.apache.org/projects/flink/flink-docs-release-1.8
-  1.7: http://ci.apache.org/projects/flink/flink-docs-release-1.7
-  1.6: http://ci.apache.org/projects/flink/flink-docs-release-1.6
-  1.5: http://ci.apache.org/projects/flink/flink-docs-release-1.5
-  1.4: http://ci.apache.org/projects/flink/flink-docs-release-1.4
-  1.3: http://ci.apache.org/projects/flink/flink-docs-release-1.3
-  1.2: http://ci.apache.org/projects/flink/flink-docs-release-1.2
-  1.1: http://ci.apache.org/projects/flink/flink-docs-release-1.1
-  1.0: http://ci.apache.org/projects/flink/flink-docs-release-1.0
+  1.8: https://ci.apache.org/projects/flink/flink-docs-release-1.8
+  1.7: https://ci.apache.org/projects/flink/flink-docs-release-1.7
+  1.6: https://ci.apache.org/projects/flink/flink-docs-release-1.6
+  1.5: https://ci.apache.org/projects/flink/flink-docs-release-1.5
+  1.4: https://ci.apache.org/projects/flink/flink-docs-release-1.4
+  1.3: https://ci.apache.org/projects/flink/flink-docs-release-1.3
+  1.2: https://ci.apache.org/projects/flink/flink-docs-release-1.2
+  1.1: https://ci.apache.org/projects/flink/flink-docs-release-1.1
+  1.0: https://ci.apache.org/projects/flink/flink-docs-release-1.0
 
 #------------------------------------------------------------------------------
 # BUILD CONFIG

--- a/docs/_includes/sidenav.html
+++ b/docs/_includes/sidenav.html
@@ -137,7 +137,7 @@ level is determined by 'nav-pos'.
   <li class="divider"></li>
   <li><a href="{{ site.javadocs_baseurl }}/api/java"><i class="fa fa-external-link title" aria-hidden="true"></i> Javadocs</a></li>
   <li><a href="{{ site.javadocs_baseurl }}/api/scala/index.html#org.apache.flink.api.scala.package"><i class="fa fa-external-link title" aria-hidden="true"></i> Scaladocs</a></li>
-  <li><a href="http://flink.apache.org"><i class="fa fa-external-link title" aria-hidden="true"></i> Project Page</a></li>
+  <li><a href="https://flink.apache.org"><i class="fa fa-external-link title" aria-hidden="true"></i> Project Page</a></li>
 </ul>
 
 <div class="sidenav-search-box">

--- a/docs/build_docs.bat
+++ b/docs/build_docs.bat
@@ -21,7 +21,7 @@
 call jekyll -version >nul 2>&1
 if "%errorlevel%"=="0" goto check_redcarpet
 echo ERROR: Could not find jekyll.
-echo Please install with 'gem install jekyll' (see http://jekyllrb.com).
+echo Please install with 'gem install jekyll' (see https://jekyllrb.com).
 exit /b 1
 
 :check_redcarpet
@@ -36,7 +36,7 @@ goto check_pygments
 call python -c "import pygments" >nul 2>&1
 if "%errorlevel%"=="0" goto execute
 echo WARN: Could not find pygments.
-echo Please install with 'sudo easy_install Pygments' (requires Python; see http://pygments.org). 
+echo Please install with 'sudo easy_install Pygments' (requires Python; see https://pygments.org).
 echo Pygments is needed for syntax highlighting of the code examples.
 goto execute
 

--- a/docs/concepts/runtime.md
+++ b/docs/concepts/runtime.md
@@ -108,7 +108,7 @@ With hyper-threading, each slot then takes 2 or more hardware thread contexts.
 ## State Backends
 
 The exact data structures in which the key/values indexes are stored depends on the chosen [state backend](../ops/state/state_backends.html). One state backend
-stores data in an in-memory hash map, another state backend uses [RocksDB](http://rocksdb.org) as the key/value store.
+stores data in an in-memory hash map, another state backend uses [RocksDB](https://rocksdb.org) as the key/value store.
 In addition to defining the data structure that holds the state, the state backends also implement the logic to
 take a point-in-time snapshot of the key/value state and store that snapshot as part of a checkpoint.
 

--- a/docs/concepts/runtime.zh.md
+++ b/docs/concepts/runtime.zh.md
@@ -108,7 +108,7 @@ With hyper-threading, each slot then takes 2 or more hardware thread contexts.
 ## State Backends
 
 The exact data structures in which the key/values indexes are stored depends on the chosen [state backend](../ops/state/state_backends.html). One state backend
-stores data in an in-memory hash map, another state backend uses [RocksDB](http://rocksdb.org) as the key/value store.
+stores data in an in-memory hash map, another state backend uses [RocksDB](https://rocksdb.org) as the key/value store.
 In addition to defining the data structure that holds the state, the state backends also implement the logic to
 take a point-in-time snapshot of the key/value state and store that snapshot as part of a checkpoint.
 

--- a/docs/dev/api_concepts.zh.md
+++ b/docs/dev/api_concepts.zh.md
@@ -694,7 +694,7 @@ Java and Scala classes are treated by Flink as a special POJO data type if they 
 
 - All fields are either public or must be accessible through getter and setter functions. For a field called `foo` the getter and setter methods must be named `getFoo()` and `setFoo()`.
 
-- The type of a field must be supported by Flink. At the moment, Flink uses [Avro](http://avro.apache.org) to serialize arbitrary objects (such as `Date`).
+- The type of a field must be supported by Flink. At the moment, Flink uses [Avro](https://avro.apache.org) to serialize arbitrary objects (such as `Date`).
 
 Flink analyzes the structure of POJO types, i.e., it learns about the fields of a POJO. As a result POJO types are easier to use than general types. Moreover, Flink can process POJOs more efficiently than general types.
 

--- a/docs/dev/batch/connectors.md
+++ b/docs/dev/batch/connectors.md
@@ -45,9 +45,9 @@ interface. There are Hadoop `FileSystem` implementations for
 
 - [S3](https://aws.amazon.com/s3/) (tested)
 - [Google Cloud Storage Connector for Hadoop](https://cloud.google.com/hadoop/google-cloud-storage-connector) (tested)
-- [Alluxio](http://alluxio.org/) (tested)
-- [XtreemFS](http://www.xtreemfs.org/) (tested)
-- FTP via [Hftp](http://hadoop.apache.org/docs/r1.2.1/hftp.html) (not tested)
+- [Alluxio](https://alluxio.org/) (tested)
+- [XtreemFS](https://www.xtreemfs.org/) (tested)
+- FTP via [Hftp](https://hadoop.apache.org/docs/r1.2.1/hftp.html) (not tested)
 - and many more.
 
 In order to use a Hadoop file system with Flink, make sure that
@@ -86,7 +86,7 @@ This section shows some examples for connecting Flink to other systems.
 
 ## Avro support in Flink
 
-Flink has extensive built-in support for [Apache Avro](http://avro.apache.org/). This allows to easily read from Avro files with Flink.
+Flink has extensive built-in support for [Apache Avro](https://avro.apache.org/). This allows to easily read from Avro files with Flink.
 Also, the serialization framework of Flink is able to handle classes generated from Avro schemas. Be sure to include the Flink Avro dependency to the pom.xml of your project.
 
 {% highlight xml %}

--- a/docs/dev/batch/connectors.zh.md
+++ b/docs/dev/batch/connectors.zh.md
@@ -45,9 +45,9 @@ interface. There are Hadoop `FileSystem` implementations for
 
 - [S3](https://aws.amazon.com/s3/) (tested)
 - [Google Cloud Storage Connector for Hadoop](https://cloud.google.com/hadoop/google-cloud-storage-connector) (tested)
-- [Alluxio](http://alluxio.org/) (tested)
-- [XtreemFS](http://www.xtreemfs.org/) (tested)
-- FTP via [Hftp](http://hadoop.apache.org/docs/r1.2.1/hftp.html) (not tested)
+- [Alluxio](https://alluxio.org/) (tested)
+- [XtreemFS](https://www.xtreemfs.org/) (tested)
+- FTP via [Hftp](https://hadoop.apache.org/docs/r1.2.1/hftp.html) (not tested)
 - and many more.
 
 In order to use a Hadoop file system with Flink, make sure that
@@ -86,7 +86,7 @@ This section shows some examples for connecting Flink to other systems.
 
 ## Avro support in Flink
 
-Flink has extensive built-in support for [Apache Avro](http://avro.apache.org/). This allows to easily read from Avro files with Flink.
+Flink has extensive built-in support for [Apache Avro](https://avro.apache.org/). This allows to easily read from Avro files with Flink.
 Also, the serialization framework of Flink is able to handle classes generated from Avro schemas. Be sure to include the Flink Avro dependency to the pom.xml of your project.
 
 {% highlight xml %}

--- a/docs/dev/best_practices.md
+++ b/docs/dev/best_practices.md
@@ -35,7 +35,7 @@ They are used to specify input and output sources (like paths or addresses), sys
 
 Flink provides a simple utility called `ParameterTool` to provide some basic tooling for solving these problems.
 Please note that you don't have to use the `ParameterTool` described here. Other frameworks such as [Commons CLI](https://commons.apache.org/proper/commons-cli/) and
-[argparse4j](http://argparse4j.sourceforge.net/) also work well with Flink.
+[argparse4j](https://argparse4j.sourceforge.net/) also work well with Flink.
 
 
 ### Getting your configuration values into the `ParameterTool`
@@ -168,9 +168,9 @@ public static class CustomType extends Tuple11<String, String, ..., String> {
 
 **Note: This tutorial is applicable starting from Flink 0.10**
 
-Apache Flink is using [slf4j](http://www.slf4j.org/) as the logging abstraction in the code. Users are advised to use sfl4j as well in their user functions.
+Apache Flink is using [slf4j](https://www.slf4j.org/) as the logging abstraction in the code. Users are advised to use sfl4j as well in their user functions.
 
-Sfl4j is a compile-time logging interface that can use different logging implementations at runtime, such as [log4j](http://logging.apache.org/log4j/2.x/) or [Logback](http://logback.qos.ch/).
+Sfl4j is a compile-time logging interface that can use different logging implementations at runtime, such as [log4j](https://logging.apache.org/log4j/2.x/) or [Logback](https://logback.qos.ch/).
 
 Flink is depending on Log4j by default. This page describes how to use Flink with Logback. Users reported that they were also able to set up centralized logging with Graylog using this tutorial.
 

--- a/docs/dev/best_practices.zh.md
+++ b/docs/dev/best_practices.zh.md
@@ -35,7 +35,7 @@ They are used to specify input and output sources (like paths or addresses), sys
 
 Flink provides a simple utility called `ParameterTool` to provide some basic tooling for solving these problems.
 Please note that you don't have to use the `ParameterTool` described here. Other frameworks such as [Commons CLI](https://commons.apache.org/proper/commons-cli/) and
-[argparse4j](http://argparse4j.sourceforge.net/) also work well with Flink.
+[argparse4j](https://argparse4j.sourceforge.net/) also work well with Flink.
 
 
 ### Getting your configuration values into the `ParameterTool`
@@ -168,9 +168,9 @@ public static class CustomType extends Tuple11<String, String, ..., String> {
 
 **Note: This tutorial is applicable starting from Flink 0.10**
 
-Apache Flink is using [slf4j](http://www.slf4j.org/) as the logging abstraction in the code. Users are advised to use sfl4j as well in their user functions.
+Apache Flink is using [slf4j](https://www.slf4j.org/) as the logging abstraction in the code. Users are advised to use sfl4j as well in their user functions.
 
-Sfl4j is a compile-time logging interface that can use different logging implementations at runtime, such as [log4j](http://logging.apache.org/log4j/2.x/) or [Logback](http://logback.qos.ch/).
+Sfl4j is a compile-time logging interface that can use different logging implementations at runtime, such as [log4j](https://logging.apache.org/log4j/2.x/) or [Logback](https://logback.qos.ch/).
 
 Flink is depending on Log4j by default. This page describes how to use Flink with Logback. Users reported that they were also able to set up centralized logging with Graylog using this tutorial.
 

--- a/docs/dev/connectors/cassandra.md
+++ b/docs/dev/connectors/cassandra.md
@@ -48,7 +48,7 @@ Note that the streaming connectors are currently __NOT__ part of the binary dist
 ## Installing Apache Cassandra
 There are multiple ways to bring up a Cassandra instance on local machine:
 
-1. Follow the instructions from [Cassandra Getting Started page](http://cassandra.apache.org/doc/latest/getting_started/index.html).
+1. Follow the instructions from [Cassandra Getting Started page](https://cassandra.apache.org/doc/latest/getting_started/index.html).
 2. Launch a container running Cassandra from [Official Docker Repository](https://hub.docker.com/_/cassandra/)
 
 ## Cassandra Sinks
@@ -202,9 +202,9 @@ result.print().setParallelism(1)
 
 
 ### Cassandra Sink Example for Streaming POJO Data Type
-An example of streaming a POJO data type and store the same POJO entity back to Cassandra. In addition, this POJO implementation needs to follow [DataStax Java Driver Manual](http://docs.datastax.com/en/developer/java-driver/2.1/manual/object_mapper/creating/) to annotate the class as each field of this entity is mapped to an associated column of the designated table using the DataStax Java Driver `com.datastax.driver.mapping.Mapper` class.
+An example of streaming a POJO data type and store the same POJO entity back to Cassandra. In addition, this POJO implementation needs to follow [DataStax Java Driver Manual](https://docs.datastax.com/en/developer/java-driver/2.1/manual/object_mapper/creating/) to annotate the class as each field of this entity is mapped to an associated column of the designated table using the DataStax Java Driver `com.datastax.driver.mapping.Mapper` class.
 
-The mapping of each table column can be defined through annotations placed on a field declaration in the Pojo class.  For details of the mapping, please refer to CQL documentation on [Definition of Mapped Classes](http://docs.datastax.com/en/developer/java-driver/3.1/manual/object_mapper/creating/) and [CQL Data types](https://docs.datastax.com/en/cql/3.1/cql/cql_reference/cql_data_types_c.html)
+The mapping of each table column can be defined through annotations placed on a field declaration in the Pojo class.  For details of the mapping, please refer to CQL documentation on [Definition of Mapped Classes](https://docs.datastax.com/en/developer/java-driver/3.1/manual/object_mapper/creating/) and [CQL Data types](https://docs.datastax.com/en/cql/3.1/cql/cql_reference/cql_data_types_c.html)
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">

--- a/docs/dev/connectors/cassandra.zh.md
+++ b/docs/dev/connectors/cassandra.zh.md
@@ -48,7 +48,7 @@ Note that the streaming connectors are currently __NOT__ part of the binary dist
 ## Installing Apache Cassandra
 There are multiple ways to bring up a Cassandra instance on local machine:
 
-1. Follow the instructions from [Cassandra Getting Started page](http://cassandra.apache.org/doc/latest/getting_started/index.html).
+1. Follow the instructions from [Cassandra Getting Started page](https://cassandra.apache.org/doc/latest/getting_started/index.html).
 2. Launch a container running Cassandra from [Official Docker Repository](https://hub.docker.com/_/cassandra/)
 
 ## Cassandra Sinks
@@ -202,9 +202,9 @@ result.print().setParallelism(1)
 
 
 ### Cassandra Sink Example for Streaming POJO Data Type
-An example of streaming a POJO data type and store the same POJO entity back to Cassandra. In addition, this POJO implementation needs to follow [DataStax Java Driver Manual](http://docs.datastax.com/en/developer/java-driver/2.1/manual/object_mapper/creating/) to annotate the class as each field of this entity is mapped to an associated column of the designated table using the DataStax Java Driver `com.datastax.driver.mapping.Mapper` class.
+An example of streaming a POJO data type and store the same POJO entity back to Cassandra. In addition, this POJO implementation needs to follow [DataStax Java Driver Manual](https://docs.datastax.com/en/developer/java-driver/2.1/manual/object_mapper/creating/) to annotate the class as each field of this entity is mapped to an associated column of the designated table using the DataStax Java Driver `com.datastax.driver.mapping.Mapper` class.
 
-The mapping of each table column can be defined through annotations placed on a field declaration in the Pojo class.  For details of the mapping, please refer to CQL documentation on [Definition of Mapped Classes](http://docs.datastax.com/en/developer/java-driver/3.1/manual/object_mapper/creating/) and [CQL Data types](https://docs.datastax.com/en/cql/3.1/cql/cql_reference/cql_data_types_c.html)
+The mapping of each table column can be defined through annotations placed on a field declaration in the Pojo class.  For details of the mapping, please refer to CQL documentation on [Definition of Mapped Classes](https://docs.datastax.com/en/developer/java-driver/3.1/manual/object_mapper/creating/) and [CQL Data types](https://docs.datastax.com/en/cql/3.1/cql/cql_reference/cql_data_types_c.html)
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">

--- a/docs/dev/connectors/filesystem_sink.md
+++ b/docs/dev/connectors/filesystem_sink.md
@@ -24,7 +24,7 @@ under the License.
 -->
 
 This connector provides a Sink that writes partitioned files to any filesystem supported by
-[Hadoop FileSystem](http://hadoop.apache.org). To use this connector, add the
+[Hadoop FileSystem](https://hadoop.apache.org). To use this connector, add the
 following dependency to your project:
 
 {% highlight xml %}
@@ -144,6 +144,6 @@ of the parallel sink instance and `count` is the running number of part files th
 because of the batch size or batch roll over interval.
 
 For in-depth information, please refer to the JavaDoc for
-[BucketingSink](http://flink.apache.org/docs/latest/api/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.html).
+[BucketingSink](https://flink.apache.org/docs/latest/api/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.html).
 
 {% top %}

--- a/docs/dev/connectors/filesystem_sink.zh.md
+++ b/docs/dev/connectors/filesystem_sink.zh.md
@@ -24,7 +24,7 @@ under the License.
 -->
 
 This connector provides a Sink that writes partitioned files to any filesystem supported by
-[Hadoop FileSystem](http://hadoop.apache.org). To use this connector, add the
+[Hadoop FileSystem](https://hadoop.apache.org). To use this connector, add the
 following dependency to your project:
 
 {% highlight xml %}
@@ -144,6 +144,6 @@ of the parallel sink instance and `count` is the running number of part files th
 because of the batch size or batch roll over interval.
 
 For in-depth information, please refer to the JavaDoc for
-[BucketingSink](http://flink.apache.org/docs/latest/api/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.html).
+[BucketingSink](https://flink.apache.org/docs/latest/api/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.html).
 
 {% top %}

--- a/docs/dev/connectors/kafka.md
+++ b/docs/dev/connectors/kafka.md
@@ -62,7 +62,7 @@ For most users, the `FlinkKafkaConsumer08` (part of `flink-connector-kafka`) is 
         <td>FlinkKafkaConsumer09<br>
         FlinkKafkaProducer09</td>
         <td>0.9.x</td>
-        <td>Uses the new <a href="http://kafka.apache.org/documentation.html#newconsumerapi">Consumer API</a> Kafka.</td>
+        <td>Uses the new <a href="https://kafka.apache.org/documentation.html#newconsumerapi">Consumer API</a> Kafka.</td>
     </tr>
     <tr>
         <td>flink-connector-kafka-0.10{{ site.scala_version_suffix }}</td>
@@ -762,7 +762,7 @@ Flink's Kafka connectors provide some metrics through Flink's [metrics system]({
 the behavior of the connector.
 The producers export Kafka's internal metrics through Flink's metric system for all supported versions. The consumers export 
 all metrics starting from Kafka version 0.9. The Kafka documentation lists all exported metrics 
-in its [documentation](http://kafka.apache.org/documentation/#selector_monitoring).
+in its [documentation](https://kafka.apache.org/documentation/#selector_monitoring).
 
 In addition to these metrics, all consumers expose the `current-offsets` and `committed-offsets` for each topic partition.
 The `current-offsets` refers to the current offset in the partition. This refers to the offset of the last element that

--- a/docs/dev/connectors/kafka.zh.md
+++ b/docs/dev/connectors/kafka.zh.md
@@ -62,7 +62,7 @@ For most users, the `FlinkKafkaConsumer08` (part of `flink-connector-kafka`) is 
         <td>FlinkKafkaConsumer09<br>
         FlinkKafkaProducer09</td>
         <td>0.9.x</td>
-        <td>Uses the new <a href="http://kafka.apache.org/documentation.html#newconsumerapi">Consumer API</a> Kafka.</td>
+        <td>Uses the new <a href="https://kafka.apache.org/documentation.html#newconsumerapi">Consumer API</a> Kafka.</td>
     </tr>
     <tr>
         <td>flink-connector-kafka-0.10{{ site.scala_version_suffix }}</td>
@@ -762,7 +762,7 @@ Flink's Kafka connectors provide some metrics through Flink's [metrics system]({
 the behavior of the connector.
 The producers export Kafka's internal metrics through Flink's metric system for all supported versions. The consumers export 
 all metrics starting from Kafka version 0.9. The Kafka documentation lists all exported metrics 
-in its [documentation](http://kafka.apache.org/documentation/#selector_monitoring).
+in its [documentation](https://kafka.apache.org/documentation/#selector_monitoring).
 
 In addition to these metrics, all consumers expose the `current-offsets` and `committed-offsets` for each topic partition.
 The `current-offsets` refers to the current offset in the partition. This refers to the offset of the last element that

--- a/docs/dev/connectors/kinesis.md
+++ b/docs/dev/connectors/kinesis.md
@@ -26,7 +26,7 @@ under the License.
 * This will be replaced by the TOC
 {:toc}
 
-The Kinesis connector provides access to [Amazon AWS Kinesis Streams](http://aws.amazon.com/kinesis/streams/).
+The Kinesis connector provides access to [Amazon AWS Kinesis Streams](https://aws.amazon.com/kinesis/streams/).
 
 To use the connector, add the following Maven dependency to your project:
 
@@ -137,7 +137,7 @@ a custom implementation of `KinesisShardAssigner` can be set on the consumer.
 ### Configuring Starting Position
 
 The Flink Kinesis Consumer currently provides the following options to configure where to start reading Kinesis streams, simply by setting `ConsumerConfigConstants.STREAM_INITIAL_POSITION` to
-one of the following values in the provided configuration properties (the naming of the options identically follows [the namings used by the AWS Kinesis Streams service](http://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html#API_GetShardIterator_RequestSyntax)):
+one of the following values in the provided configuration properties (the naming of the options identically follows [the namings used by the AWS Kinesis Streams service](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html#API_GetShardIterator_RequestSyntax)):
 
 - `LATEST`: read all shards of all streams starting from the latest record.
 - `TRIM_HORIZON`: read all shards of all streams starting from the earliest record possible (data may be trimmed by Kinesis depending on the retention settings).
@@ -237,13 +237,13 @@ one thread per open shard.
 
 ### Internally Used Kinesis APIs
 
-The Flink Kinesis Consumer uses the [AWS Java SDK](http://aws.amazon.com/sdk-for-java/) internally to call Kinesis APIs
-for shard discovery and data consumption. Due to Amazon's [service limits for Kinesis Streams](http://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html)
+The Flink Kinesis Consumer uses the [AWS Java SDK](https://aws.amazon.com/sdk-for-java/) internally to call Kinesis APIs
+for shard discovery and data consumption. Due to Amazon's [service limits for Kinesis Streams](https://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html)
 on the APIs, the consumer will be competing with other non-Flink consuming applications that the user may be running.
 Below is a list of APIs called by the consumer with description of how the consumer uses the API, as well as information
 on how to deal with any errors or warnings that the Flink Kinesis Consumer may have due to these service limits.
 
-- *[DescribeStream](http://docs.aws.amazon.com/kinesis/latest/APIReference/API_DescribeStream.html)*: this is constantly called
+- *[DescribeStream](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_DescribeStream.html)*: this is constantly called
 by a single thread in each parallel consumer subtask to discover any new shards as a result of stream resharding. By default,
 the consumer performs the shard discovery at an interval of 10 seconds, and will retry indefinitely until it gets a result
 from Kinesis. If this interferes with other non-Flink consuming applications, users can slow down the consumer of
@@ -251,14 +251,14 @@ calling this API by setting a value for `ConsumerConfigConstants.SHARD_DISCOVERY
 configuration properties. This sets the discovery interval to a different value. Note that this setting directly impacts
 the maximum delay of discovering a new shard and starting to consume it, as shards will not be discovered during the interval.
 
-- *[GetShardIterator](http://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html)*: this is called
+- *[GetShardIterator](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html)*: this is called
 only once when per shard consuming threads are started, and will retry if Kinesis complains that the transaction limit for the
 API has exceeded, up to a default of 3 attempts. Note that since the rate limit for this API is per shard (not per stream),
 the consumer itself should not exceed the limit. Usually, if this happens, users can either try to slow down any other
 non-Flink consuming applications of calling this API, or modify the retry behaviour of this API call in the consumer by
 setting keys prefixed by `ConsumerConfigConstants.SHARD_GETITERATOR_*` in the supplied configuration properties.
 
-- *[GetRecords](http://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetRecords.html)*: this is constantly called
+- *[GetRecords](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetRecords.html)*: this is constantly called
 by per shard consuming threads to fetch records from Kinesis. When a shard has multiple concurrent consumers (when there
 are any other non-Flink consuming applications running), the per shard rate limit may be exceeded. By default, on each call
 of this API, the consumer will retry if Kinesis complains that the data size / transaction limit for the API has exceeded,
@@ -271,9 +271,9 @@ consumer when calling this API can also be modified by using the other keys pref
 
 ## Kinesis Producer
 
-The `FlinkKinesisProducer` uses [Kinesis Producer Library (KPL)](http://docs.aws.amazon.com/streams/latest/dev/developing-producers-with-kpl.html) to put data from a Flink stream into a Kinesis stream.
+The `FlinkKinesisProducer` uses [Kinesis Producer Library (KPL)](https://docs.aws.amazon.com/streams/latest/dev/developing-producers-with-kpl.html) to put data from a Flink stream into a Kinesis stream.
 
-Note that the producer is not participating in Flink's checkpointing and doesn't provide exactly-once processing guarantees. Also, the Kinesis producer does not guarantee that records are written in order to the shards (See [here](https://github.com/awslabs/amazon-kinesis-producer/issues/23) and [here](http://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecord.html#API_PutRecord_RequestSyntax) for more details).
+Note that the producer is not participating in Flink's checkpointing and doesn't provide exactly-once processing guarantees. Also, the Kinesis producer does not guarantee that records are written in order to the shards (See [here](https://github.com/awslabs/amazon-kinesis-producer/issues/23) and [here](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecord.html#API_PutRecord_RequestSyntax) for more details).
 
 In case of a failure or a resharding, data will be written again to Kinesis, leading to duplicates. This behavior is usually called "at-least-once" semantics.
 

--- a/docs/dev/connectors/kinesis.zh.md
+++ b/docs/dev/connectors/kinesis.zh.md
@@ -26,7 +26,7 @@ under the License.
 * This will be replaced by the TOC
 {:toc}
 
-The Kinesis connector provides access to [Amazon AWS Kinesis Streams](http://aws.amazon.com/kinesis/streams/).
+The Kinesis connector provides access to [Amazon AWS Kinesis Streams](https://aws.amazon.com/kinesis/streams/).
 
 To use the connector, add the following Maven dependency to your project:
 
@@ -137,7 +137,7 @@ a custom implementation of `KinesisShardAssigner` can be set on the consumer.
 ### Configuring Starting Position
 
 The Flink Kinesis Consumer currently provides the following options to configure where to start reading Kinesis streams, simply by setting `ConsumerConfigConstants.STREAM_INITIAL_POSITION` to
-one of the following values in the provided configuration properties (the naming of the options identically follows [the namings used by the AWS Kinesis Streams service](http://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html#API_GetShardIterator_RequestSyntax)):
+one of the following values in the provided configuration properties (the naming of the options identically follows [the namings used by the AWS Kinesis Streams service](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html#API_GetShardIterator_RequestSyntax)):
 
 - `LATEST`: read all shards of all streams starting from the latest record.
 - `TRIM_HORIZON`: read all shards of all streams starting from the earliest record possible (data may be trimmed by Kinesis depending on the retention settings).
@@ -237,13 +237,13 @@ one thread per open shard.
 
 ### Internally Used Kinesis APIs
 
-The Flink Kinesis Consumer uses the [AWS Java SDK](http://aws.amazon.com/sdk-for-java/) internally to call Kinesis APIs
-for shard discovery and data consumption. Due to Amazon's [service limits for Kinesis Streams](http://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html)
+The Flink Kinesis Consumer uses the [AWS Java SDK](https://aws.amazon.com/sdk-for-java/) internally to call Kinesis APIs
+for shard discovery and data consumption. Due to Amazon's [service limits for Kinesis Streams](https://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html)
 on the APIs, the consumer will be competing with other non-Flink consuming applications that the user may be running.
 Below is a list of APIs called by the consumer with description of how the consumer uses the API, as well as information
 on how to deal with any errors or warnings that the Flink Kinesis Consumer may have due to these service limits.
 
-- *[DescribeStream](http://docs.aws.amazon.com/kinesis/latest/APIReference/API_DescribeStream.html)*: this is constantly called
+- *[DescribeStream](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_DescribeStream.html)*: this is constantly called
 by a single thread in each parallel consumer subtask to discover any new shards as a result of stream resharding. By default,
 the consumer performs the shard discovery at an interval of 10 seconds, and will retry indefinitely until it gets a result
 from Kinesis. If this interferes with other non-Flink consuming applications, users can slow down the consumer of
@@ -251,14 +251,14 @@ calling this API by setting a value for `ConsumerConfigConstants.SHARD_DISCOVERY
 configuration properties. This sets the discovery interval to a different value. Note that this setting directly impacts
 the maximum delay of discovering a new shard and starting to consume it, as shards will not be discovered during the interval.
 
-- *[GetShardIterator](http://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html)*: this is called
+- *[GetShardIterator](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html)*: this is called
 only once when per shard consuming threads are started, and will retry if Kinesis complains that the transaction limit for the
 API has exceeded, up to a default of 3 attempts. Note that since the rate limit for this API is per shard (not per stream),
 the consumer itself should not exceed the limit. Usually, if this happens, users can either try to slow down any other
 non-Flink consuming applications of calling this API, or modify the retry behaviour of this API call in the consumer by
 setting keys prefixed by `ConsumerConfigConstants.SHARD_GETITERATOR_*` in the supplied configuration properties.
 
-- *[GetRecords](http://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetRecords.html)*: this is constantly called
+- *[GetRecords](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetRecords.html)*: this is constantly called
 by per shard consuming threads to fetch records from Kinesis. When a shard has multiple concurrent consumers (when there
 are any other non-Flink consuming applications running), the per shard rate limit may be exceeded. By default, on each call
 of this API, the consumer will retry if Kinesis complains that the data size / transaction limit for the API has exceeded,
@@ -271,9 +271,9 @@ consumer when calling this API can also be modified by using the other keys pref
 
 ## Kinesis Producer
 
-The `FlinkKinesisProducer` uses [Kinesis Producer Library (KPL)](http://docs.aws.amazon.com/streams/latest/dev/developing-producers-with-kpl.html) to put data from a Flink stream into a Kinesis stream.
+The `FlinkKinesisProducer` uses [Kinesis Producer Library (KPL)](https://docs.aws.amazon.com/streams/latest/dev/developing-producers-with-kpl.html) to put data from a Flink stream into a Kinesis stream.
 
-Note that the producer is not participating in Flink's checkpointing and doesn't provide exactly-once processing guarantees. Also, the Kinesis producer does not guarantee that records are written in order to the shards (See [here](https://github.com/awslabs/amazon-kinesis-producer/issues/23) and [here](http://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecord.html#API_PutRecord_RequestSyntax) for more details).
+Note that the producer is not participating in Flink's checkpointing and doesn't provide exactly-once processing guarantees. Also, the Kinesis producer does not guarantee that records are written in order to the shards (See [here](https://github.com/awslabs/amazon-kinesis-producer/issues/23) and [here](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecord.html#API_PutRecord_RequestSyntax) for more details).
 
 In case of a failure or a resharding, data will be written again to Kinesis, leading to duplicates. This behavior is usually called "at-least-once" semantics.
 

--- a/docs/dev/connectors/rabbitmq.md
+++ b/docs/dev/connectors/rabbitmq.md
@@ -37,7 +37,7 @@ must be aware that this may be subject to conditions declared in the Mozilla Pub
 
 # RabbitMQ Connector
 
-This connector provides access to data streams from [RabbitMQ](http://www.rabbitmq.com/). To use this connector, add the following dependency to your project:
+This connector provides access to data streams from [RabbitMQ](https://www.rabbitmq.com/). To use this connector, add the following dependency to your project:
 
 {% highlight xml %}
 <dependency>
@@ -50,7 +50,7 @@ This connector provides access to data streams from [RabbitMQ](http://www.rabbit
 Note that the streaming connectors are currently not part of the binary distribution. See linking with them for cluster execution [here]({{site.baseurl}}/dev/projectsetup/dependencies.html).
 
 #### Installing RabbitMQ
-Follow the instructions from the [RabbitMQ download page](http://www.rabbitmq.com/download.html). After the installation the server automatically starts, and the application connecting to RabbitMQ can be launched.
+Follow the instructions from the [RabbitMQ download page](https://www.rabbitmq.com/download.html). After the installation the server automatically starts, and the application connecting to RabbitMQ can be launched.
 
 #### RabbitMQ Source
 
@@ -170,6 +170,6 @@ stream.addSink(new RMQSink[String](
 </div>
 </div>
 
-More about RabbitMQ can be found [here](http://www.rabbitmq.com/).
+More about RabbitMQ can be found [here](https://www.rabbitmq.com/).
 
 {% top %}

--- a/docs/dev/connectors/rabbitmq.zh.md
+++ b/docs/dev/connectors/rabbitmq.zh.md
@@ -37,7 +37,7 @@ must be aware that this may be subject to conditions declared in the Mozilla Pub
 
 # RabbitMQ Connector
 
-This connector provides access to data streams from [RabbitMQ](http://www.rabbitmq.com/). To use this connector, add the following dependency to your project:
+This connector provides access to data streams from [RabbitMQ](https://www.rabbitmq.com/). To use this connector, add the following dependency to your project:
 
 {% highlight xml %}
 <dependency>
@@ -50,7 +50,7 @@ This connector provides access to data streams from [RabbitMQ](http://www.rabbit
 Note that the streaming connectors are currently not part of the binary distribution. See linking with them for cluster execution [here]({{site.baseurl}}/dev/projectsetup/dependencies.html).
 
 #### Installing RabbitMQ
-Follow the instructions from the [RabbitMQ download page](http://www.rabbitmq.com/download.html). After the installation the server automatically starts, and the application connecting to RabbitMQ can be launched.
+Follow the instructions from the [RabbitMQ download page](https://www.rabbitmq.com/download.html). After the installation the server automatically starts, and the application connecting to RabbitMQ can be launched.
 
 #### RabbitMQ Source
 
@@ -170,6 +170,6 @@ stream.addSink(new RMQSink[String](
 </div>
 </div>
 
-More about RabbitMQ can be found [here](http://www.rabbitmq.com/).
+More about RabbitMQ can be found [here](https://www.rabbitmq.com/).
 
 {% top %}

--- a/docs/dev/connectors/streamfile_sink.md
+++ b/docs/dev/connectors/streamfile_sink.md
@@ -37,7 +37,7 @@ too big. This is also configurable but the default policy rolls files based on
 file size and a timeout, *i.e* if no new data was written to a part file. 
 
 The `StreamingFileSink` supports both row-wise encoding formats and
-bulk-encoding formats, such as [Apache Parquet](http://parquet.apache.org).
+bulk-encoding formats, such as [Apache Parquet](https://parquet.apache.org).
 
 #### Using Row-encoded Output Formats
 
@@ -102,7 +102,7 @@ interactions of bucket assigners and rolling policies.
 
 In the above example we used an `Encoder` that can encode or serialize each
 record individually. The streaming file sink also supports bulk-encoded output
-formats such as [Apache Parquet](http://parquet.apache.org). To use these,
+formats such as [Apache Parquet](https://parquet.apache.org). To use these,
 instead of `StreamingFileSink.forRowFormat()` you would use
 `StreamingFileSink.forBulkFormat()` and specify a `BulkWriter.Factory`.
 

--- a/docs/dev/connectors/streamfile_sink.zh.md
+++ b/docs/dev/connectors/streamfile_sink.zh.md
@@ -37,7 +37,7 @@ too big. This is also configurable but the default policy rolls files based on
 file size and a timeout, *i.e* if no new data was written to a part file.
 
 The `StreamingFileSink` supports both row-wise encoding formats and
-bulk-encoding formats, such as [Apache Parquet](http://parquet.apache.org).
+bulk-encoding formats, such as [Apache Parquet](https://parquet.apache.org).
 
 #### Using Row-encoded Output Formats
 
@@ -102,7 +102,7 @@ interactions of bucket assigners and rolling policies.
 
 In the above example we used an `Encoder` that can encode or serialize each
 record individually. The streaming file sink also supports bulk-encoded output
-formats such as [Apache Parquet](http://parquet.apache.org). To use these,
+formats such as [Apache Parquet](https://parquet.apache.org). To use these,
 instead of `StreamingFileSink.forRowFormat()` you would use
 `StreamingFileSink.forBulkFormat()` and specify a `BulkWriter.Factory`.
 

--- a/docs/dev/libs/gelly/bipartite_graph.md
+++ b/docs/dev/libs/gelly/bipartite_graph.md
@@ -34,7 +34,7 @@ A bipartite graph (also called a two-mode graph) is a type of graph where vertic
 
 These graphs have wide application in practice and can be a more natural choice for particular domains. For example to represent authorship of scientific papers top vertices can represent scientific papers while bottom nodes will represent authors. Naturally an edge between a top and a bottom nodes would represent an authorship of a particular scientific paper. Another common example for applications of bipartite graphs is relationships between actors and movies. In this case an edge represents that a particular actor played in a movie.
 
-Bipartite graphs are used instead of regular graphs (one-mode) for the following practical [reasons](http://www.complexnetworks.fr/wp-content/uploads/2011/01/socnet07.pdf):
+Bipartite graphs are used instead of regular graphs (one-mode) for the following practical [reasons](httpy://www.complexnetworks.fr/wp-content/uploads/2011/01/socnet07.pdf):
  * They preserve more information about a connection between vertices. For example instead of a single link between two researchers in a graph that represents that they authored a paper together a bipartite graph preserves the information about what papers they authored
  * Bipartite graphs can encode the same information more compactly than one-mode graphs
  

--- a/docs/dev/libs/gelly/bipartite_graph.zh.md
+++ b/docs/dev/libs/gelly/bipartite_graph.zh.md
@@ -34,7 +34,7 @@ A bipartite graph (also called a two-mode graph) is a type of graph where vertic
 
 These graphs have wide application in practice and can be a more natural choice for particular domains. For example to represent authorship of scientific papers top vertices can represent scientific papers while bottom nodes will represent authors. Naturally an edge between a top and a bottom nodes would represent an authorship of a particular scientific paper. Another common example for applications of bipartite graphs is relationships between actors and movies. In this case an edge represents that a particular actor played in a movie.
 
-Bipartite graphs are used instead of regular graphs (one-mode) for the following practical [reasons](http://www.complexnetworks.fr/wp-content/uploads/2011/01/socnet07.pdf):
+Bipartite graphs are used instead of regular graphs (one-mode) for the following practical [reasons](https://www.complexnetworks.fr/wp-content/uploads/2011/01/socnet07.pdf):
  * They preserve more information about a connection between vertices. For example instead of a single link between two researchers in a graph that represents that they authored a paper together a bipartite graph preserves the information about what papers they authored
  * Bipartite graphs can encode the same information more compactly than one-mode graphs
  

--- a/docs/dev/libs/gelly/graph_generators.md
+++ b/docs/dev/libs/gelly/graph_generators.md
@@ -74,8 +74,8 @@ val graph = new GridGraph(env.getJavaEnv).addDimension(2, wrapEndpoints).addDime
 
 ## Circulant Graph
 
-A [circulant graph](http://mathworld.wolfram.com/CirculantGraph.html) is an
-[oriented graph](http://mathworld.wolfram.com/OrientedGraph.html) configured
+A [circulant graph](httpx://mathworld.wolfram.com/CirculantGraph.html) is an
+[oriented graph](httpx://mathworld.wolfram.com/OrientedGraph.html) configured
 with one or more contiguous ranges of offsets. Edges connect integer vertex IDs
 whose difference equals a configured offset. The circulant graph with no offsets
 is the [empty graph](#empty-graph) and the graph with the maximum range is the
@@ -231,7 +231,7 @@ val graph = new CycleGraph(env.getJavaEnv, vertexCount).generate()
 
 ## Echo Graph
 
-An [echo graph](http://mathworld.wolfram.com/EchoGraph.html) is a
+An [echo graph](https://mathworld.wolfram.com/EchoGraph.html) is a
 [circulant graph](#circulant-graph) with `n` vertices defined by the width of a
 single range of offsets centered at `n/2`. A vertex is connected to 'far'
 vertices, which connect to 'near' vertices, which connect to 'far' vertices, ....
@@ -518,7 +518,7 @@ val graph = new PathGraph(env.getJavaEnv, vertexCount).generate()
 ## RMat Graph
 
 A directed power-law multigraph generated using the
-[Recursive Matrix (R-Mat)](http://www.cs.cmu.edu/~christos/PUBLICATIONS/siam04.pdf) model.
+[Recursive Matrix (R-Mat)](https://www.cs.cmu.edu/~christos/PUBLICATIONS/siam04.pdf) model.
 
 RMat is a stochastic generator configured with a source of randomness implementing the
 `RandomGenerableFactory` interface. Provided implementations are `JDKRandomGeneratorFactory`

--- a/docs/dev/libs/gelly/graph_generators.zh.md
+++ b/docs/dev/libs/gelly/graph_generators.zh.md
@@ -74,8 +74,8 @@ val graph = new GridGraph(env.getJavaEnv).addDimension(2, wrapEndpoints).addDime
 
 ## Circulant Graph
 
-A [circulant graph](http://mathworld.wolfram.com/CirculantGraph.html) is an
-[oriented graph](http://mathworld.wolfram.com/OrientedGraph.html) configured
+A [circulant graph](https://mathworld.wolfram.com/CirculantGraph.html) is an
+[oriented graph](https://mathworld.wolfram.com/OrientedGraph.html) configured
 with one or more contiguous ranges of offsets. Edges connect integer vertex IDs
 whose difference equals a configured offset. The circulant graph with no offsets
 is the [empty graph](#empty-graph) and the graph with the maximum range is the
@@ -231,7 +231,7 @@ val graph = new CycleGraph(env.getJavaEnv, vertexCount).generate()
 
 ## Echo Graph
 
-An [echo graph](http://mathworld.wolfram.com/EchoGraph.html) is a
+An [echo graph](https://mathworld.wolfram.com/EchoGraph.html) is a
 [circulant graph](#circulant-graph) with `n` vertices defined by the width of a
 single range of offsets centered at `n/2`. A vertex is connected to 'far'
 vertices, which connect to 'near' vertices, which connect to 'far' vertices, ....
@@ -518,7 +518,7 @@ val graph = new PathGraph(env.getJavaEnv, vertexCount).generate()
 ## RMat Graph
 
 A directed power-law multigraph generated using the
-[Recursive Matrix (R-Mat)](http://www.cs.cmu.edu/~christos/PUBLICATIONS/siam04.pdf) model.
+[Recursive Matrix (R-Mat)](https://www.cs.cmu.edu/~christos/PUBLICATIONS/siam04.pdf) model.
 
 RMat is a stochastic generator configured with a source of randomness implementing the
 `RandomGenerableFactory` interface. Provided implementations are `JDKRandomGeneratorFactory`

--- a/docs/dev/libs/gelly/index.md
+++ b/docs/dev/libs/gelly/index.md
@@ -73,7 +73,7 @@ Running Gelly Examples
 
 The Gelly library jars are provided in the [Flink distribution](https://flink.apache.org/downloads.html "Apache Flink: Downloads")
 in the **opt** directory (for versions older than Flink 1.2 these can be manually downloaded from
-[Maven Central](http://search.maven.org/#search|ga|1|flink%20gelly)). To run the Gelly examples the **flink-gelly** (for
+[Maven Central](https://search.maven.org/#search|ga|1|flink%20gelly)). To run the Gelly examples the **flink-gelly** (for
 Java) or **flink-gelly-scala** (for Scala) jar must be copied to Flink's **lib** directory.
 
 {% highlight bash %}
@@ -110,12 +110,12 @@ The size of the graph is adjusted by the *\-\-scale* and *\-\-edge_factor* param
 [library generator](./graph_generators.html#rmat-graph) provides access to additional configuration to adjust the
 power-law skew and random noise.
 
-Sample social network data is provided by the [Stanford Network Analysis Project](http://snap.stanford.edu/data/index.html).
-The [com-lj](http://snap.stanford.edu/data/bigdata/communities/com-lj.ungraph.txt.gz) data set is a good starter size.
+Sample social network data is provided by the [Stanford Network Analysis Project](https://snap.stanford.edu/data/index.html).
+The [com-lj](https://snap.stanford.edu/data/bigdata/communities/com-lj.ungraph.txt.gz) data set is a good starter size.
 Run a few algorithms and monitor the job progress in Flink's Web UI:
 
 {% highlight bash %}
-wget -O - http://snap.stanford.edu/data/bigdata/communities/com-lj.ungraph.txt.gz | gunzip -c > com-lj.ungraph.txt
+wget -O - https://snap.stanford.edu/data/bigdata/communities/com-lj.ungraph.txt.gz | gunzip -c > com-lj.ungraph.txt
 
 ./bin/flink run -q examples/gelly/flink-gelly-examples_*.jar \
     --algorithm GraphMetrics --order undirected \

--- a/docs/dev/libs/gelly/index.zh.md
+++ b/docs/dev/libs/gelly/index.zh.md
@@ -73,7 +73,7 @@ Running Gelly Examples
 
 The Gelly library jars are provided in the [Flink distribution](https://flink.apache.org/downloads.html "Apache Flink: Downloads")
 in the **opt** directory (for versions older than Flink 1.2 these can be manually downloaded from
-[Maven Central](http://search.maven.org/#search|ga|1|flink%20gelly)). To run the Gelly examples the **flink-gelly** (for
+[Maven Central](https://search.maven.org/#search|ga|1|flink%20gelly)). To run the Gelly examples the **flink-gelly** (for
 Java) or **flink-gelly-scala** (for Scala) jar must be copied to Flink's **lib** directory.
 
 {% highlight bash %}
@@ -110,12 +110,12 @@ The size of the graph is adjusted by the *\-\-scale* and *\-\-edge_factor* param
 [library generator](./graph_generators.html#rmat-graph) provides access to additional configuration to adjust the
 power-law skew and random noise.
 
-Sample social network data is provided by the [Stanford Network Analysis Project](http://snap.stanford.edu/data/index.html).
-The [com-lj](http://snap.stanford.edu/data/bigdata/communities/com-lj.ungraph.txt.gz) data set is a good starter size.
+Sample social network data is provided by the [Stanford Network Analysis Project](https://snap.stanford.edu/data/index.html).
+The [com-lj](https://snap.stanford.edu/data/bigdata/communities/com-lj.ungraph.txt.gz) data set is a good starter size.
 Run a few algorithms and monitor the job progress in Flink's Web UI:
 
 {% highlight bash %}
-wget -O - http://snap.stanford.edu/data/bigdata/communities/com-lj.ungraph.txt.gz | gunzip -c > com-lj.ungraph.txt
+wget -O - https://snap.stanford.edu/data/bigdata/communities/com-lj.ungraph.txt.gz | gunzip -c > com-lj.ungraph.txt
 
 ./bin/flink run -q examples/gelly/flink-gelly-examples_*.jar \
     --algorithm GraphMetrics --order undirected \

--- a/docs/dev/libs/gelly/library_methods.md
+++ b/docs/dev/libs/gelly/library_methods.md
@@ -65,7 +65,7 @@ verticesWithCommunity.print()
 
 #### Overview
 In graph theory, communities refer to groups of nodes that are well connected internally, but sparsely connected to other groups.
-This library method is an implementation of the community detection algorithm described in the paper [Towards real-time community detection in large networks](http://arxiv.org/pdf/0808.2633.pdf).
+This library method is an implementation of the community detection algorithm described in the paper [Towards real-time community detection in large networks](https://arxiv.org/pdf/0808.2633.pdf).
 
 #### Details
 The algorithm is implemented using [scatter-gather iterations](#scatter-gather-iterations).
@@ -87,7 +87,7 @@ The constructor takes two parameters:
 ## Label Propagation
 
 #### Overview
-This is an implementation of the well-known Label Propagation algorithm described in [this paper](http://journals.aps.org/pre/abstract/10.1103/PhysRevE.76.036106). The algorithm discovers communities in a graph, by iteratively propagating labels between neighbors. Unlike the [Community Detection library method](#community-detection), this implementation does not use scores associated with the labels.
+This is an implementation of the well-known Label Propagation algorithm described in [this paper](https://journals.aps.org/pre/abstract/10.1103/PhysRevE.76.036106). The algorithm discovers communities in a graph, by iteratively propagating labels between neighbors. Unlike the [Community Detection library method](#community-detection), this implementation does not use scores associated with the labels.
 
 #### Details
 The algorithm is implemented using [scatter-gather iterations](#scatter-gather-iterations).
@@ -272,7 +272,7 @@ provides a method to compute the local clustering coefficient score. The graph I
 
 #### Overview
 A triad is formed by any three vertices in a graph. Each triad contains three pairs of vertices which may be connected
-or unconnected. The [Triadic Census](http://vlado.fmf.uni-lj.si/pub/networks/doc/triads/triads.pdf) counts the
+or unconnected. The [Triadic Census](https://vlado.fmf.uni-lj.si/pub/networks/doc/triads/triads.pdf) counts the
 occurrences of each type of triad with the graph.
 
 #### Details
@@ -297,7 +297,7 @@ size 3.
 #### Details
 Triangles are listed by joining open triplets (two edges with a common neighbor) against edges on the triplet endpoints.
 This implementation uses optimizations from
-[Schank's algorithm](http://i11www.iti.uni-karlsruhe.de/extra/publications/sw-fclt-05_t.pdf) to improve performance with
+[Schank's algorithm](https://i11www.iti.uni-karlsruhe.de/extra/publications/sw-fclt-05_t.pdf) to improve performance with
 high-degree vertices. Triplets are generated from the lowest degree vertex since each triangle need only be listed once.
 This greatly reduces the number of generated triplets which is quadratic in vertex degree.
 
@@ -314,7 +314,7 @@ six potential edges connecting the three vertices. The graph ID type must be `Co
 ### Hyperlink-Induced Topic Search
 
 #### Overview
-[Hyperlink-Induced Topic Search](http://www.cs.cornell.edu/home/kleinber/auth.pdf) (HITS, or "Hubs and Authorities")
+[Hyperlink-Induced Topic Search](https://www.cs.cornell.edu/home/kleinber/auth.pdf) (HITS, or "Hubs and Authorities")
 computes two interdependent scores for every vertex in a directed graph. Good hubs are those which point to many
 good authorities and good authorities are those pointed to by many good hubs.
 

--- a/docs/dev/libs/gelly/library_methods.zh.md
+++ b/docs/dev/libs/gelly/library_methods.zh.md
@@ -65,7 +65,7 @@ verticesWithCommunity.print()
 
 #### Overview
 In graph theory, communities refer to groups of nodes that are well connected internally, but sparsely connected to other groups.
-This library method is an implementation of the community detection algorithm described in the paper [Towards real-time community detection in large networks](http://arxiv.org/pdf/0808.2633.pdf).
+This library method is an implementation of the community detection algorithm described in the paper [Towards real-time community detection in large networks](https://arxiv.org/pdf/0808.2633.pdf).
 
 #### Details
 The algorithm is implemented using [scatter-gather iterations](#scatter-gather-iterations).
@@ -87,7 +87,7 @@ The constructor takes two parameters:
 ## Label Propagation
 
 #### Overview
-This is an implementation of the well-known Label Propagation algorithm described in [this paper](http://journals.aps.org/pre/abstract/10.1103/PhysRevE.76.036106). The algorithm discovers communities in a graph, by iteratively propagating labels between neighbors. Unlike the [Community Detection library method](#community-detection), this implementation does not use scores associated with the labels.
+This is an implementation of the well-known Label Propagation algorithm described in [this paper](https://journals.aps.org/pre/abstract/10.1103/PhysRevE.76.036106). The algorithm discovers communities in a graph, by iteratively propagating labels between neighbors. Unlike the [Community Detection library method](#community-detection), this implementation does not use scores associated with the labels.
 
 #### Details
 The algorithm is implemented using [scatter-gather iterations](#scatter-gather-iterations).
@@ -272,7 +272,7 @@ provides a method to compute the local clustering coefficient score. The graph I
 
 #### Overview
 A triad is formed by any three vertices in a graph. Each triad contains three pairs of vertices which may be connected
-or unconnected. The [Triadic Census](http://vlado.fmf.uni-lj.si/pub/networks/doc/triads/triads.pdf) counts the
+or unconnected. The [Triadic Census](https://vlado.fmf.uni-lj.si/pub/networks/doc/triads/triads.pdf) counts the
 occurrences of each type of triad with the graph.
 
 #### Details
@@ -297,7 +297,7 @@ size 3.
 #### Details
 Triangles are listed by joining open triplets (two edges with a common neighbor) against edges on the triplet endpoints.
 This implementation uses optimizations from
-[Schank's algorithm](http://i11www.iti.uni-karlsruhe.de/extra/publications/sw-fclt-05_t.pdf) to improve performance with
+[Schank's algorithm](https://i11www.iti.uni-karlsruhe.de/extra/publications/sw-fclt-05_t.pdf) to improve performance with
 high-degree vertices. Triplets are generated from the lowest degree vertex since each triangle need only be listed once.
 This greatly reduces the number of generated triplets which is quadratic in vertex degree.
 
@@ -314,7 +314,7 @@ six potential edges connecting the three vertices. The graph ID type must be `Co
 ### Hyperlink-Induced Topic Search
 
 #### Overview
-[Hyperlink-Induced Topic Search](http://www.cs.cornell.edu/home/kleinber/auth.pdf) (HITS, or "Hubs and Authorities")
+[Hyperlink-Induced Topic Search](https://www.cs.cornell.edu/home/kleinber/auth.pdf) (HITS, or "Hubs and Authorities")
 computes two interdependent scores for every vertex in a directed graph. Good hubs are those which point to many
 good authorities and good authorities are those pointed to by many good hubs.
 

--- a/docs/dev/libs/ml/als.md
+++ b/docs/dev/libs/ml/als.md
@@ -41,7 +41,7 @@ $$\arg\min_{U,V} \sum_{\{i,j\mid r_{i,j} \not= 0\}} \left(r_{i,j} - u_{i}^Tv_{j}
 
 with $\lambda$ being the regularization factor, $$n_{u_i}$$ being the number of items the user $i$ has rated and $$n_{v_j}$$ being the number of times the item $j$ has been rated.
 This regularization scheme to avoid overfitting is called weighted-$\lambda$-regularization.
-Details can be found in the work of [Zhou et al.](http://dx.doi.org/10.1007/978-3-540-68880-8_32).
+Details can be found in the work of [Zhou et al.](https://dx.doi.org/10.1007/978-3-540-68880-8_32).
 
 By fixing one of the matrices $U$ or $V$, we obtain a quadratic form which can be solved directly.
 The solution of the modified problem is guaranteed to monotonically decrease the overall cost function.

--- a/docs/dev/libs/ml/als.zh.md
+++ b/docs/dev/libs/ml/als.zh.md
@@ -41,7 +41,7 @@ $$\arg\min_{U,V} \sum_{\{i,j\mid r_{i,j} \not= 0\}} \left(r_{i,j} - u_{i}^Tv_{j}
 
 with $\lambda$ being the regularization factor, $$n_{u_i}$$ being the number of items the user $i$ has rated and $$n_{v_j}$$ being the number of times the item $j$ has been rated.
 This regularization scheme to avoid overfitting is called weighted-$\lambda$-regularization.
-Details can be found in the work of [Zhou et al.](http://dx.doi.org/10.1007/978-3-540-68880-8_32).
+Details can be found in the work of [Zhou et al.](https://dx.doi.org/10.1007/978-3-540-68880-8_32).
 
 By fixing one of the matrices $U$ or $V$, we obtain a quadratic form which can be solved directly.
 The solution of the modified problem is guaranteed to monotonically decrease the overall cost function.

--- a/docs/dev/libs/ml/contribution_guide.md
+++ b/docs/dev/libs/ml/contribution_guide.md
@@ -31,7 +31,7 @@ The following document describes how to contribute to FlinkML.
 
 ## Getting Started
 
-In order to get started first read Flink's [contribution guide](http://flink.apache.org/how-to-contribute.html).
+In order to get started first read Flink's [contribution guide](https://flink.apache.org/how-to-contribute.html).
 Everything from this guide also applies to FlinkML.
 
 ## Pick a Topic
@@ -69,7 +69,7 @@ class ExampleITSuite extends FlatSpec with FlinkTestBase {
 {% endhighlight %}
 
 The test style does not have to be `FlatSpec` but can be any other scalatest `Suite` subclass.
-See [ScalaTest testing styles](http://scalatest.org/user_guide/selecting_a_style) for more information.
+See [ScalaTest testing styles](https://scalatest.org/user_guide/selecting_a_style) for more information.
 
 ## Documentation
 
@@ -103,6 +103,6 @@ See `docs/_include/latex_commands.html` for the complete list of predefined late
 ## Contributing
 
 Once you have implemented the algorithm with adequate test coverage and added documentation, you are ready to open a pull request.
-Details of how to open a pull request can be found [here](http://flink.apache.org/how-to-contribute.html#contributing-code--documentation).
+Details of how to open a pull request can be found [here](https://flink.apache.org/how-to-contribute.html#contributing-code--documentation).
 
 {% top %}

--- a/docs/dev/libs/ml/contribution_guide.zh.md
+++ b/docs/dev/libs/ml/contribution_guide.zh.md
@@ -31,7 +31,7 @@ The following document describes how to contribute to FlinkML.
 
 ## Getting Started
 
-In order to get started first read Flink's [contribution guide](http://flink.apache.org/how-to-contribute.html).
+In order to get started first read Flink's [contribution guide](https://flink.apache.org/how-to-contribute.html).
 Everything from this guide also applies to FlinkML.
 
 ## Pick a Topic
@@ -69,7 +69,7 @@ class ExampleITSuite extends FlatSpec with FlinkTestBase {
 {% endhighlight %}
 
 The test style does not have to be `FlatSpec` but can be any other scalatest `Suite` subclass.
-See [ScalaTest testing styles](http://scalatest.org/user_guide/selecting_a_style) for more information.
+See [ScalaTest testing styles](https://scalatest.org/user_guide/selecting_a_style) for more information.
 
 ## Documentation
 
@@ -103,6 +103,6 @@ See `docs/_include/latex_commands.html` for the complete list of predefined late
 ## Contributing
 
 Once you have implemented the algorithm with adequate test coverage and added documentation, you are ready to open a pull request.
-Details of how to open a pull request can be found [here](http://flink.apache.org/how-to-contribute.html#contributing-code--documentation).
+Details of how to open a pull request can be found [here](https://flink.apache.org/how-to-contribute.html#contributing-code--documentation).
 
 {% top %}

--- a/docs/dev/libs/ml/index.md
+++ b/docs/dev/libs/ml/index.md
@@ -113,7 +113,7 @@ val predictions: DataSet[LabeledVector] = mlr.predict(testingData)
 
 ## Pipelines
 
-A key concept of FlinkML is its [scikit-learn](http://scikit-learn.org) inspired pipelining mechanism.
+A key concept of FlinkML is its [scikit-learn](https://scikit-learn.org) inspired pipelining mechanism.
 It allows you to quickly build complex data analysis pipelines how they appear in every data scientist's daily work.
 An in-depth description of FlinkML's pipelines and their internal workings can be found [here](pipelines.html).
 

--- a/docs/dev/libs/ml/index.zh.md
+++ b/docs/dev/libs/ml/index.zh.md
@@ -113,7 +113,7 @@ val predictions: DataSet[LabeledVector] = mlr.predict(testingData)
 
 ## Pipelines
 
-A key concept of FlinkML is its [scikit-learn](http://scikit-learn.org) inspired pipelining mechanism.
+A key concept of FlinkML is its [scikit-learn](https://scikit-learn.org) inspired pipelining mechanism.
 It allows you to quickly build complex data analysis pipelines how they appear in every data scientist's daily work.
 An in-depth description of FlinkML's pipelines and their internal workings can be found [here](pipelines.html).
 

--- a/docs/dev/libs/ml/knn.md
+++ b/docs/dev/libs/ml/knn.md
@@ -141,6 +141,6 @@ knn.fit(trainingSet)
 val result = knn.predict(testingSet).collect()
 {% endhighlight %}
 
-For more details on the computing KNN with and without and quadtree, here is a presentation: [http://danielblazevski.github.io/](http://danielblazevski.github.io/)
+For more details on the computing KNN with and without and quadtree, here is a presentation: [https://danielblazevski.github.io/](https://danielblazevski.github.io/)
 
 {% top %}

--- a/docs/dev/libs/ml/knn.zh.md
+++ b/docs/dev/libs/ml/knn.zh.md
@@ -141,6 +141,6 @@ knn.fit(trainingSet)
 val result = knn.predict(testingSet).collect()
 {% endhighlight %}
 
-For more details on the computing KNN with and without and quadtree, here is a presentation: [http://danielblazevski.github.io/](http://danielblazevski.github.io/)
+For more details on the computing KNN with and without and quadtree, here is a presentation: [https://danielblazevski.github.io/](https://danielblazevski.github.io/)
 
 {% top %}

--- a/docs/dev/libs/ml/optimization.md
+++ b/docs/dev/libs/ml/optimization.md
@@ -80,7 +80,7 @@ The $L_1$ penalty can be used to drive a number of the solution coefficients to 
 producing sparse solutions.
 The regularization constant $\lambda$ in $\eqref{eq:objectiveFunc}$ determines the amount of regularization applied to the model,
 and is usually determined through model cross-validation.
-A good comparison of regularization types can be found in [this](http://www.robotics.stanford.edu/~ang/papers/icml04-l1l2.pdf) paper by Andrew Ng.
+A good comparison of regularization types can be found in [this](https://www.robotics.stanford.edu/~ang/papers/icml04-l1l2.pdf) paper by Andrew Ng.
 Which regularization type is supported depends on the actually used optimization algorithm.
 
 ## Stochastic Gradient Descent
@@ -99,7 +99,7 @@ the average of the gradients computed from each mini-batch.
 
 An important parameter is the learning rate $\eta$, or step size, which can be determined by one of five methods, listed below. The setting of the initial step size can significantly affect the performance of the
 algorithm. For some practical tips on tuning SGD see Leon Botou's
-"[Stochastic Gradient Descent Tricks](http://research.microsoft.com/pubs/192769/tricks-2012.pdf)".
+"[Stochastic Gradient Descent Tricks](https://research.microsoft.com/pubs/192769/tricks-2012.pdf)".
 
 The current implementation of SGD  uses the whole partition, making it
 effectively a batch gradient descent. Once a sampling operator has been introduced in Flink, true
@@ -377,7 +377,7 @@ Where:
         <td><strong>Wei Xu's Method</strong></td>
         <td>
           <p>
-            Method proposed by Wei Xu in <a href="http://arxiv.org/pdf/1107.2490.pdf">Towards Optimal One Pass Large Scale Learning with
+            Method proposed by Wei Xu in <a href="https://arxiv.org/pdf/1107.2490.pdf">Towards Optimal One Pass Large Scale Learning with
             Averaged Stochastic Gradient Descent</a>
           </p>
         </td>

--- a/docs/dev/libs/ml/optimization.zh.md
+++ b/docs/dev/libs/ml/optimization.zh.md
@@ -80,7 +80,7 @@ The $L_1$ penalty can be used to drive a number of the solution coefficients to 
 producing sparse solutions.
 The regularization constant $\lambda$ in $\eqref{eq:objectiveFunc}$ determines the amount of regularization applied to the model,
 and is usually determined through model cross-validation.
-A good comparison of regularization types can be found in [this](http://www.robotics.stanford.edu/~ang/papers/icml04-l1l2.pdf) paper by Andrew Ng.
+A good comparison of regularization types can be found in [this](https://www.robotics.stanford.edu/~ang/papers/icml04-l1l2.pdf) paper by Andrew Ng.
 Which regularization type is supported depends on the actually used optimization algorithm.
 
 ## Stochastic Gradient Descent
@@ -99,7 +99,7 @@ the average of the gradients computed from each mini-batch.
 
 An important parameter is the learning rate $\eta$, or step size, which can be determined by one of five methods, listed below. The setting of the initial step size can significantly affect the performance of the
 algorithm. For some practical tips on tuning SGD see Leon Botou's
-"[Stochastic Gradient Descent Tricks](http://research.microsoft.com/pubs/192769/tricks-2012.pdf)".
+"[Stochastic Gradient Descent Tricks](https://research.microsoft.com/pubs/192769/tricks-2012.pdf)".
 
 The current implementation of SGD  uses the whole partition, making it
 effectively a batch gradient descent. Once a sampling operator has been introduced in Flink, true
@@ -377,7 +377,7 @@ Where:
         <td><strong>Wei Xu's Method</strong></td>
         <td>
           <p>
-            Method proposed by Wei Xu in <a href="http://arxiv.org/pdf/1107.2490.pdf">Towards Optimal One Pass Large Scale Learning with
+            Method proposed by Wei Xu in <a href="https://arxiv.org/pdf/1107.2490.pdf">Towards Optimal One Pass Large Scale Learning with
             Averaged Stochastic Gradient Descent</a>
           </p>
         </td>

--- a/docs/dev/libs/ml/pipelines.md
+++ b/docs/dev/libs/ml/pipelines.md
@@ -50,7 +50,7 @@ and
 then output the transformed data, either to be used as the input (features) of a predictor
 function, such as a learning model, or just output the transformed data themselves, to be used in
 some other task. The end learner can of course be a part of the pipeline as well.
-ML pipelines can often be complicated sets of operations ([in-depth explanation](http://research.google.com/pubs/pub43146.html)) and
+ML pipelines can often be complicated sets of operations ([in-depth explanation](https://research.google.com/pubs/pub43146.html)) and
 can become sources of errors for end-to-end learning systems.
 
 The purpose of ML pipelines is then to create a
@@ -70,9 +70,9 @@ pipeline "fit".
 ## Pipelines in FlinkML
 
 The building blocks for pipelines in FlinkML can be found in the `ml.pipeline` package.
-FlinkML follows an API inspired by [sklearn](http://scikit-learn.org) which means that we have
+FlinkML follows an API inspired by [sklearn](https://scikit-learn.org) which means that we have
 `Estimator`, `Transformer` and `Predictor` interfaces. For an in-depth look at the design of the
-sklearn API the interested reader is referred to [this](http://arxiv.org/abs/1309.0238) paper.
+sklearn API the interested reader is referred to [this](https://arxiv.org/abs/1309.0238) paper.
 In short, the `Estimator` is the base class from which `Transformer` and `Predictor` inherit.
 `Estimator` defines a `fit` method, and `Transformer` also defines a `transform` method and
 `Predictor` defines a `predict` method.
@@ -128,7 +128,7 @@ and predict operations together in a type-safe manner.
 
 As we mentioned, the trait (abstract class) `Estimator` defines a `fit` method. The method has two
 parameter lists
-(i.e. is a [curried function](http://docs.scala-lang.org/tutorials/tour/currying.html)). The
+(i.e. is a [curried function](https://docs.scala-lang.org/tutorials/tour/currying.html)). The
 first parameter list
 takes the input (training) `DataSet` and the parameters for the estimator. The second parameter
 list takes one `implicit` parameter, of type `FitOperation`. `FitOperation` is a class that also
@@ -138,7 +138,7 @@ method of `FitOperation`. The `predict` method of `Predictor` and the `transform
 `Transform` are designed in a similar manner, with a respective operation class.
 
 In these methods the operation object is provided as an implicit parameter.
-Scala will [look for implicits](http://docs.scala-lang.org/tutorials/FAQ/finding-implicits.html)
+Scala will [look for implicits](https://docs.scala-lang.org/tutorials/FAQ/finding-implicits.html)
 in the companion object of a type, so classes that implement these interfaces should provide these
 objects as implicit objects inside the companion object.
 

--- a/docs/dev/libs/ml/pipelines.zh.md
+++ b/docs/dev/libs/ml/pipelines.zh.md
@@ -50,7 +50,7 @@ and
 then output the transformed data, either to be used as the input (features) of a predictor
 function, such as a learning model, or just output the transformed data themselves, to be used in
 some other task. The end learner can of course be a part of the pipeline as well.
-ML pipelines can often be complicated sets of operations ([in-depth explanation](http://research.google.com/pubs/pub43146.html)) and
+ML pipelines can often be complicated sets of operations ([in-depth explanation](https://research.google.com/pubs/pub43146.html)) and
 can become sources of errors for end-to-end learning systems.
 
 The purpose of ML pipelines is then to create a
@@ -70,9 +70,9 @@ pipeline "fit".
 ## Pipelines in FlinkML
 
 The building blocks for pipelines in FlinkML can be found in the `ml.pipeline` package.
-FlinkML follows an API inspired by [sklearn](http://scikit-learn.org) which means that we have
+FlinkML follows an API inspired by [sklearn](https://scikit-learn.org) which means that we have
 `Estimator`, `Transformer` and `Predictor` interfaces. For an in-depth look at the design of the
-sklearn API the interested reader is referred to [this](http://arxiv.org/abs/1309.0238) paper.
+sklearn API the interested reader is referred to [this](https://arxiv.org/abs/1309.0238) paper.
 In short, the `Estimator` is the base class from which `Transformer` and `Predictor` inherit.
 `Estimator` defines a `fit` method, and `Transformer` also defines a `transform` method and
 `Predictor` defines a `predict` method.
@@ -128,7 +128,7 @@ and predict operations together in a type-safe manner.
 
 As we mentioned, the trait (abstract class) `Estimator` defines a `fit` method. The method has two
 parameter lists
-(i.e. is a [curried function](http://docs.scala-lang.org/tutorials/tour/currying.html)). The
+(i.e. is a [curried function](https://docs.scala-lang.org/tutorials/tour/currying.html)). The
 first parameter list
 takes the input (training) `DataSet` and the parameters for the estimator. The second parameter
 list takes one `implicit` parameter, of type `FitOperation`. `FitOperation` is a class that also
@@ -138,7 +138,7 @@ method of `FitOperation`. The `predict` method of `Predictor` and the `transform
 `Transform` are designed in a similar manner, with a respective operation class.
 
 In these methods the operation object is provided as an implicit parameter.
-Scala will [look for implicits](http://docs.scala-lang.org/tutorials/FAQ/finding-implicits.html)
+Scala will [look for implicits](https://docs.scala-lang.org/tutorials/FAQ/finding-implicits.html)
 in the companion object of a type, so classes that implement these interfaces should provide these
 objects as implicit objects inside the companion object.
 

--- a/docs/dev/libs/ml/quickstart.md
+++ b/docs/dev/libs/ml/quickstart.md
@@ -76,7 +76,7 @@ member which represents the label, which could be the class in a classification 
 variable for a regression problem.
 
 As an example, we can use Haberman's Survival Data Set , which you can
-[download from the UCI ML repository](http://archive.ics.uci.edu/ml/machine-learning-databases/haberman/haberman.data).
+[download from the UCI ML repository](https://archive.ics.uci.edu/ml/machine-learning-databases/haberman/haberman.data).
 This dataset *"contains cases from a study conducted on the survival of patients who had undergone
 surgery for breast cancer"*. The data comes in a comma-separated file, where the first 3 columns
 are the features and last column is the class, and the 4th column indicates whether the patient
@@ -119,13 +119,13 @@ building a learner; that will allow us to show how we can import other dataset f
 **LibSVM files**
 
 A common format for ML datasets is the LibSVM format and a number of datasets using that format can be
-found [in the LibSVM datasets website](http://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/). FlinkML provides utilities for loading
+found [in the LibSVM datasets website](https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/). FlinkML provides utilities for loading
 datasets using the LibSVM format through the `readLibSVM` function available through the `MLUtils`
 object.
 You can also save datasets in the LibSVM format using the `writeLibSVM` function.
 Let's import the svmguide1 dataset. You can download the
-[training set here](http://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/binary/svmguide1)
-and the [test set here](http://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/binary/svmguide1.t).
+[training set here](https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/binary/svmguide1)
+and the [test set here](https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/binary/svmguide1.t).
 This is an astroparticle binary classification dataset, used by Hsu et al. [[3]](#hsu) in their
 practical Support Vector Machine (SVM) guide. It contains 4 numerical features, and the class label.
 
@@ -243,7 +243,7 @@ algorithms.
 A very good way to get started is to play around with interesting datasets from the UCI ML
 repository and the LibSVM datasets.
 Tackling an interesting problem from a website like [Kaggle](https://www.kaggle.com) or
-[DrivenData](http://www.drivendata.org/) is also a great way to learn by competing with other
+[DrivenData](https://www.drivendata.org/) is also a great way to learn by competing with other
 data scientists.
 If you would like to contribute some new algorithms take a look at our
 [contribution guide](contribution_guide.html).

--- a/docs/dev/libs/ml/quickstart.zh.md
+++ b/docs/dev/libs/ml/quickstart.zh.md
@@ -76,7 +76,7 @@ member which represents the label, which could be the class in a classification 
 variable for a regression problem.
 
 As an example, we can use Haberman's Survival Data Set , which you can
-[download from the UCI ML repository](http://archive.ics.uci.edu/ml/machine-learning-databases/haberman/haberman.data).
+[download from the UCI ML repository](https://archive.ics.uci.edu/ml/machine-learning-databases/haberman/haberman.data).
 This dataset *"contains cases from a study conducted on the survival of patients who had undergone
 surgery for breast cancer"*. The data comes in a comma-separated file, where the first 3 columns
 are the features and last column is the class, and the 4th column indicates whether the patient
@@ -119,13 +119,13 @@ building a learner; that will allow us to show how we can import other dataset f
 **LibSVM files**
 
 A common format for ML datasets is the LibSVM format and a number of datasets using that format can be
-found [in the LibSVM datasets website](http://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/). FlinkML provides utilities for loading
+found [in the LibSVM datasets website](https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/). FlinkML provides utilities for loading
 datasets using the LibSVM format through the `readLibSVM` function available through the `MLUtils`
 object.
 You can also save datasets in the LibSVM format using the `writeLibSVM` function.
 Let's import the svmguide1 dataset. You can download the
-[training set here](http://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/binary/svmguide1)
-and the [test set here](http://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/binary/svmguide1.t).
+[training set here](https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/binary/svmguide1)
+and the [test set here](https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/binary/svmguide1.t).
 This is an astroparticle binary classification dataset, used by Hsu et al. [[3]](#hsu) in their
 practical Support Vector Machine (SVM) guide. It contains 4 numerical features, and the class label.
 
@@ -243,7 +243,7 @@ algorithms.
 A very good way to get started is to play around with interesting datasets from the UCI ML
 repository and the LibSVM datasets.
 Tackling an interesting problem from a website like [Kaggle](https://www.kaggle.com) or
-[DrivenData](http://www.drivendata.org/) is also a great way to learn by competing with other
+[DrivenData](https://www.drivendata.org/) is also a great way to learn by competing with other
 data scientists.
 If you would like to contribute some new algorithms take a look at our
 [contribution guide](contribution_guide.html).

--- a/docs/dev/libs/ml/svm.md
+++ b/docs/dev/libs/ml/svm.md
@@ -55,7 +55,7 @@ The local SDCA iterations are embarrassingly parallel once the individual data p
 distributed across the cluster.
 
 The implementation of this algorithm is based on the work of
-[Jaggi et al.](http://arxiv.org/abs/1409.1458)
+[Jaggi et al.](https://arxiv.org/abs/1409.1458)
 
 ## Operations
 

--- a/docs/dev/libs/ml/svm.zh.md
+++ b/docs/dev/libs/ml/svm.zh.md
@@ -55,7 +55,7 @@ The local SDCA iterations are embarrassingly parallel once the individual data p
 distributed across the cluster.
 
 The implementation of this algorithm is based on the work of
-[Jaggi et al.](http://arxiv.org/abs/1409.1458)
+[Jaggi et al.](https://arxiv.org/abs/1409.1458)
 
 ## Operations
 

--- a/docs/dev/projectsetup/java_api_quickstart.md
+++ b/docs/dev/projectsetup/java_api_quickstart.md
@@ -74,7 +74,7 @@ Use one of the following commands to __create a project__:
     </div>
     {% unless site.is_stable %}
     <p style="border-radius: 5px; padding: 5px" class="bg-danger">
-        <b>Note</b>: For Maven 3.0 or higher, it is no longer possible to specify the repository (-DarchetypeCatalog) via the command line. If you wish to use the snapshot repository, you need to add a repository entry to your settings.xml. For details about this change, please refer to <a href="http://maven.apache.org/archetype/maven-archetype-plugin/archetype-repository.html">Maven official document</a>
+        <b>Note</b>: For Maven 3.0 or higher, it is no longer possible to specify the repository (-DarchetypeCatalog) via the command line. If you wish to use the snapshot repository, you need to add a repository entry to your settings.xml. For details about this change, please refer to <a href="https://maven.apache.org/archetype/maven-archetype-plugin/archetype-repository.html">Maven official document</a>
     </p>
     {% endunless %}
 </div>
@@ -106,8 +106,8 @@ The _main_ method is the entry point of the program, both for in-IDE testing/exe
 
 We recommend you __import this project into your IDE__ to develop and
 test it. IntelliJ IDEA supports Maven projects out of the box.
-If you use Eclipse, the [m2e plugin](http://www.eclipse.org/m2e/)
-allows to [import Maven projects](http://books.sonatype.com/m2eclipse-book/reference/creating-sect-importing-projects.html#fig-creating-import).
+If you use Eclipse, the [m2e plugin](https://www.eclipse.org/m2e/)
+allows to [import Maven projects](https://books.sonatype.com/m2eclipse-book/reference/creating-sect-importing-projects.html#fig-creating-import).
 Some Eclipse bundles include that plugin by default, others require you
 to install it manually. 
 
@@ -348,7 +348,7 @@ For a complete overview over the APIs, have a look at the
 [Here]({{ site.baseurl }}/tutorials/local_setup.html) you can find out how to run an application outside the IDE on a local cluster.
 
 If you have any trouble, ask on our
-[Mailing List](http://mail-archives.apache.org/mod_mbox/flink-user/).
+[Mailing List](https://mail-archives.apache.org/mod_mbox/flink-user/).
 We are happy to provide help.
 
 {% top %}

--- a/docs/dev/projectsetup/java_api_quickstart.zh.md
+++ b/docs/dev/projectsetup/java_api_quickstart.zh.md
@@ -74,7 +74,7 @@ Use one of the following commands to __create a project__:
     </div>
     {% unless site.is_stable %}
     <p style="border-radius: 5px; padding: 5px" class="bg-danger">
-        <b>Note</b>: For Maven 3.0 or higher, it is no longer possible to specify the repository (-DarchetypeCatalog) via the command line. If you wish to use the snapshot repository, you need to add a repository entry to your settings.xml. For details about this change, please refer to <a href="http://maven.apache.org/archetype/maven-archetype-plugin/archetype-repository.html">Maven official document</a>
+        <b>Note</b>: For Maven 3.0 or higher, it is no longer possible to specify the repository (-DarchetypeCatalog) via the command line. If you wish to use the snapshot repository, you need to add a repository entry to your settings.xml. For details about this change, please refer to <a href="https://maven.apache.org/archetype/maven-archetype-plugin/archetype-repository.html">Maven official document</a>
     </p>
     {% endunless %}
 </div>
@@ -106,8 +106,8 @@ The _main_ method is the entry point of the program, both for in-IDE testing/exe
 
 We recommend you __import this project into your IDE__ to develop and
 test it. IntelliJ IDEA supports Maven projects out of the box.
-If you use Eclipse, the [m2e plugin](http://www.eclipse.org/m2e/)
-allows to [import Maven projects](http://books.sonatype.com/m2eclipse-book/reference/creating-sect-importing-projects.html#fig-creating-import).
+If you use Eclipse, the [m2e plugin](https://www.eclipse.org/m2e/)
+allows to [import Maven projects](https://books.sonatype.com/m2eclipse-book/reference/creating-sect-importing-projects.html#fig-creating-import).
 Some Eclipse bundles include that plugin by default, others require you
 to install it manually. 
 
@@ -348,7 +348,7 @@ For a complete overview over the APIs, have a look at the
 [Here]({{ site.baseurl }}/tutorials/local_setup.html) you can find out how to run an application outside the IDE on a local cluster.
 
 If you have any trouble, ask on our
-[Mailing List](http://mail-archives.apache.org/mod_mbox/flink-user/).
+[Mailing List](https://mail-archives.apache.org/mod_mbox/flink-user/).
 We are happy to provide help.
 
 {% top %}

--- a/docs/dev/projectsetup/scala_api_quickstart.md
+++ b/docs/dev/projectsetup/scala_api_quickstart.md
@@ -54,7 +54,7 @@ You can scaffold a new project via either of the following two methods:
     $ sbt new tillrohrmann/flink-project.g8
     {% endhighlight %}
     This will prompt you for a couple of parameters (project name, flink version...) and then create a Flink project from the <a href="https://github.com/tillrohrmann/flink-project.g8">flink-project template</a>.
-    You need sbt >= 0.13.13 to execute this command. You can follow this <a href="http://www.scala-sbt.org/download.html">installation guide</a> to obtain it if necessary.
+    You need sbt >= 0.13.13 to execute this command. You can follow this <a href="https://www.scala-sbt.org/download.html">installation guide</a> to obtain it if necessary.
     </div>
     <div class="tab-pane" id="quickstart-script-sbt">
     {% highlight bash %}
@@ -148,7 +148,7 @@ Use one of the following commands to __create a project__:
     </div>
     {% unless site.is_stable %}
     <p style="border-radius: 5px; padding: 5px" class="bg-danger">
-        <b>Note</b>: For Maven 3.0 or higher, it is no longer possible to specify the repository (-DarchetypeCatalog) via the commandline. If you wish to use the snapshot repository, you need to add a repository entry to your settings.xml. For details about this change, please refer to <a href="http://maven.apache.org/archetype/maven-archetype-plugin/archetype-repository.html">Maven official document</a>
+        <b>Note</b>: For Maven 3.0 or higher, it is no longer possible to specify the repository (-DarchetypeCatalog) via the commandline. If you wish to use the snapshot repository, you need to add a repository entry to your settings.xml. For details about this change, please refer to <a href="https://maven.apache.org/archetype/maven-archetype-plugin/archetype-repository.html">Maven official document</a>
     </p>
     {% endunless %}
 </div>
@@ -187,12 +187,12 @@ From our experience, IntelliJ provides the best experience for developing Flink 
 For Eclipse, you need the following plugins, which you can install from the provided Eclipse Update Sites:
 
 * _Eclipse 4.x_
-  * [Scala IDE](http://download.scala-ide.org/sdk/lithium/e44/scala211/stable/site)
-  * [m2eclipse-scala](http://alchim31.free.fr/m2e-scala/update-site)
+  * [Scala IDE](https://download.scala-ide.org/sdk/lithium/e44/scala211/stable/site)
+  * [m2eclipse-scala](https://alchim31.free.fr/m2e-scala/update-site)
   * [Build Helper Maven Plugin](https://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-buildhelper/0.15.0/N/0.15.0.201207090124/)
 * _Eclipse 3.8_
-  * [Scala IDE for Scala 2.11](http://download.scala-ide.org/sdk/helium/e38/scala211/stable/site) or [Scala IDE for Scala 2.10](http://download.scala-ide.org/sdk/helium/e38/scala210/stable/site)
-  * [m2eclipse-scala](http://alchim31.free.fr/m2e-scala/update-site)
+  * [Scala IDE for Scala 2.11](https://download.scala-ide.org/sdk/helium/e38/scala211/stable/site) or [Scala IDE for Scala 2.10](https://download.scala-ide.org/sdk/helium/e38/scala210/stable/site)
+  * [m2eclipse-scala](https://alchim31.free.fr/m2e-scala/update-site)
   * [Build Helper Maven Plugin](https://repository.sonatype.org/content/repositories/forge-sites/m2e-extras/0.14.0/N/0.14.0.201109282148/)
 
 ### Build Project
@@ -224,7 +224,7 @@ For a complete overview over the APIa, have a look at the
 [Here]({{ site.baseurl }}/tutorials/local_setup.html) you can find out how to run an application outside the IDE on a local cluster.
 
 If you have any trouble, ask on our
-[Mailing List](http://mail-archives.apache.org/mod_mbox/flink-user/).
+[Mailing List](https://mail-archives.apache.org/mod_mbox/flink-user/).
 We are happy to provide help.
 
 {% top %}

--- a/docs/dev/projectsetup/scala_api_quickstart.zh.md
+++ b/docs/dev/projectsetup/scala_api_quickstart.zh.md
@@ -54,7 +54,7 @@ under the License.
     $ sbt new tillrohrmann/flink-project.g8
     {% endhighlight %}
     这里将提示你输入几个参数 (项目名称，Flink版本...) 然后从 <a href="https://github.com/tillrohrmann/flink-project.g8">Flink项目模版</a>创建一个Flink项目。
-    你的sbt版本需要不小于0.13.13才能执行这个命令。如有必要，你可以参考这个<a href="http://www.scala-sbt.org/download.html">安装指南</a>获取合适版本的sbt。
+    你的sbt版本需要不小于0.13.13才能执行这个命令。如有必要，你可以参考这个<a href="https://www.scala-sbt.org/download.html">安装指南</a>获取合适版本的sbt。
     </div>
     <div class="tab-pane" id="quickstart-script-sbt">
     {% highlight bash %}
@@ -146,7 +146,7 @@ addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "4.0.0")
     </div>
     {% unless site.is_stable %}
     <p style="border-radius: 5px; padding: 5px" class="bg-danger">
-        <b>注意</b>: 对于 Maven 3.0 及更高版本, 不再能够通过命令行指定仓库 (-DarchetypeCatalog). 如果你想使用快照仓库，需要在 settings.xml 文件中添加仓库条目。有关该设置的详细信息，请参阅 <a href="http://maven.apache.org/archetype/maven-archetype-plugin/archetype-repository.html">Maven 官方文档</a>
+        <b>注意</b>: 对于 Maven 3.0 及更高版本, 不再能够通过命令行指定仓库 (-DarchetypeCatalog). 如果你想使用快照仓库，需要在 settings.xml 文件中添加仓库条目。有关该设置的详细信息，请参阅 <a href="https://maven.apache.org/archetype/maven-archetype-plugin/archetype-repository.html">Maven 官方文档</a>
     </p>
     {% endunless %}
 </div>
@@ -183,12 +183,12 @@ IntelliJ IDEA 支持 Maven 开箱即用，并为Scala开发提供插件。
 对于 Eclipse，需要以下的插件，你可以从提供的 Eclipse Update Sites 安装这些插件：
 
 * _Eclipse 4.x_
-  * [Scala IDE](http://download.scala-ide.org/sdk/lithium/e44/scala211/stable/site)
-  * [m2eclipse-scala](http://alchim31.free.fr/m2e-scala/update-site)
+  * [Scala IDE](https://download.scala-ide.org/sdk/lithium/e44/scala211/stable/site)
+  * [m2eclipse-scala](https://alchim31.free.fr/m2e-scala/update-site)
   * [Build Helper Maven Plugin](https://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-buildhelper/0.15.0/N/0.15.0.201207090124/)
 * _Eclipse 3.8_
-  * [Scala IDE for Scala 2.11](http://download.scala-ide.org/sdk/helium/e38/scala211/stable/site) 或者 [Scala IDE for Scala 2.10](http://download.scala-ide.org/sdk/helium/e38/scala210/stable/site)
-  * [m2eclipse-scala](http://alchim31.free.fr/m2e-scala/update-site)
+  * [Scala IDE for Scala 2.11](https://download.scala-ide.org/sdk/helium/e38/scala211/stable/site) 或者 [Scala IDE for Scala 2.10](https://download.scala-ide.org/sdk/helium/e38/scala210/stable/site)
+  * [m2eclipse-scala](https://alchim31.free.fr/m2e-scala/update-site)
   * [Build Helper Maven Plugin](https://repository.sonatype.org/content/repositories/forge-sites/m2e-extras/0.14.0/N/0.14.0.201109282148/)
 
 ### 构建
@@ -215,7 +215,7 @@ __注意:__ 如果你使用其他类而不是 *StreamingJob* 作为应用程序�
 
 在[这里]({{ site.baseurl }}/zh/tutorials/local_setup.html)，你可以找到如何在IDE外的本地集群中运行应用程序。
 
-如果你有任何问题，请发信至我们的[邮箱列表](http://mail-archives.apache.org/mod_mbox/flink-user/)。
+如果你有任何问题，请发信至我们的[邮箱列表](https://mail-archives.apache.org/mod_mbox/flink-user/)。
 我们很乐意提供帮助。
 
 {% top %}

--- a/docs/dev/stream/python.md
+++ b/docs/dev/stream/python.md
@@ -46,7 +46,7 @@ operations and advanced features.
 
 Jython Framework
 ---------------
-Flink Python streaming API uses Jython framework (see <http://www.jython.org/archive/21/docs/whatis.html>)
+Flink Python streaming API uses Jython framework (see <https://www.jython.org/archive/21/docs/whatis.html>)
 to drive the execution of a given script. The Python streaming layer, is actually a thin wrapper layer for the
 existing Java streaming APIs.
 

--- a/docs/dev/stream/python.zh.md
+++ b/docs/dev/stream/python.zh.md
@@ -46,7 +46,7 @@ operations and advanced features.
 
 Jython Framework
 ---------------
-Flink Python streaming API uses Jython framework (see <http://www.jython.org/archive/21/docs/whatis.html>)
+Flink Python streaming API uses Jython framework (see <https://www.jython.org/archive/21/docs/whatis.html>)
 to drive the execution of a given script. The Python streaming layer, is actually a thin wrapper layer for the
 existing Java streaming APIs.
 

--- a/docs/dev/stream/state/schema_evolution.md
+++ b/docs/dev/stream/state/schema_evolution.md
@@ -101,7 +101,7 @@ newer than 1.8.0. When restoring with Flink versions older than 1.8.0, the schem
 ### Avro types
 
 Flink fully supports evolving schema of Avro type state, as long as the schema change is considered compatible by
-[Avro's rules for schema resolution](http://avro.apache.org/docs/current/spec.html#Schema+Resolution).
+[Avro's rules for schema resolution](https://avro.apache.org/docs/current/spec.html#Schema+Resolution).
 
 One limitation is that Avro generated classes used as the state type cannot be relocated or have different
 namespaces when the job is restored.

--- a/docs/dev/stream/state/schema_evolution.zh.md
+++ b/docs/dev/stream/state/schema_evolution.zh.md
@@ -91,7 +91,7 @@ Flink 基于下面的规则来支持 [POJO 类型]({{ site.baseurl }}/zh/dev/typ
 ### Avro 类型
 
 Flink 完全支持 Avro 状态类型的升级，只要数据结构的修改是被
-[Avro 的数据结构解析规则](http://avro.apache.org/docs/current/spec.html#Schema+Resolution)认为兼容的即可。
+[Avro 的数据结构解析规则](https://avro.apache.org/docs/current/spec.html#Schema+Resolution)认为兼容的即可。
 
 一个例外是如果新的 Avro 数据 schema 生成的类无法被重定位或者使用了不同的命名空间，在作业恢复时状态数据会被认为是不兼容的。
 

--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -43,21 +43,21 @@ The following tables list all available connectors and formats. Their mutual com
 | Name              | Version             | Maven dependency             | SQL Client JAR         |
 | :---------------- | :------------------ | :--------------------------- | :----------------------|
 | Filesystem        |                     | Built-in                     | Built-in               |
-| Elasticsearch     | 6                   | `flink-connector-elasticsearch6` | [Download](http://central.maven.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch6{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-elasticsearch6{{site.scala_version_suffix}}-{{site.version}}.jar) |
+| Elasticsearch     | 6                   | `flink-connector-elasticsearch6` | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch6{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-elasticsearch6{{site.scala_version_suffix}}-{{site.version}}.jar) |
 | Apache Kafka      | 0.8                 | `flink-connector-kafka-0.8`  | Not available          |
-| Apache Kafka      | 0.9                 | `flink-connector-kafka-0.9`  | [Download](http://central.maven.org/maven2/org/apache/flink/flink-sql-connector-kafka-0.9{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-kafka-0.9{{site.scala_version_suffix}}-{{site.version}}.jar) |
-| Apache Kafka      | 0.10                | `flink-connector-kafka-0.10` | [Download](http://central.maven.org/maven2/org/apache/flink/flink-sql-connector-kafka-0.10{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-kafka-0.10{{site.scala_version_suffix}}-{{site.version}}.jar) |
-| Apache Kafka      | 0.11                | `flink-connector-kafka-0.11` | [Download](http://central.maven.org/maven2/org/apache/flink/flink-sql-connector-kafka-0.11{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-kafka-0.11{{site.scala_version_suffix}}-{{site.version}}.jar) |
-| Apache Kafka      | 0.11+ (`universal`) | `flink-connector-kafka`      | [Download](http://central.maven.org/maven2/org/apache/flink/flink-sql-connector-kafka{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-kafka{{site.scala_version_suffix}}-{{site.version}}.jar) |
+| Apache Kafka      | 0.9                 | `flink-connector-kafka-0.9`  | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka-0.9{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-kafka-0.9{{site.scala_version_suffix}}-{{site.version}}.jar) |
+| Apache Kafka      | 0.10                | `flink-connector-kafka-0.10` | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka-0.10{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-kafka-0.10{{site.scala_version_suffix}}-{{site.version}}.jar) |
+| Apache Kafka      | 0.11                | `flink-connector-kafka-0.11` | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka-0.11{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-kafka-0.11{{site.scala_version_suffix}}-{{site.version}}.jar) |
+| Apache Kafka      | 0.11+ (`universal`) | `flink-connector-kafka`      | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-kafka{{site.scala_version_suffix}}-{{site.version}}.jar) |
 
 ### Formats
 
 | Name                       | Maven dependency             | SQL Client JAR         |
 | :------------------------- | :--------------------------- | :--------------------- |
 | Old CSV (for files)        | Built-in                     | Built-in               |
-| CSV (for Kafka)            | `flink-csv`                  | [Download](http://central.maven.org/maven2/org/apache/flink/flink-csv/{{site.version}}/flink-csv-{{site.version}}-sql-jar.jar) |
-| JSON                       | `flink-json`                 | [Download](http://central.maven.org/maven2/org/apache/flink/flink-json/{{site.version}}/flink-json-{{site.version}}-sql-jar.jar) |
-| Apache Avro                | `flink-avro`                 | [Download](http://central.maven.org/maven2/org/apache/flink/flink-avro/{{site.version}}/flink-avro-{{site.version}}-sql-jar.jar) |
+| CSV (for Kafka)            | `flink-csv`                  | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/{{site.version}}/flink-csv-{{site.version}}-sql-jar.jar) |
+| JSON                       | `flink-json`                 | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/{{site.version}}/flink-json-{{site.version}}-sql-jar.jar) |
+| Apache Avro                | `flink-avro`                 | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/{{site.version}}/flink-avro-{{site.version}}-sql-jar.jar) |
 
 {% else %}
 
@@ -75,13 +75,13 @@ Beginning from Flink 1.6, the declaration of a connection to an external system 
 Connections can be specified either
 
 - **programmatically** using a `Descriptor` under `org.apache.flink.table.descriptors` for Table & SQL API
-- or **declaratively** via [YAML configuration files](http://yaml.org/) for the SQL Client.
+- or **declaratively** via [YAML configuration files](https://yaml.org/) for the SQL Client.
 
 This allows not only for better unification of APIs and SQL Client but also for better extensibility in case of [custom implementations](sourceSinks.html) without changing the actual declaration.
 
 Every declaration is similar to a SQL `CREATE TABLE` statement. One can define the name of the table, the schema of the table, a connector, and a data format upfront for connecting to an external system.
 
-The **connector** describes the external system that stores the data of a table. Storage systems such as [Apacha Kafka](http://kafka.apache.org/) or a regular file system can be declared here. The connector might already provide a fixed format with fields and schema.
+The **connector** describes the external system that stores the data of a table. Storage systems such as [Apacha Kafka](https://kafka.apache.org/) or a regular file system can be declared here. The connector might already provide a fixed format with fields and schema.
 
 Some systems support different **data formats**. For example, a table that is stored in Kafka or in files can encode its rows with CSV, JSON, or Avro. A database connector might need the table schema here. Whether or not a storage system requires the definition of a format, is documented for every [connector](connect.html#table-connectors). Different systems also require different [types of formats](connect.html#table-formats) (e.g., column-oriented formats vs. row-oriented formats). The documentation states which format types and connectors are compatible.
 
@@ -918,7 +918,7 @@ The following table shows the mapping of JSON schema types to Flink SQL types:
 | `string` with `encoding: base64`  | `ARRAY[TINYINT]`        |
 | `null`                            | `NULL` (unsupported yet)|
 
-Currently, Flink supports only a subset of the [JSON schema specification](http://json-schema.org/) `draft-07`. Union types (as well as `allOf`, `anyOf`, `not`) are not supported yet. `oneOf` and arrays of types are only supported for specifying nullability.
+Currently, Flink supports only a subset of the [JSON schema specification](https://json-schema.org/) `draft-07`. Union types (as well as `allOf`, `anyOf`, `not`) are not supported yet. `oneOf` and arrays of types are only supported for specifying nullability.
 
 Simple references that link to a common definition in the document are supported as shown in the more complex example below:
 
@@ -1052,7 +1052,7 @@ Avro types are mapped to the corresponding SQL data types. Union types are only 
 | `fixed` with `logicalType: decimal`         | `DECIMAL`               |
 | `null`                                      | `NULL` (unsupported yet)|
 
-Avro uses [Joda-Time](http://www.joda.org/joda-time/) for representing logical date and time types in specific record classes. The Joda-Time dependency is not part of Flink's distribution. Therefore, make sure that Joda-Time is in your classpath together with your specific record class during runtime. Avro formats specified via a schema string do not require Joda-Time to be present.
+Avro uses [Joda-Time](https://www.joda.org/joda-time/) for representing logical date and time types in specific record classes. The Joda-Time dependency is not part of Flink's distribution. Therefore, make sure that Joda-Time is in your classpath together with your specific record class during runtime. Avro formats specified via a schema string do not require Joda-Time to be present.
 
 Make sure to add the Apache Avro dependency.
 

--- a/docs/dev/table/connect.zh.md
+++ b/docs/dev/table/connect.zh.md
@@ -43,21 +43,21 @@ The following tables list all available connectors and formats. Their mutual com
 | Name              | Version             | Maven dependency             | SQL Client JAR         |
 | :---------------- | :------------------ | :--------------------------- | :----------------------|
 | Filesystem        |                     | Built-in                     | Built-in               |
-| Elasticsearch     | 6                   | `flink-connector-elasticsearch6` | [Download](http://central.maven.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch6{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-elasticsearch6{{site.scala_version_suffix}}-{{site.version}}.jar) |
+| Elasticsearch     | 6                   | `flink-connector-elasticsearch6` | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch6{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-elasticsearch6{{site.scala_version_suffix}}-{{site.version}}.jar) |
 | Apache Kafka      | 0.8                 | `flink-connector-kafka-0.8`  | Not available          |
-| Apache Kafka      | 0.9                 | `flink-connector-kafka-0.9`  | [Download](http://central.maven.org/maven2/org/apache/flink/flink-sql-connector-kafka-0.9{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-kafka-0.9{{site.scala_version_suffix}}-{{site.version}}.jar) |
-| Apache Kafka      | 0.10                | `flink-connector-kafka-0.10` | [Download](http://central.maven.org/maven2/org/apache/flink/flink-sql-connector-kafka-0.10{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-kafka-0.10{{site.scala_version_suffix}}-{{site.version}}.jar) |
-| Apache Kafka      | 0.11                | `flink-connector-kafka-0.11` | [Download](http://central.maven.org/maven2/org/apache/flink/flink-sql-connector-kafka-0.11{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-kafka-0.11{{site.scala_version_suffix}}-{{site.version}}.jar) |
-| Apache Kafka      | 0.11+ (`universal`) | `flink-connector-kafka`      | [Download](http://central.maven.org/maven2/org/apache/flink/flink-sql-connector-kafka{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-kafka{{site.scala_version_suffix}}-{{site.version}}.jar) |
+| Apache Kafka      | 0.9                 | `flink-connector-kafka-0.9`  | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka-0.9{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-kafka-0.9{{site.scala_version_suffix}}-{{site.version}}.jar) |
+| Apache Kafka      | 0.10                | `flink-connector-kafka-0.10` | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka-0.10{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-kafka-0.10{{site.scala_version_suffix}}-{{site.version}}.jar) |
+| Apache Kafka      | 0.11                | `flink-connector-kafka-0.11` | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka-0.11{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-kafka-0.11{{site.scala_version_suffix}}-{{site.version}}.jar) |
+| Apache Kafka      | 0.11+ (`universal`) | `flink-connector-kafka`      | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-kafka{{site.scala_version_suffix}}-{{site.version}}.jar) |
 
 ### Formats
 
 | Name                       | Maven dependency             | SQL Client JAR         |
 | :------------------------- | :--------------------------- | :--------------------- |
 | Old CSV (for files)        | Built-in                     | Built-in               |
-| CSV (for Kafka)            | `flink-csv`                  | [Download](http://central.maven.org/maven2/org/apache/flink/flink-csv/{{site.version}}/flink-csv-{{site.version}}-sql-jar.jar) |
-| JSON                       | `flink-json`                 | [Download](http://central.maven.org/maven2/org/apache/flink/flink-json/{{site.version}}/flink-json-{{site.version}}-sql-jar.jar) |
-| Apache Avro                | `flink-avro`                 | [Download](http://central.maven.org/maven2/org/apache/flink/flink-avro/{{site.version}}/flink-avro-{{site.version}}-sql-jar.jar) |
+| CSV (for Kafka)            | `flink-csv`                  | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/{{site.version}}/flink-csv-{{site.version}}-sql-jar.jar) |
+| JSON                       | `flink-json`                 | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/{{site.version}}/flink-json-{{site.version}}-sql-jar.jar) |
+| Apache Avro                | `flink-avro`                 | [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/{{site.version}}/flink-avro-{{site.version}}-sql-jar.jar) |
 
 {% else %}
 
@@ -75,13 +75,13 @@ Beginning from Flink 1.6, the declaration of a connection to an external system 
 Connections can be specified either
 
 - **programmatically** using a `Descriptor` under `org.apache.flink.table.descriptors` for Table & SQL API
-- or **declaratively** via [YAML configuration files](http://yaml.org/) for the SQL Client.
+- or **declaratively** via [YAML configuration files](https://yaml.org/) for the SQL Client.
 
 This allows not only for better unification of APIs and SQL Client but also for better extensibility in case of [custom implementations](sourceSinks.html) without changing the actual declaration.
 
 Every declaration is similar to a SQL `CREATE TABLE` statement. One can define the name of the table, the schema of the table, a connector, and a data format upfront for connecting to an external system.
 
-The **connector** describes the external system that stores the data of a table. Storage systems such as [Apacha Kafka](http://kafka.apache.org/) or a regular file system can be declared here. The connector might already provide a fixed format with fields and schema.
+The **connector** describes the external system that stores the data of a table. Storage systems such as [Apacha Kafka](https://kafka.apache.org/) or a regular file system can be declared here. The connector might already provide a fixed format with fields and schema.
 
 Some systems support different **data formats**. For example, a table that is stored in Kafka or in files can encode its rows with CSV, JSON, or Avro. A database connector might need the table schema here. Whether or not a storage system requires the definition of a format, is documented for every [connector](connect.html#table-connectors). Different systems also require different [types of formats](connect.html#table-formats) (e.g., column-oriented formats vs. row-oriented formats). The documentation states which format types and connectors are compatible.
 
@@ -918,7 +918,7 @@ The following table shows the mapping of JSON schema types to Flink SQL types:
 | `string` with `encoding: base64`  | `ARRAY[TINYINT]`        |
 | `null`                            | `NULL` (unsupported yet)|
 
-Currently, Flink supports only a subset of the [JSON schema specification](http://json-schema.org/) `draft-07`. Union types (as well as `allOf`, `anyOf`, `not`) are not supported yet. `oneOf` and arrays of types are only supported for specifying nullability.
+Currently, Flink supports only a subset of the [JSON schema specification](https://json-schema.org/) `draft-07`. Union types (as well as `allOf`, `anyOf`, `not`) are not supported yet. `oneOf` and arrays of types are only supported for specifying nullability.
 
 Simple references that link to a common definition in the document are supported as shown in the more complex example below:
 
@@ -1052,7 +1052,7 @@ Avro types are mapped to the corresponding SQL data types. Union types are only 
 | `fixed` with `logicalType: decimal`         | `DECIMAL`               |
 | `null`                                      | `NULL` (unsupported yet)|
 
-Avro uses [Joda-Time](http://www.joda.org/joda-time/) for representing logical date and time types in specific record classes. The Joda-Time dependency is not part of Flink's distribution. Therefore, make sure that Joda-Time is in your classpath together with your specific record class during runtime. Avro formats specified via a schema string do not require Joda-Time to be present.
+Avro uses [Joda-Time](https://www.joda.org/joda-time/) for representing logical date and time types in specific record classes. The Joda-Time dependency is not part of Flink's distribution. Therefore, make sure that Joda-Time is in your classpath together with your specific record class during runtime. Avro formats specified via a schema string do not require Joda-Time to be present.
 
 Make sure to add the Apache Avro dependency.
 

--- a/docs/dev/table/sqlClient.md
+++ b/docs/dev/table/sqlClient.md
@@ -159,7 +159,7 @@ Mode "embedded" submits Flink jobs from the local machine.
 
 A SQL query needs a configuration environment in which it is executed. The so-called *environment files* define available table sources and sinks, external catalogs, user-defined functions, and other properties required for execution and deployment.
 
-Every environment file is a regular [YAML file](http://yaml.org/). An example of such a file is presented below.
+Every environment file is a regular [YAML file](https://yaml.org/). An example of such a file is presented below.
 
 {% highlight yaml %}
 # Define tables here such as sources, sinks, views, or temporal tables.

--- a/docs/dev/table/sqlClient.zh.md
+++ b/docs/dev/table/sqlClient.zh.md
@@ -159,7 +159,7 @@ Mode "embedded" submits Flink jobs from the local machine.
 
 A SQL query needs a configuration environment in which it is executed. The so-called *environment files* define available table sources and sinks, external catalogs, user-defined functions, and other properties required for execution and deployment.
 
-Every environment file is a regular [YAML file](http://yaml.org/). An example of such a file is presented below.
+Every environment file is a regular [YAML file](https://yaml.org/). An example of such a file is presented below.
 
 {% highlight yaml %}
 # Define tables here such as sources, sinks, views, or temporal tables.

--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -69,7 +69,7 @@ result.print();
 
 The Scala Table API is enabled by importing `org.apache.flink.api.scala._` and `org.apache.flink.table.api.scala._`.
 
-The following example shows how a Scala Table API program is constructed. Table attributes are referenced using [Scala Symbols](http://scala-lang.org/files/archive/spec/2.12/01-lexical-syntax.html#symbol-literals), which start with an apostrophe character (`'`).
+The following example shows how a Scala Table API program is constructed. Table attributes are referenced using [Scala Symbols](https://scala-lang.org/files/archive/spec/2.12/01-lexical-syntax.html#symbol-literals), which start with an apostrophe character (`'`).
 
 {% highlight scala %}
 import org.apache.flink.api.scala._

--- a/docs/dev/table/tableApi.zh.md
+++ b/docs/dev/table/tableApi.zh.md
@@ -69,7 +69,7 @@ result.print();
 
 The Scala Table API is enabled by importing `org.apache.flink.api.scala._` and `org.apache.flink.table.api.scala._`.
 
-The following example shows how a Scala Table API program is constructed. Table attributes are referenced using [Scala Symbols](http://scala-lang.org/files/archive/spec/2.12/01-lexical-syntax.html#symbol-literals), which start with an apostrophe character (`'`).
+The following example shows how a Scala Table API program is constructed. Table attributes are referenced using [Scala Symbols](https://scala-lang.org/files/archive/spec/2.12/01-lexical-syntax.html#symbol-literals), which start with an apostrophe character (`'`).
 
 {% highlight scala %}
 import org.apache.flink.api.scala._

--- a/docs/flinkDev/building.md
+++ b/docs/flinkDev/building.md
@@ -48,7 +48,7 @@ The simplest way of building Flink is by running:
 mvn clean install -DskipTests
 {% endhighlight %}
 
-This instructs [Maven](http://maven.apache.org) (`mvn`) to first remove all existing builds (`clean`) and then create a new Flink binary (`install`).
+This instructs [Maven](https://maven.apache.org) (`mvn`) to first remove all existing builds (`clean`) and then create a new Flink binary (`install`).
 
 To speed up the build you can skip tests, QA plugins, and JavaDocs:
 
@@ -84,7 +84,7 @@ mvn clean install
 
 {% info %} Most users do not need to do this manually. The [download page]({{ site.download_url }}) contains binary packages for common Hadoop versions.
 
-Flink has dependencies to HDFS and YARN which are both dependencies from [Apache Hadoop](http://hadoop.apache.org). There exist many different versions of Hadoop (from both the upstream project and the different Hadoop distributions). If you are using a wrong combination of versions, exceptions can occur.
+Flink has dependencies to HDFS and YARN which are both dependencies from [Apache Hadoop](https://hadoop.apache.org). There exist many different versions of Hadoop (from both the upstream project and the different Hadoop distributions). If you are using a wrong combination of versions, exceptions can occur.
 
 Hadoop is only supported from version 2.4.0 upwards.
 You can also specify a specific Hadoop version to build against:
@@ -109,7 +109,7 @@ To build Flink against a vendor specific Hadoop version, issue the following com
 mvn clean install -DskipTests -Pvendor-repos -Dhadoop.version=2.6.0-cdh5.16.1
 {% endhighlight %}
 
-The `-Pvendor-repos` activates a Maven [build profile](http://maven.apache.org/guides/introduction/introduction-to-profiles.html) that includes the repositories of popular Hadoop vendors such as Cloudera, Hortonworks, or MapR.
+The `-Pvendor-repos` activates a Maven [build profile](https://maven.apache.org/guides/introduction/introduction-to-profiles.html) that includes the repositories of popular Hadoop vendors such as Cloudera, Hortonworks, or MapR.
 
 {% top %}
 
@@ -117,7 +117,7 @@ The `-Pvendor-repos` activates a Maven [build profile](http://maven.apache.org/g
 
 {% info %} Users that purely use the Java APIs and libraries can *ignore* this section.
 
-Flink has APIs, libraries, and runtime modules written in [Scala](http://scala-lang.org). Users of the Scala API and libraries may have to match the Scala version of Flink with the Scala version of their projects (because Scala is not strictly backwards compatible).
+Flink has APIs, libraries, and runtime modules written in [Scala](https://scala-lang.org). Users of the Scala API and libraries may have to match the Scala version of Flink with the Scala version of their projects (because Scala is not strictly backwards compatible).
 
 Since version 1.7 Flink builds with Scala version 2.11 (default) and 2.12.
 

--- a/docs/flinkDev/building.zh.md
+++ b/docs/flinkDev/building.zh.md
@@ -48,7 +48,7 @@ The simplest way of building Flink is by running:
 mvn clean install -DskipTests
 {% endhighlight %}
 
-This instructs [Maven](http://maven.apache.org) (`mvn`) to first remove all existing builds (`clean`) and then create a new Flink binary (`install`).
+This instructs [Maven](https://maven.apache.org) (`mvn`) to first remove all existing builds (`clean`) and then create a new Flink binary (`install`).
 
 To speed up the build you can skip tests, QA plugins, and JavaDocs:
 
@@ -84,7 +84,7 @@ mvn clean install
 
 {% info %} Most users do not need to do this manually. The [download page]({{ site.download_url }}) contains binary packages for common Hadoop versions.
 
-Flink has dependencies to HDFS and YARN which are both dependencies from [Apache Hadoop](http://hadoop.apache.org). There exist many different versions of Hadoop (from both the upstream project and the different Hadoop distributions). If you are using a wrong combination of versions, exceptions can occur.
+Flink has dependencies to HDFS and YARN which are both dependencies from [Apache Hadoop](https://hadoop.apache.org). There exist many different versions of Hadoop (from both the upstream project and the different Hadoop distributions). If you are using a wrong combination of versions, exceptions can occur.
 
 Hadoop is only supported from version 2.4.0 upwards.
 You can also specify a specific Hadoop version to build against:
@@ -109,7 +109,7 @@ To build Flink against a vendor specific Hadoop version, issue the following com
 mvn clean install -DskipTests -Pvendor-repos -Dhadoop.version=2.6.0-cdh5.16.1
 {% endhighlight %}
 
-The `-Pvendor-repos` activates a Maven [build profile](http://maven.apache.org/guides/introduction/introduction-to-profiles.html) that includes the repositories of popular Hadoop vendors such as Cloudera, Hortonworks, or MapR.
+The `-Pvendor-repos` activates a Maven [build profile](https://maven.apache.org/guides/introduction/introduction-to-profiles.html) that includes the repositories of popular Hadoop vendors such as Cloudera, Hortonworks, or MapR.
 
 {% top %}
 
@@ -117,7 +117,7 @@ The `-Pvendor-repos` activates a Maven [build profile](http://maven.apache.org/g
 
 {% info %} Users that purely use the Java APIs and libraries can *ignore* this section.
 
-Flink has APIs, libraries, and runtime modules written in [Scala](http://scala-lang.org). Users of the Scala API and libraries may have to match the Scala version of Flink with the Scala version of their projects (because Scala is not strictly backwards compatible).
+Flink has APIs, libraries, and runtime modules written in [Scala](https://scala-lang.org). Users of the Scala API and libraries may have to match the Scala version of Flink with the Scala version of their projects (because Scala is not strictly backwards compatible).
 
 Since version 1.7 Flink builds with Scala version 2.11 (default) and 2.12.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ Release notes cover important changes between Flink versions. Please carefully r
 
 ## External Resources
 
-- **Flink Forward**: Talks from past conferences are available at the [Flink Forward](http://flink-forward.org/) website and on [YouTube](https://www.youtube.com/channel/UCY8_lgiZLZErZPF47a2hXMA). [Robust Stream Processing with Apache Flink](http://2016.flink-forward.org/kb_sessions/robust-stream-processing-with-apache-flink/) is a good place to start.
+- **Flink Forward**: Talks from past conferences are available at the [Flink Forward](https://flink-forward.org/) website and on [YouTube](https://www.youtube.com/channel/UCY8_lgiZLZErZPF47a2hXMA). [Robust Stream Processing with Apache Flink](https://2016.flink-forward.org/kb_sessions/robust-stream-processing-with-apache-flink/) is a good place to start.
 
 - **Training**: The [training materials](https://training.ververica.com/) from data Artisans include slides, exercises, and sample solutions.
 

--- a/docs/index.zh.md
+++ b/docs/index.zh.md
@@ -51,7 +51,7 @@ Apache Flink 是一个分布式流批一体化的开源平台。Flink 的核心�
 
 ## 外部资源
 
-- **Flink Forward**: 已举办的所有大会演讲均可在 [Flink Forward](http://flink-forward.org/) 官网以及 [YouTube](https://www.youtube.com/channel/UCY8_lgiZLZErZPF47a2hXMA)找到。[使用 Apache Flink 进行高可靠的流处理](http://2016.flink-forward.org/kb_sessions/robust-stream-processing-with-apache-flink/) 可以作为你第一个学习的资源。
+- **Flink Forward**: 已举办的所有大会演讲均可在 [Flink Forward](https://flink-forward.org/) 官网以及 [YouTube](https://www.youtube.com/channel/UCY8_lgiZLZErZPF47a2hXMA)找到。[使用 Apache Flink 进行高可靠的流处理](https://2016.flink-forward.org/kb_sessions/robust-stream-processing-with-apache-flink/) 可以作为你第一个学习的资源。
 
 - **培训**: [培训资料](https://training.ververica.com/) 包含讲义，练习以及示例程序。
 

--- a/docs/internals/stream_checkpointing.md
+++ b/docs/internals/stream_checkpointing.md
@@ -48,7 +48,7 @@ have been part of the previously checkpointed state.
 *Note:* By default, checkpointing is disabled. See [Checkpointing]({{ site.baseurl }}/dev/stream/state/checkpointing.html) for details on how to enable and configure checkpointing.
 
 *Note:* For this mechanism to realize its full guarantees, the data stream source (such as message queue or broker) needs to be able
-to rewind the stream to a defined recent point. [Apache Kafka](http://kafka.apache.org) has this ability and Flink's connector to
+to rewind the stream to a defined recent point. [Apache Kafka](https://kafka.apache.org) has this ability and Flink's connector to
 Kafka exploits this ability. See [Fault Tolerance Guarantees of Data Sources and Sinks]({{ site.baseurl }}/dev/connectors/guarantees.html) for
 more information about the guarantees provided by Flink's connectors.
 
@@ -59,8 +59,8 @@ more information about the guarantees provided by Flink's connectors.
 
 The central part of Flink's fault tolerance mechanism is drawing consistent snapshots of the distributed data stream and operator state.
 These snapshots act as consistent checkpoints to which the system can fall back in case of a failure. Flink's mechanism for drawing these
-snapshots is described in "[Lightweight Asynchronous Snapshots for Distributed Dataflows](http://arxiv.org/abs/1506.08603)". It is inspired by
-the standard [Chandy-Lamport algorithm](http://research.microsoft.com/en-us/um/people/lamport/pubs/chandy.pdf) for distributed snapshots and is
+snapshots is described in "[Lightweight Asynchronous Snapshots for Distributed Dataflows](https://arxiv.org/abs/1506.08603)". It is inspired by
+the standard [Chandy-Lamport algorithm](https://research.microsoft.com/en-us/um/people/lamport/pubs/chandy.pdf) for distributed snapshots and is
 specifically tailored to Flink's execution model.
 
 

--- a/docs/internals/stream_checkpointing.zh.md
+++ b/docs/internals/stream_checkpointing.zh.md
@@ -48,7 +48,7 @@ have been part of the previously checkpointed state.
 *Note:* By default, checkpointing is disabled. See [Checkpointing]({{ site.baseurl }}/dev/stream/state/checkpointing.html) for details on how to enable and configure checkpointing.
 
 *Note:* For this mechanism to realize its full guarantees, the data stream source (such as message queue or broker) needs to be able
-to rewind the stream to a defined recent point. [Apache Kafka](http://kafka.apache.org) has this ability and Flink's connector to
+to rewind the stream to a defined recent point. [Apache Kafka](https://kafka.apache.org) has this ability and Flink's connector to
 Kafka exploits this ability. See [Fault Tolerance Guarantees of Data Sources and Sinks]({{ site.baseurl }}/dev/connectors/guarantees.html) for
 more information about the guarantees provided by Flink's connectors.
 
@@ -59,8 +59,8 @@ more information about the guarantees provided by Flink's connectors.
 
 The central part of Flink's fault tolerance mechanism is drawing consistent snapshots of the distributed data stream and operator state.
 These snapshots act as consistent checkpoints to which the system can fall back in case of a failure. Flink's mechanism for drawing these
-snapshots is described in "[Lightweight Asynchronous Snapshots for Distributed Dataflows](http://arxiv.org/abs/1506.08603)". It is inspired by
-the standard [Chandy-Lamport algorithm](http://research.microsoft.com/en-us/um/people/lamport/pubs/chandy.pdf) for distributed snapshots and is
+snapshots is described in "[Lightweight Asynchronous Snapshots for Distributed Dataflows](https://arxiv.org/abs/1506.08603)". It is inspired by
+the standard [Chandy-Lamport algorithm](https://research.microsoft.com/en-us/um/people/lamport/pubs/chandy.pdf) for distributed snapshots and is
 specifically tailored to Flink's execution model.
 
 

--- a/docs/monitoring/application_profiling.md
+++ b/docs/monitoring/application_profiling.md
@@ -36,7 +36,7 @@ using `FLINK_LOG_PREFIX` are rotated along with the default `.out` and `.log` fi
 # Profiling with Java Flight Recorder
 
 Java Flight Recorder is a profiling and event collection framework built into the Oracle JDK.
-[Java Mission Control](http://www.oracle.com/technetwork/java/javaseproducts/mission-control/java-mission-control-1998576.html)
+[Java Mission Control](https://www.oracle.com/technetwork/java/javaseproducts/mission-control/java-mission-control-1998576.html)
 is an advanced set of tools that enables efficient and detailed analysis of the extensive of data collected by Java
 Flight Recorder. Example configuration:
 

--- a/docs/monitoring/application_profiling.zh.md
+++ b/docs/monitoring/application_profiling.zh.md
@@ -36,7 +36,7 @@ using `FLINK_LOG_PREFIX` are rotated along with the default `.out` and `.log` fi
 # Profiling with Java Flight Recorder
 
 Java Flight Recorder is a profiling and event collection framework built into the Oracle JDK.
-[Java Mission Control](http://www.oracle.com/technetwork/java/javaseproducts/mission-control/java-mission-control-1998576.html)
+[Java Mission Control](https://www.oracle.com/technetwork/java/javaseproducts/mission-control/java-mission-control-1998576.html)
 is an advanced set of tools that enables efficient and detailed analysis of the extensive of data collected by Java
 Flight Recorder. Example configuration:
 

--- a/docs/monitoring/logging.md
+++ b/docs/monitoring/logging.md
@@ -68,7 +68,7 @@ In order to control the logging level of `org.apache.flink.runtime.jobgraph.JobG
 <logger name="org.apache.flink.runtime.jobgraph.JobGraph" level="DEBUG"/>
 {% endhighlight %}
 
-For further information on configuring logback see [LOGback's manual](http://logback.qos.ch/manual/configuration.html).
+For further information on configuring logback see [LOGback's manual](https://logback.qos.ch/manual/configuration.html).
 
 ## Best practices for developers
 

--- a/docs/monitoring/logging.zh.md
+++ b/docs/monitoring/logging.zh.md
@@ -68,7 +68,7 @@ In order to control the logging level of `org.apache.flink.runtime.jobgraph.JobG
 <logger name="org.apache.flink.runtime.jobgraph.JobGraph" level="DEBUG"/>
 {% endhighlight %}
 
-For further information on configuring logback see [LOGback's manual](http://logback.qos.ch/manual/configuration.html).
+For further information on configuring logback see [LOGback's manual](https://logback.qos.ch/manual/configuration.html).
 
 ## Best practices for developers
 

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -29,7 +29,7 @@ The out of the box configuration will use your default Java installation. You ca
 
 This page lists the most common options that are typically needed to set up a well performing (distributed) installation. In addition a full list of all available configuration parameters is listed here.
 
-All configuration is done in `conf/flink-conf.yaml`, which is expected to be a flat collection of [YAML key value pairs](http://www.yaml.org/spec/1.2/spec.html) with format `key: value`.
+All configuration is done in `conf/flink-conf.yaml`, which is expected to be a flat collection of [YAML key value pairs](https://www.yaml.org/spec/1.2/spec.html) with format `key: value`.
 
 The system and run scripts parse the config at startup time. Changes to the configuration file require restarting the Flink JobManager and TaskManagers.
 

--- a/docs/ops/config.zh.md
+++ b/docs/ops/config.zh.md
@@ -29,7 +29,7 @@ The out of the box configuration will use your default Java installation. You ca
 
 This page lists the most common options that are typically needed to set up a well performing (distributed) installation. In addition a full list of all available configuration parameters is listed here.
 
-All configuration is done in `conf/flink-conf.yaml`, which is expected to be a flat collection of [YAML key value pairs](http://www.yaml.org/spec/1.2/spec.html) with format `key: value`.
+All configuration is done in `conf/flink-conf.yaml`, which is expected to be a flat collection of [YAML key value pairs](https://www.yaml.org/spec/1.2/spec.html) with format `key: value`.
 
 The system and run scripts parse the config at startup time. Changes to the configuration file require restarting the Flink JobManager and TaskManagers.
 

--- a/docs/ops/deployment/aws.md
+++ b/docs/ops/deployment/aws.md
@@ -34,7 +34,7 @@ Amazon Web Services offers cloud computing services on which you can run Flink.
 
 ### Standard EMR Installation
 
-Flink is a supported application on Amazon EMR. [Amazon's documentation](http://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-flink.html)
+Flink is a supported application on Amazon EMR. [Amazon's documentation](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-flink.html)
 describes configuring Flink, creating and monitoring a cluster, and working with jobs.
 
 ### Custom EMR Installation
@@ -44,16 +44,16 @@ can be manually installed in a stock EMR cluster.
 
 **Create EMR Cluster**
 
-The EMR documentation contains [examples showing how to start an EMR cluster](http://docs.aws.amazon.com/ElasticMapReduce/latest/ManagementGuide/emr-gs-launch-sample-cluster.html). You can follow that guide and install any EMR release. You don't need to install the *All Applications* part of the EMR release, but can stick to *Core Hadoop*.
+The EMR documentation contains [examples showing how to start an EMR cluster](https://docs.aws.amazon.com/ElasticMapReduce/latest/ManagementGuide/emr-gs-launch-sample-cluster.html). You can follow that guide and install any EMR release. You don't need to install the *All Applications* part of the EMR release, but can stick to *Core Hadoop*.
 
 {% warn Note %}
 Access to S3 buckets requires
-[configuration of IAM roles](http://docs.aws.amazon.com/ElasticMapReduce/latest/ManagementGuide/emr-iam-roles.html)
+[configuration of IAM roles](https://docs.aws.amazon.com/ElasticMapReduce/latest/ManagementGuide/emr-iam-roles.html)
 when creating an EMR cluster.
 
 **Install Flink on EMR Cluster**
 
-After creating your cluster, you can [connect to the master node](http://docs.aws.amazon.com/ElasticMapReduce/latest/ManagementGuide/emr-connect-master-node.html) and install Flink:
+After creating your cluster, you can [connect to the master node](https://docs.aws.amazon.com/ElasticMapReduce/latest/ManagementGuide/emr-connect-master-node.html) and install Flink:
 
 1. Go the [Downloads Page]({{ site.download_url }}) and **download a binary version of Flink matching the Hadoop version** of your EMR cluster, e.g. Hadoop 2.7 for EMR releases 4.3.0, 4.4.0, or 4.5.0.
 2. Make sure all the Hadoop dependencies are in the classpath before you submit any jobs to EMR:

--- a/docs/ops/deployment/aws.zh.md
+++ b/docs/ops/deployment/aws.zh.md
@@ -34,7 +34,7 @@ Amazon Web Services offers cloud computing services on which you can run Flink.
 
 ### Standard EMR Installation
 
-Flink is a supported application on Amazon EMR. [Amazon's documentation](http://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-flink.html)
+Flink is a supported application on Amazon EMR. [Amazon's documentation](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-flink.html)
 describes configuring Flink, creating and monitoring a cluster, and working with jobs.
 
 ### Custom EMR Installation
@@ -44,16 +44,16 @@ can be manually installed in a stock EMR cluster.
 
 **Create EMR Cluster**
 
-The EMR documentation contains [examples showing how to start an EMR cluster](http://docs.aws.amazon.com/ElasticMapReduce/latest/ManagementGuide/emr-gs-launch-sample-cluster.html). You can follow that guide and install any EMR release. You don't need to install the *All Applications* part of the EMR release, but can stick to *Core Hadoop*.
+The EMR documentation contains [examples showing how to start an EMR cluster](https://docs.aws.amazon.com/ElasticMapReduce/latest/ManagementGuide/emr-gs-launch-sample-cluster.html). You can follow that guide and install any EMR release. You don't need to install the *All Applications* part of the EMR release, but can stick to *Core Hadoop*.
 
 {% warn Note %}
 Access to S3 buckets requires
-[configuration of IAM roles](http://docs.aws.amazon.com/ElasticMapReduce/latest/ManagementGuide/emr-iam-roles.html)
+[configuration of IAM roles](https://docs.aws.amazon.com/ElasticMapReduce/latest/ManagementGuide/emr-iam-roles.html)
 when creating an EMR cluster.
 
 **Install Flink on EMR Cluster**
 
-After creating your cluster, you can [connect to the master node](http://docs.aws.amazon.com/ElasticMapReduce/latest/ManagementGuide/emr-connect-master-node.html) and install Flink:
+After creating your cluster, you can [connect to the master node](https://docs.aws.amazon.com/ElasticMapReduce/latest/ManagementGuide/emr-connect-master-node.html) and install Flink:
 
 1. Go the [Downloads Page]({{ site.download_url }}) and **download a binary version of Flink matching the Hadoop version** of your EMR cluster, e.g. Hadoop 2.7 for EMR releases 4.3.0, 4.4.0, or 4.5.0.
 2. Extract the Flink distribution and you are ready to deploy [Flink jobs via YARN](yarn_setup.html) after **setting the Hadoop config directory**:

--- a/docs/ops/deployment/mapr_setup.md
+++ b/docs/ops/deployment/mapr_setup.md
@@ -59,7 +59,7 @@ the `hadoop.version` and `zookeeper.version` properties.
 For different MapR versions, simply override these properties to appropriate
 values. The corresponding Hadoop / Zookeeper distributions for each MapR version
 can be found on MapR documentations such as
-[here](http://maprdocs.mapr.com/home/DevelopmentGuide/MavenArtifacts.html).
+[here](https://maprdocs.mapr.com/home/DevelopmentGuide/MavenArtifacts.html).
 
 ### Job Submission Client Setup
 
@@ -117,7 +117,7 @@ versions in order to use Flink with a secured MapR cluster. For more details,
 please see [FLINK-5949](https://issues.apache.org/jira/browse/FLINK-5949).*
 
 Flink's [Kerberos authentication]({{ site.baseurl }}/ops/security-kerberos.html) is independent of
-[MapR's Security authentication](http://maprdocs.mapr.com/home/SecurityGuide/Configuring-MapR-Security.html).
+[MapR's Security authentication](https://maprdocs.mapr.com/home/SecurityGuide/Configuring-MapR-Security.html).
 With the above build procedures and environment variable setups, Flink
 does not require any additional configuration to work with MapR Security.
 

--- a/docs/ops/deployment/mapr_setup.zh.md
+++ b/docs/ops/deployment/mapr_setup.zh.md
@@ -59,7 +59,7 @@ the `hadoop.version` and `zookeeper.version` properties.
 For different MapR versions, simply override these properties to appropriate
 values. The corresponding Hadoop / Zookeeper distributions for each MapR version
 can be found on MapR documentations such as
-[here](http://maprdocs.mapr.com/home/DevelopmentGuide/MavenArtifacts.html).
+[here](https://maprdocs.mapr.com/home/DevelopmentGuide/MavenArtifacts.html).
 
 ### Job Submission Client Setup
 
@@ -117,7 +117,7 @@ versions in order to use Flink with a secured MapR cluster. For more details,
 please see [FLINK-5949](https://issues.apache.org/jira/browse/FLINK-5949).*
 
 Flink's [Kerberos authentication]({{ site.baseurl }}/ops/security-kerberos.html) is independent of
-[MapR's Security authentication](http://maprdocs.mapr.com/home/SecurityGuide/Configuring-MapR-Security.html).
+[MapR's Security authentication](https://maprdocs.mapr.com/home/SecurityGuide/Configuring-MapR-Security.html).
 With the above build procedures and environment variable setups, Flink
 does not require any additional configuration to work with MapR Security.
 

--- a/docs/ops/deployment/mesos.md
+++ b/docs/ops/deployment/mesos.md
@@ -99,7 +99,7 @@ You can also run Mesos without DC/OS.
 
 ### Installing Mesos
 
-Please follow the [instructions on how to setup Mesos on the official website](http://mesos.apache.org/getting-started/).
+Please follow the [instructions on how to setup Mesos on the official website](https://mesos.apache.org/getting-started/).
 
 After installation you have to configure the set of master and agent nodes by creating the files `MESOS_HOME/etc/mesos/masters` and `MESOS_HOME/etc/mesos/slaves`.
 These files contain in each row a single hostname on which the respective component will be started (assuming SSH access to these nodes).
@@ -133,7 +133,7 @@ Under Mac OS X you have to export `MESOS_NATIVE_JAVA_LIBRARY=MESOS_HOME/lib/libm
 
 In order to start your mesos cluster, use the deployment script `MESOS_HOME/sbin/mesos-start-cluster.sh`.
 In order to stop your mesos cluster, use the deployment script `MESOS_HOME/sbin/mesos-stop-cluster.sh`.
-More information about the deployment scripts can be found [here](http://mesos.apache.org/documentation/latest/deploy-scripts/).
+More information about the deployment scripts can be found [here](https://mesos.apache.org/documentation/latest/deploy-scripts/).
 
 ### Installing Marathon
 

--- a/docs/ops/deployment/mesos.zh.md
+++ b/docs/ops/deployment/mesos.zh.md
@@ -99,7 +99,7 @@ You can also run Mesos without DC/OS.
 
 ### Installing Mesos
 
-Please follow the [instructions on how to setup Mesos on the official website](http://mesos.apache.org/getting-started/).
+Please follow the [instructions on how to setup Mesos on the official website](https://mesos.apache.org/getting-started/).
 
 After installation you have to configure the set of master and agent nodes by creating the files `MESOS_HOME/etc/mesos/masters` and `MESOS_HOME/etc/mesos/slaves`.
 These files contain in each row a single hostname on which the respective component will be started (assuming SSH access to these nodes).
@@ -133,7 +133,7 @@ Under Mac OS X you have to export `MESOS_NATIVE_JAVA_LIBRARY=MESOS_HOME/lib/libm
 
 In order to start your mesos cluster, use the deployment script `MESOS_HOME/sbin/mesos-start-cluster.sh`.
 In order to stop your mesos cluster, use the deployment script `MESOS_HOME/sbin/mesos-stop-cluster.sh`.
-More information about the deployment scripts can be found [here](http://mesos.apache.org/documentation/latest/deploy-scripts/).
+More information about the deployment scripts can be found [here](https://mesos.apache.org/documentation/latest/deploy-scripts/).
 
 ### Installing Marathon
 

--- a/docs/ops/deployment/yarn_setup.md
+++ b/docs/ops/deployment/yarn_setup.md
@@ -58,14 +58,14 @@ cd flink-{{ site.version }}/
 
 ## Flink YARN Session
 
-Apache [Hadoop YARN](http://hadoop.apache.org/) is a cluster resource management framework. It allows to run various distributed applications on top of a cluster. Flink runs on YARN next to other applications. Users do not have to setup or install anything if there is already a YARN setup.
+Apache [Hadoop YARN](https://hadoop.apache.org/) is a cluster resource management framework. It allows to run various distributed applications on top of a cluster. Flink runs on YARN next to other applications. Users do not have to setup or install anything if there is already a YARN setup.
 
 **Requirements**
 
 - at least Apache Hadoop 2.2
 - HDFS (Hadoop Distributed File System) (or another distributed file system supported by Hadoop)
 
-If you have troubles using the Flink YARN client, have a look in the [FAQ section](http://flink.apache.org/faq.html#yarn-deployment).
+If you have troubles using the Flink YARN client, have a look in the [FAQ section](https://flink.apache.org/faq.html#yarn-deployment).
 
 ### Start Flink Session
 
@@ -268,7 +268,7 @@ There are many reasons why a Flink YARN session deployment can fail. A misconfig
 
 ### Log Files
 
-In cases where the Flink YARN session fails during the deployment itself, users have to rely on the logging capabilities of Hadoop YARN. The most useful feature for that is the [YARN log aggregation](http://hortonworks.com/blog/simplifying-user-logs-management-and-access-in-yarn/).
+In cases where the Flink YARN session fails during the deployment itself, users have to rely on the logging capabilities of Hadoop YARN. The most useful feature for that is the [YARN log aggregation](https://hortonworks.com/blog/simplifying-user-logs-management-and-access-in-yarn/).
 To enable it, users have to set the `yarn.log-aggregation-enable` property to `true` in the `yarn-site.xml` file.
 Once that is enabled, users can use the following command to retrieve all log files of a (failed) YARN session.
 

--- a/docs/ops/deployment/yarn_setup.zh.md
+++ b/docs/ops/deployment/yarn_setup.zh.md
@@ -58,14 +58,14 @@ cd flink-{{ site.version }}/
 
 ## Flink YARN Session
 
-Apache [Hadoop YARN](http://hadoop.apache.org/) is a cluster resource management framework. It allows to run various distributed applications on top of a cluster. Flink runs on YARN next to other applications. Users do not have to setup or install anything if there is already a YARN setup.
+Apache [Hadoop YARN](https://hadoop.apache.org/) is a cluster resource management framework. It allows to run various distributed applications on top of a cluster. Flink runs on YARN next to other applications. Users do not have to setup or install anything if there is already a YARN setup.
 
 **Requirements**
 
 - at least Apache Hadoop 2.2
 - HDFS (Hadoop Distributed File System) (or another distributed file system supported by Hadoop)
 
-If you have troubles using the Flink YARN client, have a look in the [FAQ section](http://flink.apache.org/faq.html#yarn-deployment).
+If you have troubles using the Flink YARN client, have a look in the [FAQ section](https://flink.apache.org/faq.html#yarn-deployment).
 
 ### Start Flink Session
 
@@ -268,7 +268,7 @@ There are many reasons why a Flink YARN session deployment can fail. A misconfig
 
 ### Log Files
 
-In cases where the Flink YARN session fails during the deployment itself, users have to rely on the logging capabilities of Hadoop YARN. The most useful feature for that is the [YARN log aggregation](http://hortonworks.com/blog/simplifying-user-logs-management-and-access-in-yarn/).
+In cases where the Flink YARN session fails during the deployment itself, users have to rely on the logging capabilities of Hadoop YARN. The most useful feature for that is the [YARN log aggregation](https://hortonworks.com/blog/simplifying-user-logs-management-and-access-in-yarn/).
 To enable it, users have to set the `yarn.log-aggregation-enable` property to `true` in the `yarn-site.xml` file.
 Once that is enabled, users can use the following command to retrieve all log files of a (failed) YARN session.
 

--- a/docs/ops/filesystems/oss.md
+++ b/docs/ops/filesystems/oss.md
@@ -65,7 +65,7 @@ After setting up the OSS FileSystem wrapper, you need to add some configurations
 
 To allow for easy adoption, you can use the same configuration keys in `flink-conf.yaml` as in Hadoop's `core-site.xml`
 
-You can see the configuration keys in the [Hadoop OSS documentation](http://hadoop.apache.org/docs/current/hadoop-aliyun/tools/hadoop-aliyun/index.html).
+You can see the configuration keys in the [Hadoop OSS documentation](https://hadoop.apache.org/docs/current/hadoop-aliyun/tools/hadoop-aliyun/index.html).
 
 There are some required configurations that must be added to `flink-conf.yaml` (**Other configurations defined in Hadoop OSS documentation are advanced configurations which used by performance tuning**):
 

--- a/docs/ops/filesystems/oss.zh.md
+++ b/docs/ops/filesystems/oss.zh.md
@@ -65,7 +65,7 @@ After setting up the OSS FileSystem wrapper, you need to add some configurations
 
 To allow for easy adoption, you can use the same configuration keys in `flink-conf.yaml` as in Hadoop's `core-site.xml`
 
-You can see the configuration keys in the [Hadoop OSS documentation](http://hadoop.apache.org/docs/current/hadoop-aliyun/tools/hadoop-aliyun/index.html).
+You can see the configuration keys in the [Hadoop OSS documentation](https://hadoop.apache.org/docs/current/hadoop-aliyun/tools/hadoop-aliyun/index.html).
 
 There are some required configurations that must be added to `flink-conf.yaml` (**Other configurations defined in Hadoop OSS documentation are advanced configurations which used by performance tuning**):
 

--- a/docs/ops/filesystems/s3.md
+++ b/docs/ops/filesystems/s3.md
@@ -23,7 +23,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-[Amazon Simple Storage Service](http://aws.amazon.com/s3/) (Amazon S3) provides cloud object storage for a variety of use cases. You can use S3 with Flink for **reading** and **writing data** as well in conjunction with the [streaming **state backends**]({{ site.baseurl}}/ops/state/state_backends.html).
+[Amazon Simple Storage Service](https://aws.amazon.com/s3/) (Amazon S3) provides cloud object storage for a variety of use cases. You can use S3 with Flink for **reading** and **writing data** as well in conjunction with the [streaming **state backends**]({{ site.baseurl}}/ops/state/state_backends.html).
 
 * This will be replaced by the TOC
 {:toc}
@@ -84,7 +84,7 @@ After setting up the S3 FileSystem wrapper, you need to make sure that Flink is 
 
 ##### Identity and Access Management (IAM) (Recommended)
 
-The recommended way of setting up credentials on AWS is via [Identity and Access Management (IAM)](http://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html). You can use IAM features to securely give Flink instances the credentials that they need to access S3 buckets. Details about how to do this are beyond the scope of this documentation. Please refer to the AWS user guide. What you are looking for are [IAM Roles](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html).
+The recommended way of setting up credentials on AWS is via [Identity and Access Management (IAM)](https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html). You can use IAM features to securely give Flink instances the credentials that they need to access S3 buckets. Details about how to do this are beyond the scope of this documentation. Please refer to the AWS user guide. What you are looking for are [IAM Roles](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html).
 
 If you set this up correctly, you can manage access to S3 within AWS and don't need to distribute any access keys to Flink.
 

--- a/docs/ops/filesystems/s3.zh.md
+++ b/docs/ops/filesystems/s3.zh.md
@@ -23,7 +23,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-[Amazon Simple Storage Service](http://aws.amazon.com/s3/) (Amazon S3) provides cloud object storage for a variety of use cases. You can use S3 with Flink for **reading** and **writing data** as well in conjunction with the [streaming **state backends**]({{ site.baseurl}}/ops/state/state_backends.html).
+[Amazon Simple Storage Service](https://aws.amazon.com/s3/) (Amazon S3) provides cloud object storage for a variety of use cases. You can use S3 with Flink for **reading** and **writing data** as well in conjunction with the [streaming **state backends**]({{ site.baseurl}}/ops/state/state_backends.html).
 
 * This will be replaced by the TOC
 {:toc}
@@ -84,7 +84,7 @@ After setting up the S3 FileSystem wrapper, you need to make sure that Flink is 
 
 ##### Identity and Access Management (IAM) (Recommended)
 
-The recommended way of setting up credentials on AWS is via [Identity and Access Management (IAM)](http://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html). You can use IAM features to securely give Flink instances the credentials that they need to access S3 buckets. Details about how to do this are beyond the scope of this documentation. Please refer to the AWS user guide. What you are looking for are [IAM Roles](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html).
+The recommended way of setting up credentials on AWS is via [Identity and Access Management (IAM)](https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html). You can use IAM features to securely give Flink instances the credentials that they need to access S3 buckets. Details about how to do this are beyond the scope of this documentation. Please refer to the AWS user guide. What you are looking for are [IAM Roles](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html).
 
 If you set this up correctly, you can manage access to S3 within AWS and don't need to distribute any access keys to Flink.
 

--- a/docs/ops/jobmanager_high_availability.md
+++ b/docs/ops/jobmanager_high_availability.md
@@ -48,7 +48,7 @@ As an example, consider the following setup with three JobManager instances:
 
 To enable JobManager High Availability you have to set the **high-availability mode** to *zookeeper*, configure a **ZooKeeper quorum** and set up a **masters file** with all JobManagers hosts and their web UI ports.
 
-Flink leverages **[ZooKeeper](http://zookeeper.apache.org)** for *distributed coordination* between all running JobManager instances. ZooKeeper is a separate service from Flink, which provides highly reliable distributed coordination via leader election and light-weight consistent state storage. Check out [ZooKeeper's Getting Started Guide](http://zookeeper.apache.org/doc/current/zookeeperStarted.html) for more information about ZooKeeper. Flink includes scripts to [bootstrap a simple ZooKeeper](#bootstrap-zookeeper) installation.
+Flink leverages **[ZooKeeper](https://zookeeper.apache.org)** for *distributed coordination* between all running JobManager instances. ZooKeeper is a separate service from Flink, which provides highly reliable distributed coordination via leader election and light-weight consistent state storage. Check out [ZooKeeper's Getting Started Guide](https://zookeeper.apache.org/doc/current/zookeeperStarted.html) for more information about ZooKeeper. Flink includes scripts to [bootstrap a simple ZooKeeper](#bootstrap-zookeeper) installation.
 
 #### Masters File (masters)
 
@@ -179,7 +179,7 @@ In addition to the HA configuration ([see above](#configuration)), you have to c
 
 <pre>yarn.application-attempts: 10</pre>
 
-This means that the application can be restarted 9 times for failed attempts before YARN fails the application (9 retries + 1 initial attempt). Additional restarts can be performed by YARN if required by YARN operations: Preemption, node hardware failures or reboots, or NodeManager resyncs. These restarts are not counted against `yarn.application-attempts`, see <a href="http://johnjianfang.blogspot.de/2015/04/the-number-of-maximum-attempts-of-yarn.html">Jian Fang's blog post</a>. It's important to note that `yarn.resourcemanager.am.max-attempts` is an upper bound for the application restarts. Therefore, the number of application attempts set within Flink cannot exceed the YARN cluster setting with which YARN was started.
+This means that the application can be restarted 9 times for failed attempts before YARN fails the application (9 retries + 1 initial attempt). Additional restarts can be performed by YARN if required by YARN operations: Preemption, node hardware failures or reboots, or NodeManager resyncs. These restarts are not counted against `yarn.application-attempts`, see <a href="https://johnjianfang.blogspot.de/2015/04/the-number-of-maximum-attempts-of-yarn.html">Jian Fang's blog post</a>. It's important to note that `yarn.resourcemanager.am.max-attempts` is an upper bound for the application restarts. Therefore, the number of application attempts set within Flink cannot exceed the YARN cluster setting with which YARN was started.
 
 #### Container Shutdown Behaviour
 

--- a/docs/ops/jobmanager_high_availability.zh.md
+++ b/docs/ops/jobmanager_high_availability.zh.md
@@ -48,7 +48,7 @@ As an example, consider the following setup with three JobManager instances:
 
 To enable JobManager High Availability you have to set the **high-availability mode** to *zookeeper*, configure a **ZooKeeper quorum** and set up a **masters file** with all JobManagers hosts and their web UI ports.
 
-Flink leverages **[ZooKeeper](http://zookeeper.apache.org)** for *distributed coordination* between all running JobManager instances. ZooKeeper is a separate service from Flink, which provides highly reliable distributed coordination via leader election and light-weight consistent state storage. Check out [ZooKeeper's Getting Started Guide](http://zookeeper.apache.org/doc/current/zookeeperStarted.html) for more information about ZooKeeper. Flink includes scripts to [bootstrap a simple ZooKeeper](#bootstrap-zookeeper) installation.
+Flink leverages **[ZooKeeper](https://zookeeper.apache.org)** for *distributed coordination* between all running JobManager instances. ZooKeeper is a separate service from Flink, which provides highly reliable distributed coordination via leader election and light-weight consistent state storage. Check out [ZooKeeper's Getting Started Guide](https://zookeeper.apache.org/doc/current/zookeeperStarted.html) for more information about ZooKeeper. Flink includes scripts to [bootstrap a simple ZooKeeper](#bootstrap-zookeeper) installation.
 
 #### Masters File (masters)
 
@@ -179,7 +179,7 @@ In addition to the HA configuration ([see above](#configuration)), you have to c
 
 <pre>yarn.application-attempts: 10</pre>
 
-This means that the application can be restarted 9 times for failed attempts before YARN fails the application (9 retries + 1 initial attempt). Additional restarts can be performed by YARN if required by YARN operations: Preemption, node hardware failures or reboots, or NodeManager resyncs. These restarts are not counted against `yarn.application-attempts`, see <a href="http://johnjianfang.blogspot.de/2015/04/the-number-of-maximum-attempts-of-yarn.html">Jian Fang's blog post</a>. It's important to note that `yarn.resourcemanager.am.max-attempts` is an upper bound for the application restarts. Therefore, the number of application attempts set within Flink cannot exceed the YARN cluster setting with which YARN was started.
+This means that the application can be restarted 9 times for failed attempts before YARN fails the application (9 retries + 1 initial attempt). Additional restarts can be performed by YARN if required by YARN operations: Preemption, node hardware failures or reboots, or NodeManager resyncs. These restarts are not counted against `yarn.application-attempts`, see <a href="https://johnjianfang.blogspot.de/2015/04/the-number-of-maximum-attempts-of-yarn.html">Jian Fang's blog post</a>. It's important to note that `yarn.resourcemanager.am.max-attempts` is an upper bound for the application restarts. Therefore, the number of application attempts set within Flink cannot exceed the YARN cluster setting with which YARN was started.
 
 #### Container Shutdown Behaviour
 

--- a/docs/ops/security-kerberos.md
+++ b/docs/ops/security-kerberos.md
@@ -69,7 +69,7 @@ the login user conveys only the user identity of the OS account that launched th
 This module provides a dynamic JAAS configuration to the cluster, making available the configured Kerberos credential to ZooKeeper,
 Kafka, and other such components that rely on JAAS.
 
-Note that the user may also provide a static JAAS configuration file using the mechanisms described in the [Java SE Documentation](http://docs.oracle.com/javase/7/docs/technotes/guides/security/jgss/tutorials/LoginConfigFile.html).   Static entries override any
+Note that the user may also provide a static JAAS configuration file using the mechanisms described in the [Java SE Documentation](https://docs.oracle.com/javase/7/docs/technotes/guides/security/jgss/tutorials/LoginConfigFile.html).   Static entries override any
 dynamic entries provided by this module.
 
 ### ZooKeeper Security Module

--- a/docs/ops/security-kerberos.zh.md
+++ b/docs/ops/security-kerberos.zh.md
@@ -69,7 +69,7 @@ the login user conveys only the user identity of the OS account that launched th
 This module provides a dynamic JAAS configuration to the cluster, making available the configured Kerberos credential to ZooKeeper,
 Kafka, and other such components that rely on JAAS.
 
-Note that the user may also provide a static JAAS configuration file using the mechanisms described in the [Java SE Documentation](http://docs.oracle.com/javase/7/docs/technotes/guides/security/jgss/tutorials/LoginConfigFile.html).   Static entries override any
+Note that the user may also provide a static JAAS configuration file using the mechanisms described in the [Java SE Documentation](https://docs.oracle.com/javase/7/docs/technotes/guides/security/jgss/tutorials/LoginConfigFile.html).   Static entries override any
 dynamic entries provided by this module.
 
 ### ZooKeeper Security Module

--- a/docs/ops/security-ssl.md
+++ b/docs/ops/security-ssl.md
@@ -69,7 +69,7 @@ The REST endpoints can be configured to require SSL connections. The server will
 Simple mutual authentication may be enabled by configuration if authentication of connections to the REST endpoint is required, but we recommend to deploy a "side car proxy":
 Bind the REST endpoint to the loopback interface (or the pod-local interface in Kubernetes) and start a REST proxy that authenticates and forwards the requests to Flink.
 Examples for proxies that Flink users have deployed are [Envoy Proxy](https://www.envoyproxy.io/) or
-[NGINX with MOD_AUTH](http://nginx.org/en/docs/http/ngx_http_auth_request_module.html).
+[NGINX with MOD_AUTH](https://nginx.org/en/docs/http/ngx_http_auth_request_module.html).
 
 The rationale behind delegating authentication to a proxy is that such proxies offer a wide variety of authentication options and thus better integration into existing infrastructures.
 

--- a/docs/ops/security-ssl.zh.md
+++ b/docs/ops/security-ssl.zh.md
@@ -69,7 +69,7 @@ The REST endpoints can be configured to require SSL connections. The server will
 Simple mutual authentication may be enabled by configuration if authentication of connections to the REST endpoint is required, but we recommend to deploy a "side car proxy":
 Bind the REST endpoint to the loopback interface (or the pod-local interface in Kubernetes) and start a REST proxy that authenticates and forwards the requests to Flink.
 Examples for proxies that Flink users have deployed are [Envoy Proxy](https://www.envoyproxy.io/) or
-[NGINX with MOD_AUTH](http://nginx.org/en/docs/http/ngx_http_auth_request_module.html).
+[NGINX with MOD_AUTH](https://nginx.org/en/docs/http/ngx_http_auth_request_module.html).
 
 The rationale behind delegating authentication to a proxy is that such proxies offer a wide variety of authentication options and thus better integration into existing infrastructures.
 

--- a/docs/ops/state/state_backends.md
+++ b/docs/ops/state/state_backends.md
@@ -96,7 +96,7 @@ The FsStateBackend is encouraged for:
 
 The *RocksDBStateBackend* is configured with a file system URL (type, address, path), such as "hdfs://namenode:40010/flink/checkpoints" or "file:///data/flink/checkpoints".
 
-The RocksDBStateBackend holds in-flight data in a [RocksDB](http://rocksdb.org) database
+The RocksDBStateBackend holds in-flight data in a [RocksDB](https://rocksdb.org) database
 that is (per default) stored in the TaskManager data directories. Upon checkpointing, the whole
 RocksDB database will be checkpointed into the configured file system and directory. Minimal
 metadata is stored in the JobManager's memory (or, in high-availability mode, in the metadata checkpoint).

--- a/docs/ops/state/state_backends.zh.md
+++ b/docs/ops/state/state_backends.zh.md
@@ -96,7 +96,7 @@ The FsStateBackend is encouraged for:
 
 The *RocksDBStateBackend* is configured with a file system URL (type, address, path), such as "hdfs://namenode:40010/flink/checkpoints" or "file:///data/flink/checkpoints".
 
-The RocksDBStateBackend holds in-flight data in a [RocksDB](http://rocksdb.org) database
+The RocksDBStateBackend holds in-flight data in a [RocksDB](https://rocksdb.org) database
 that is (per default) stored in the TaskManager data directories. Upon checkpointing, the whole
 RocksDB database will be checkpointed into the configured file system and directory. Minimal
 metadata is stored in the JobManager's memory (or, in high-availability mode, in the metadata checkpoint).

--- a/docs/tutorials/datastream_api.md
+++ b/docs/tutorials/datastream_api.md
@@ -55,7 +55,7 @@ $ mvn archetype:generate \
 
 {% unless site.is_stable %}
 <p style="border-radius: 5px; padding: 5px" class="bg-danger">
-    <b>Note</b>: For Maven 3.0 or higher, it is no longer possible to specify the repository (-DarchetypeCatalog) via the commandline. If you wish to use the snapshot repository, you need to add a repository entry to your settings.xml. For details about this change, please refer to <a href="http://maven.apache.org/archetype/maven-archetype-plugin/archetype-repository.html">Maven official document</a>
+    <b>Note</b>: For Maven 3.0 or higher, it is no longer possible to specify the repository (-DarchetypeCatalog) via the commandline. If you wish to use the snapshot repository, you need to add a repository entry to your settings.xml. For details about this change, please refer to <a href="https://maven.apache.org/archetype/maven-archetype-plugin/archetype-repository.html">Maven official document</a>
 </p>
 {% endunless %}
 
@@ -317,7 +317,7 @@ you can check out our guides
 about [basic concepts]({{ site.baseurl }}/dev/api_concepts.html) and the
 [DataStream API]({{ site.baseurl }}/dev/datastream_api.html). Stick
 around for the bonus exercise if you want to learn about setting up a Flink cluster on
-your own machine and writing results to [Kafka](http://kafka.apache.org).
+your own machine and writing results to [Kafka](https://kafka.apache.org).
 
 ## Bonus Exercise: Running on a Cluster and Writing to Kafka
 
@@ -425,6 +425,6 @@ and, for example, see the number of processed elements:
 
 <a href="{{ site.baseurl }}/page/img/quickstart-example/jobmanager-job.png" ><img class="img-responsive" src="{{ site.baseurl }}/page/img/quickstart-example/jobmanager-job.png" alt="Example Job View"/></a>
 
-This concludes our little tour of Flink. If you have any questions, please don't hesitate to ask on our [Mailing Lists](http://flink.apache.org/community.html#mailing-lists).
+This concludes our little tour of Flink. If you have any questions, please don't hesitate to ask on our [Mailing Lists](https://flink.apache.org/community.html#mailing-lists).
 
 {% top %}

--- a/docs/tutorials/datastream_api.zh.md
+++ b/docs/tutorials/datastream_api.zh.md
@@ -55,7 +55,7 @@ $ mvn archetype:generate \
 
 {% unless site.is_stable %}
 <p style="border-radius: 5px; padding: 5px" class="bg-danger">
-    <b>Note</b>: For Maven 3.0 or higher, it is no longer possible to specify the repository (-DarchetypeCatalog) via the commandline. If you wish to use the snapshot repository, you need to add a repository entry to your settings.xml. For details about this change, please refer to <a href="http://maven.apache.org/archetype/maven-archetype-plugin/archetype-repository.html">Maven official document</a>
+    <b>Note</b>: For Maven 3.0 or higher, it is no longer possible to specify the repository (-DarchetypeCatalog) via the commandline. If you wish to use the snapshot repository, you need to add a repository entry to your settings.xml. For details about this change, please refer to <a href="https://maven.apache.org/archetype/maven-archetype-plugin/archetype-repository.html">Maven official document</a>
 </p>
 {% endunless %}
 
@@ -317,7 +317,7 @@ you can check out our guides
 about [basic concepts]({{ site.baseurl }}/dev/api_concepts.html) and the
 [DataStream API]({{ site.baseurl }}/dev/datastream_api.html). Stick
 around for the bonus exercise if you want to learn about setting up a Flink cluster on
-your own machine and writing results to [Kafka](http://kafka.apache.org).
+your own machine and writing results to [Kafka](https://kafka.apache.org).
 
 ## Bonus Exercise: Running on a Cluster and Writing to Kafka
 
@@ -425,6 +425,6 @@ and, for example, see the number of processed elements:
 
 <a href="{{ site.baseurl }}/page/img/quickstart-example/jobmanager-job.png" ><img class="img-responsive" src="{{ site.baseurl }}/page/img/quickstart-example/jobmanager-job.png" alt="Example Job View"/></a>
 
-This concludes our little tour of Flink. If you have any questions, please don't hesitate to ask on our [Mailing Lists](http://flink.apache.org/community.html#mailing-lists).
+This concludes our little tour of Flink. If you have any questions, please don't hesitate to ask on our [Mailing Lists](https://flink.apache.org/community.html#mailing-lists).
 
 {% top %}

--- a/docs/tutorials/flink_on_windows.md
+++ b/docs/tutorials/flink_on_windows.md
@@ -22,13 +22,13 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-If you want to run Flink locally on a Windows machine you need to [download](http://flink.apache.org/downloads.html) and unpack the binary Flink distribution. After that you can either use the **Windows Batch** file (`.bat`), or use **Cygwin** to run the Flink Jobmanager.
+If you want to run Flink locally on a Windows machine you need to [download](https://flink.apache.org/downloads.html) and unpack the binary Flink distribution. After that you can either use the **Windows Batch** file (`.bat`), or use **Cygwin** to run the Flink Jobmanager.
 
 ## Starting with Windows Batch Files
 
 To start Flink in from the *Windows Command Line*, open the command window, navigate to the `bin/` directory of Flink and run `start-cluster.bat`.
 
-Note: The ``bin`` folder of your Java Runtime Environment must be included in Window's ``%PATH%`` variable. Follow this [guide](http://www.java.com/en/download/help/path.xml) to add Java to the ``%PATH%`` variable.
+Note: The ``bin`` folder of your Java Runtime Environment must be included in Window's ``%PATH%`` variable. Follow this [guide](https://www.java.com/en/download/help/path.xml) to add Java to the ``%PATH%`` variable.
 
 {% highlight bash %}
 $ cd flink

--- a/docs/tutorials/flink_on_windows.zh.md
+++ b/docs/tutorials/flink_on_windows.zh.md
@@ -22,13 +22,13 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-If you want to run Flink locally on a Windows machine you need to [download](http://flink.apache.org/downloads.html) and unpack the binary Flink distribution. After that you can either use the **Windows Batch** file (`.bat`), or use **Cygwin** to run the Flink Jobmanager.
+If you want to run Flink locally on a Windows machine you need to [download](https://flink.apache.org/downloads.html) and unpack the binary Flink distribution. After that you can either use the **Windows Batch** file (`.bat`), or use **Cygwin** to run the Flink Jobmanager.
 
 ## Starting with Windows Batch Files
 
 To start Flink in from the *Windows Command Line*, open the command window, navigate to the `bin/` directory of Flink and run `start-cluster.bat`.
 
-Note: The ``bin`` folder of your Java Runtime Environment must be included in Window's ``%PATH%`` variable. Follow this [guide](http://www.java.com/en/download/help/path.xml) to add Java to the ``%PATH%`` variable.
+Note: The ``bin`` folder of your Java Runtime Environment must be included in Window's ``%PATH%`` variable. Follow this [guide](https://www.java.com/en/download/help/path.xml) to add Java to the ``%PATH%`` variable.
 
 {% highlight bash %}
 $ cd flink

--- a/docs/tutorials/local_setup.md
+++ b/docs/tutorials/local_setup.md
@@ -50,7 +50,7 @@ Java HotSpot(TM) 64-Bit Server VM (build 25.111-b14, mixed mode)
 <div class="codetabs" markdown="1">
 
 <div data-lang="Download and Unpack" markdown="1">
-1. Download a binary from the [downloads page](http://flink.apache.org/downloads.html). You can pick
+1. Download a binary from the [downloads page](https://flink.apache.org/downloads.html). You can pick
    any Hadoop/Scala combination you like. If you plan to just use the local file system, any Hadoop
    version will work fine.
 2. Go to the download directory.
@@ -78,7 +78,7 @@ Version: 1.2.0, Commit ID: 1c659cf
 
 {% else %}
 ### Download and Compile
-Clone the source code from one of our [repositories](http://flink.apache.org/community.html#source-code), e.g.:
+Clone the source code from one of our [repositories](https://flink.apache.org/community.html#source-code), e.g.:
 
 {% highlight bash %}
 $ git clone https://github.com/apache/flink.git

--- a/docs/tutorials/local_setup.zh.md
+++ b/docs/tutorials/local_setup.zh.md
@@ -50,7 +50,7 @@ Java HotSpot(TM) 64-Bit Server VM (build 25.111-b14, mixed mode)
 <div class="codetabs" markdown="1">
 
 <div data-lang="Download and Unpack" markdown="1">
-1. Download a binary from the [downloads page](http://flink.apache.org/downloads.html). You can pick
+1. Download a binary from the [downloads page](https://flink.apache.org/downloads.html). You can pick
    any Hadoop/Scala combination you like. If you plan to just use the local file system, any Hadoop
    version will work fine.
 2. Go to the download directory.
@@ -78,7 +78,7 @@ Version: 1.2.0, Commit ID: 1c659cf
 
 {% else %}
 ### Download and Compile
-Clone the source code from one of our [repositories](http://flink.apache.org/community.html#source-code), e.g.:
+Clone the source code from one of our [repositories](https://flink.apache.org/community.html#source-code), e.g.:
 
 {% highlight bash %}
 $ git clone https://github.com/apache/flink.git

--- a/flink-contrib/flink-connector-wikiedits/README.md
+++ b/flink-contrib/flink-connector-wikiedits/README.md
@@ -10,7 +10,7 @@ The purpose of this source is to ease the setup of demos of the `DataStream`
 API with live data.
 
 The original idea is from the [Hello Samza](https://samza.apache.org/startup/hello-samza/latest/)
-project of [Apache Samza](http://samza.apache.org). The Samza code for this is located in the
+project of [Apache Samza](https://samza.apache.org). The Samza code for this is located in the
 [samza-hello-samza](https://github.com/apache/samza-hello-samza) repository.
 
 ## Example

--- a/flink-dist/src/main/flink-bin/README.txt
+++ b/flink-dist/src/main/flink-bin/README.txt
@@ -1,6 +1,6 @@
 For the latest information about Flink, please visit our website at:
 
-   http://flink.apache.org
+   https://flink.apache.org
 
 and our GitHub Account 
 
@@ -17,7 +17,7 @@ possession, use, and/or re-export to another country, of
 encryption software.  BEFORE using any encryption software, please 
 check your country's laws, regulations and policies concerning the
 import, possession, or use, and re-export of encryption software, to 
-see if this is permitted.  See <http://www.wassenaar.org/> for more
+see if this is permitted.  See <https://www.wassenaar.org/> for more
 information.
 
 The U.S. Government Department of Commerce, Bureau of Industry and

--- a/flink-end-to-end-tests/README.md
+++ b/flink-end-to-end-tests/README.md
@@ -37,7 +37,7 @@ $ FLINK_DIR=<flink dir> flink-end-to-end-tests/run-single-test.sh your_test.sh a
 
 Before running this nightly test case (test_streaming_bucketing.sh), please make sure to run `mvn -DskipTests install` in the `flink-end-to-end-tests` directory, so jar files necessary for the test like `BucketingSinkTestProgram.jar` could be generated.
 
-What's more, starting from 1.8.0 release it's required to make sure that `HADOOP_CLASSPATH` is [correctly set](https://ci.apache.org/projects/flink/flink-docs-stable/ops/deployment/hadoop.html) or the pre-bundled hadoop jar has been put into the `lib` folder of the `FLINK_DIR` (You can find the binaries from the [Downloads page](http://flink.apache.org/downloads.html) on the Flink project site).
+What's more, starting from 1.8.0 release it's required to make sure that `HADOOP_CLASSPATH` is [correctly set](https://ci.apache.org/projects/flink/flink-docs-stable/ops/deployment/hadoop.html) or the pre-bundled hadoop jar has been put into the `lib` folder of the `FLINK_DIR` (You can find the binaries from the [Downloads page](https://flink.apache.org/downloads.html) on the Flink project site).
 
 ### Kubernetes test
 

--- a/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/misc/CollectionExecutionExample.java
+++ b/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/misc/CollectionExecutionExample.java
@@ -31,7 +31,7 @@ import java.util.List;
  * DataSet transformations are executed on Java collections.
  *
  * <p>See the "Local Execution" section in the documentation for more details:
- * 	http://flink.apache.org/docs/latest/apis/local_execution.html
+ * 	https://flink.apache.org/docs/latest/apis/local_execution.html
  */
 public class CollectionExecutionExample {
 

--- a/flink-libraries/flink-ml/README.md
+++ b/flink-libraries/flink-ml/README.md
@@ -19,4 +19,4 @@ Therefore, Flink will support the Mahout DSL as a execution engine and provide t
 
 Flink-ML has just been recently started.
 As part of Apache Flink, it heavily relies on the active work and contributions of its community and others.
-Thus, if you want to add a new algorithm to the library, then find out [how to contribute]((http://flink.apache.org/how-to-contribute.html)) and open a pull request!
+Thus, if you want to add a new algorithm to the library, then find out [how to contribute]((https://flink.apache.org/how-to-contribute.html)) and open a pull request!

--- a/flink-libraries/flink-python/src/main/python/org/apache/flink/python/api/setup.py
+++ b/flink-libraries/flink-python/src/main/python/org/apache/flink/python/api/setup.py
@@ -25,7 +25,7 @@ setup(
               'flink.functions',
               'flink.plan',
               'flink.utilities'],
-    url='http://flink.apache.org',
+    url='https://flink.apache.org',
     license='Licensed under the Apache License, Version 2.0',
     author='',
     author_email='',

--- a/flink-python/README.md
+++ b/flink-python/README.md
@@ -2,7 +2,7 @@
 
 Apache Flink is an open source stream processing framework with the powerful stream- and batch-processing capabilities.
 
-Learn more about Flink at [http://flink.apache.org/](http://flink.apache.org/)
+Learn more about Flink at [https://flink.apache.org/](https://flink.apache.org/)
 
 This packaging allows you to write Flink programs in Python, but it is currently a very initial version and will change in future versions.
 

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -48,7 +48,7 @@ setup(
     packages=['pyflink',
               'pyflink.table',
               'pyflink.util'],
-    url='http://flink.apache.org',
+    url='https://flink.apache.org',
     license='http://www.apache.org/licenses/LICENSE-2.0',
     author='Flink Developers',
     author_email='dev@flink.apache.org',

--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/src/main/java/BatchJob.java
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/src/main/java/BatchJob.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.java.ExecutionEnvironment;
  * Skeleton for a Flink Batch Job.
  *
  * <p>For a tutorial how to write a Flink batch application, check the
- * tutorials and examples on the <a href="http://flink.apache.org/docs/stable/">Flink Website</a>.
+ * tutorials and examples on the <a href="https://flink.apache.org/docs/stable/">Flink Website</a>.
  *
  * <p>To package your application into a JAR file for execution,
  * change the main class in the POM.xml file to this class (simply search for 'mainClass')
@@ -52,11 +52,11 @@ public class BatchJob {
 		 * and many more.
 		 * Have a look at the programming guide for the Java API:
 		 *
-		 * http://flink.apache.org/docs/latest/apis/batch/index.html
+		 * https://flink.apache.org/docs/latest/apis/batch/index.html
 		 *
 		 * and the examples
 		 *
-		 * http://flink.apache.org/docs/latest/apis/batch/examples.html
+		 * https://flink.apache.org/docs/latest/apis/batch/examples.html
 		 *
 		 */
 

--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/src/main/java/StreamingJob.java
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/src/main/java/StreamingJob.java
@@ -24,7 +24,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
  * Skeleton for a Flink Streaming Job.
  *
  * <p>For a tutorial how to write a Flink streaming application, check the
- * tutorials and examples on the <a href="http://flink.apache.org/docs/stable/">Flink Website</a>.
+ * tutorials and examples on the <a href="https://flink.apache.org/docs/stable/">Flink Website</a>.
  *
  * <p>To package your application into a JAR file for execution, run
  * 'mvn clean package' on the command line.
@@ -54,7 +54,7 @@ public class StreamingJob {
 		 * and many more.
 		 * Have a look at the programming guide for the Java API:
 		 *
-		 * http://flink.apache.org/docs/latest/apis/streaming/index.html
+		 * https://flink.apache.org/docs/latest/apis/streaming/index.html
 		 *
 		 */
 

--- a/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/src/main/scala/BatchJob.scala
+++ b/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/src/main/scala/BatchJob.scala
@@ -24,7 +24,7 @@ import org.apache.flink.api.scala._
  * Skeleton for a Flink Batch Job.
  *
  * For a tutorial how to write a Flink batch application, check the
- * tutorials and examples on the <a href="http://flink.apache.org/docs/stable/">Flink Website</a>.
+ * tutorials and examples on the <a href="https://flink.apache.org/docs/stable/">Flink Website</a>.
  *
  * To package your application into a JAR file for execution,
  * change the main class in the POM.xml file to this class (simply search for 'mainClass')
@@ -52,11 +52,11 @@ object BatchJob {
      * and many more.
      * Have a look at the programming guide:
      *
-     * http://flink.apache.org/docs/latest/apis/batch/index.html
+     * https://flink.apache.org/docs/latest/apis/batch/index.html
      *
      * and the examples
      *
-     * http://flink.apache.org/docs/latest/apis/batch/examples.html
+     * https://flink.apache.org/docs/latest/apis/batch/examples.html
      *
      */
 

--- a/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/src/main/scala/StreamingJob.scala
+++ b/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/src/main/scala/StreamingJob.scala
@@ -24,7 +24,7 @@ import org.apache.flink.streaming.api.scala._
  * Skeleton for a Flink Streaming Job.
  *
  * For a tutorial how to write a Flink streaming application, check the
- * tutorials and examples on the <a href="http://flink.apache.org/docs/stable/">Flink Website</a>.
+ * tutorials and examples on the <a href="https://flink.apache.org/docs/stable/">Flink Website</a>.
  *
  * To package your application into a JAR file for execution, run
  * 'mvn clean package' on the command line.
@@ -53,7 +53,7 @@ object StreamingJob {
      * and many more.
      * Have a look at the programming guide:
      *
-     * http://flink.apache.org/docs/latest/apis/streaming/index.html
+     * https://flink.apache.org/docs/latest/apis/streaming/index.html
      *
      */
 

--- a/flink-runtime-web/README.md
+++ b/flink-runtime-web/README.md
@@ -34,7 +34,7 @@ that serves the new web pages and additional background requests.
 
 ## Server Backend
 
-The server side of the dashboard is implemented using [Netty](http://netty.io) with
+The server side of the dashboard is implemented using [Netty](https://netty.io) with
 [Netty Router](https://github.com/sinetja/netty-router) for REST paths.
 The framework has very lightweight dependencies.
 
@@ -62,7 +62,7 @@ Verify that the installed version is at least *10.9.0*, via `npm -version`.
 
 #### MacOS
 
-First install *brew* by following [these instructions](http://brew.sh/).
+First install *brew* by following [these instructions](https://brew.sh/).
 
 Install *node.js* via:
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,13 +32,13 @@ under the License.
 
 	<name>flink</name>
 	<packaging>pom</packaging>
-	<url>http://flink.apache.org</url>
+	<url>https://flink.apache.org</url>
 	<inceptionYear>2014</inceptionYear>
 
 	<licenses>
 		<license>
 			<name>The Apache Software License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
 			<distribution>repo</distribution>
 		</license>
 	</licenses>

--- a/tools/qa-check.sh
+++ b/tools/qa-check.sh
@@ -52,7 +52,7 @@ cd _qa_workdir
 
 if [ ! -d  "flink" ] ; then
 	echo "There is no flink copy in the workdir. Cloning flink"
-	git clone http://git-wip-us.apache.org/repos/asf/flink.git flink
+	git clone https://git-wip-us.apache.org/repos/asf/flink.git flink
 fi
 
 cd flink


### PR DESCRIPTION
Mirror of apache flink#8519
## What is the purpose of the change

This PR updates the documentation / examples to use HTTPS links instead of plain HTTP.

Additionally, some HTTP URLs in other parts (tools, maven, flink-python) have also been changed accordingly.
