### PR TITLE
Mirror of apache flink#8518

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartialConsumePipelinedResultTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartialConsumePipelinedResultTest.java
@@ -119,8 +119,7 @@ public class PartialConsumePipelinedResultTest extends TestLogger {
 			final ResultPartitionWriter writer = getEnvironment().getWriter(0);
 
 			for (int i = 0; i < 8; i++) {
-				final BufferBuilder bufferBuilder = writer.getBufferProvider().requestBufferBuilderBlocking();
-				writer.addBufferConsumer(bufferBuilder.createBufferConsumer(), 0);
+				BufferBuilder bufferBuilder = writer.requestBufferBuilder(0);
 				Thread.sleep(50);
 				bufferBuilder.finish();
 			}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -104,24 +104,18 @@ public class ResultPartitionTest {
 	 *
 	 * @param pipelined the result partition type to set up
 	 */
-	protected void testAddOnFinishedPartition(final ResultPartitionType pipelined)
-		throws Exception {
-		BufferConsumer bufferConsumer = createFilledBufferConsumer(BufferBuilderTestUtils.BUFFER_SIZE);
+	protected void testAddOnFinishedPartition(final ResultPartitionType pipelined) throws Exception {
 		ResultPartitionConsumableNotifier notifier = mock(ResultPartitionConsumableNotifier.class);
 		try {
 			ResultPartition partition = createPartition(notifier, pipelined, true);
 			partition.finish();
 			reset(notifier);
-			// partition.add() should fail
-			partition.addBufferConsumer(bufferConsumer, 0);
+			// partition.requestBufferBuilder() should fail
+			partition.requestBufferBuilder(0);
 			Assert.fail("exception expected");
 		} catch (IllegalStateException e) {
 			// expected => ignored
 		} finally {
-			if (!bufferConsumer.isRecycled()) {
-				bufferConsumer.close();
-				Assert.fail("bufferConsumer not recycled");
-			}
 			// should not have notified either
 			verify(notifier, never()).notifyPartitionConsumable(any(JobID.class), any(ResultPartitionID.class), any(TaskActions.class));
 		}


### PR DESCRIPTION
Mirror of apache flink#8518
## What is the purpose of the change

*`ResultPartitionWriter#getBufferProvider` seems not very general for all the writer implementations. So this method could be merged with `ResultPartitionWriter#addBufferConsumer` to refactor as `ResultPartitionWriter#requestBufferBuilder` which returns a `BufferBuilder` for writing data and the corresponding `BufferConsumer` is added into sub partition.*

## Brief change log

  - *Remove `getBufferProvider` from `ResultPartitionWriter`*
  - *Introduce `requestBufferBuilder` and `broadcastEvents` for `ResultPartitionWriter`*
  - *Refactor the process in `RecordWriter`*

## Verifying this change

covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
