### PR TITLE
Mirror of apache flink#8514

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogGenericMetadataTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogGenericMetadataTest.java
@@ -32,7 +32,6 @@ import org.apache.flink.table.catalog.GenericCatalogDatabase;
 import org.apache.flink.table.catalog.GenericCatalogFunction;
 import org.apache.flink.table.catalog.GenericCatalogTable;
 import org.apache.flink.table.catalog.GenericCatalogView;
-import org.apache.flink.table.catalog.exceptions.CatalogException;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -91,21 +90,6 @@ public class HiveCatalogGenericMetadataTest extends CatalogTestBase {
 		catalog.createTable(path1, table, false);
 
 		checkEquals(table, (CatalogTable) catalog.getTable(path1));
-	}
-
-	// ------ functions ------
-
-	@Test
-	public void testAlterFunction_differentTypedFunction() throws Exception {
-		catalog.createDatabase(db1, createDb(), false);
-		catalog.createFunction(path1, createFunction(), false);
-
-		exception.expect(CatalogException.class);
-		exception.expectMessage(
-			"Function types don't match. " +
-				"Existing function is 'org.apache.flink.table.catalog.GenericCatalogFunction' and " +
-				"new function is 'org.apache.flink.table.catalog.CatalogTestBase$TestFunction'.");
-		catalog.alterFunction(path1, new TestFunction(), false);
 	}
 
 	// ------ test utils ------

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
@@ -67,6 +67,9 @@ public class HiveCatalogHiveMetadataTest extends CatalogTestBase {
 	public void testAlterFunction() throws Exception {
 	}
 
+	public void testAlterFunction_differentTypedFunction() throws Exception {
+	}
+
 	public void testAlterFunction_FunctionNotExistException() throws Exception {
 	}
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
@@ -149,7 +149,16 @@ public class GenericInMemoryCatalog implements Catalog {
 		checkArgument(!StringUtils.isNullOrWhitespaceOnly(databaseName));
 		checkNotNull(newDatabase);
 
-		if (databaseExists(databaseName)) {
+		CatalogDatabase existingDatabase = databases.get(databaseName);
+
+		if (existingDatabase != null) {
+			if (existingDatabase.getClass() != newDatabase.getClass()) {
+				throw new CatalogException(
+					String.format("Database types don't match. Existing database is '%s' and new database is '%s'.",
+						existingDatabase.getClass().getName(), newDatabase.getClass().getName())
+				);
+			}
+
 			databases.put(databaseName, newDatabase.copy());
 		} else if (!ignoreIfNotExists) {
 			throw new DatabaseNotExistException(catalogName, databaseName);
@@ -212,13 +221,13 @@ public class GenericInMemoryCatalog implements Catalog {
 		checkNotNull(tablePath);
 		checkNotNull(newTable);
 
-		if (tableExists(tablePath)) {
-			CatalogBaseTable oldTable = tables.get(tablePath);
+		CatalogBaseTable existingTable = tables.get(tablePath);
 
-			if (oldTable.getClass() != newTable.getClass()) {
+		if (existingTable != null) {
+			if (existingTable.getClass() != newTable.getClass()) {
 				throw new CatalogException(
-					String.format("Table classes don't match. Existing table is '%s' and new table is '%s'. They should be of the same class.",
-						oldTable.getClass().getName(), newTable.getClass().getName()));
+					String.format("Table types don't match. Existing table is '%s' and new table is '%s'.",
+						existingTable.getClass().getName(), newTable.getClass().getName()));
 			}
 
 			tables.put(tablePath, newTable.copy());
@@ -362,7 +371,16 @@ public class GenericInMemoryCatalog implements Catalog {
 		checkNotNull(functionPath);
 		checkNotNull(newFunction);
 
-		if (functionExists(functionPath)) {
+		CatalogFunction existingFunction = functions.get(functionPath);
+
+		if (existingFunction != null) {
+			if (existingFunction.getClass() != newFunction.getClass()) {
+				throw new CatalogException(
+					String.format("Function types don't match. Existing function is '%s' and new function is '%s'.",
+						existingFunction.getClass().getName(), newFunction.getClass().getName())
+				);
+			}
+
 			functions.put(functionPath, newFunction.copy());
 		} else if (!ignoreIfNotExists) {
 			throw new FunctionNotExistException(catalogName, functionPath);
@@ -464,6 +482,15 @@ public class GenericInMemoryCatalog implements Catalog {
 		checkNotNull(newPartition);
 
 		if (partitionExists(tablePath, partitionSpec)) {
+			CatalogPartition existingPartition = partitions.get(tablePath).get(partitionSpec);
+
+			if (existingPartition.getClass() != newPartition.getClass()) {
+				throw new CatalogException(
+					String.format("Partition types don't match. Existing partition is '%s' and new partition is '%s'.",
+						existingPartition.getClass().getName(), newPartition.getClass().getName())
+				);
+			}
+
 			partitions.get(tablePath).put(partitionSpec, newPartition.copy());
 		} else if (!ignoreIfNotExists) {
 			throw new PartitionNotExistException(catalogName, tablePath, partitionSpec);

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
@@ -97,28 +97,6 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 		assertFalse(catalog.partitionExists(path1, catalogPartitionSpec));
 	}
 
-	@Test
-	public void testAlterTable_alterTableWithView() throws Exception {
-		catalog.createDatabase(db1, createDb(), false);
-		catalog.createTable(path1, createTable(), false);
-
-		exception.expect(CatalogException.class);
-		exception.expectMessage("Existing table is 'org.apache.flink.table.catalog.GenericCatalogTable' " +
-			"and new table is 'org.apache.flink.table.catalog.GenericCatalogView'. They should be of the same class.");
-		catalog.alterTable(path1, createView(), false);
-	}
-
-	@Test
-	public void testAlterTable_alterViewWithTable() throws Exception {
-		catalog.createDatabase(db1, createDb(), false);
-		catalog.createTable(path1, createView(), false);
-
-		exception.expect(CatalogException.class);
-		exception.expectMessage("Existing table is 'org.apache.flink.table.catalog.GenericCatalogView' " +
-			"and new table is 'org.apache.flink.table.catalog.GenericCatalogTable'. They should be of the same class.");
-		catalog.alterTable(path1, createTable(), false);
-	}
-
 	// ------ partitions ------
 
 	@Test
@@ -307,6 +285,24 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 		CatalogTestUtil.checkEquals(another, cp);
 
 		assertEquals("v", cp.getProperties().get("k"));
+	}
+
+	@Test
+	public void testAlterPartition_differentTypedPartition() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+		catalog.createTable(path1, createPartitionedTable(), false);
+
+		CatalogPartitionSpec partitionSpec = createPartitionSpec();
+		CatalogPartition partition = createPartition();
+		catalog.createPartition(path1, partitionSpec, partition, false);
+
+		exception.expect(CatalogException.class);
+		exception.expectMessage(
+			String.format("Partition types don't match. " +
+				"Existing partition is '%s' and " +
+				"new partition is 'org.apache.flink.table.catalog.CatalogTestBase$TestPartition'.",
+				partition.getClass().getName()));
+		catalog.alterPartition(path1, partitionSpec, new TestPartition(), false);
 	}
 
 	@Test

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
@@ -200,6 +200,19 @@ public abstract class CatalogTestBase {
 	}
 
 	@Test
+	public void testAlterDb_differentTypedDb() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+
+		exception.expect(CatalogException.class);
+		exception.expectMessage(
+			String.format("Database types don't match. " +
+					"Existing database is '%s' and " +
+					"new database is 'org.apache.flink.table.catalog.CatalogTestBase$TestDatabase'.",
+				createDb().getClass().getName()));
+		catalog.alterDatabase(db1, new TestDatabase(), false);
+	}
+
+	@Test
 	public void testAlterDb_DatabaseNotExistException() throws Exception {
 		exception.expect(DatabaseNotExistException.class);
 		exception.expectMessage("Database nonexistent does not exist in Catalog");
@@ -382,6 +395,22 @@ public abstract class CatalogTestBase {
 	}
 
 	@Test
+	public void testAlterTable_differentTypedTable() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+
+		CatalogTable table = createTable();
+		catalog.createTable(path1, table, false);
+
+		exception.expect(CatalogException.class);
+		exception.expectMessage(
+			String.format("Table types don't match. " +
+					"Existing table is '%s' and " +
+					"new table is 'org.apache.flink.table.catalog.CatalogTestBase$TestTable'.",
+				table.getClass().getName()));
+		catalog.alterTable(path1, new TestTable(), false);
+	}
+
+	@Test
 	public void testAlterTable_TableNotExistException() throws Exception {
 		exception.expect(TableNotExistException.class);
 		exception.expectMessage("Table (or view) non.exist does not exist in Catalog");
@@ -394,26 +423,6 @@ public abstract class CatalogTestBase {
 		catalog.alterTable(nonExistObjectPath, createTable(), true);
 
 		assertFalse(catalog.tableExists(nonExistObjectPath));
-	}
-
-	@Test
-	public void testAlterTable_alterTableWithView() throws Exception {
-		catalog.createDatabase(db1, createDb(), false);
-		catalog.createTable(path1, createTable(), false);
-
-		exception.expect(CatalogException.class);
-		exception.expectMessage("The existing table is a table, but the new catalog base table is not.");
-		catalog.alterTable(path1, createView(), false);
-	}
-
-	@Test
-	public void testAlterTable_alterViewWithTable() throws Exception {
-		catalog.createDatabase(db1, createDb(), false);
-		catalog.createTable(path1, createView(), false);
-
-		exception.expect(CatalogException.class);
-		exception.expectMessage("The existing table is a view, but the new catalog base table is not.");
-		catalog.alterTable(path1, createTable(), false);
 	}
 
 	@Test
@@ -656,6 +665,21 @@ public abstract class CatalogTestBase {
 	}
 
 	@Test
+	public void testAlterFunction_differentTypedFunction() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+		CatalogFunction function = createFunction();
+		catalog.createFunction(path1, createFunction(), false);
+
+		exception.expect(CatalogException.class);
+		exception.expectMessage(
+			String.format("Function types don't match. " +
+				"Existing function is '%s' and " +
+				"new function is 'org.apache.flink.table.catalog.CatalogTestBase$TestFunction'.",
+				function.getClass().getName()));
+		catalog.alterFunction(path1, new TestFunction(), false);
+	}
+
+	@Test
 	public void testAlterFunction_FunctionNotExistException() throws Exception {
 		exception.expect(FunctionNotExistException.class);
 		exception.expectMessage("Function db1.nonexist does not exist in Catalog");
@@ -861,6 +885,97 @@ public abstract class CatalogTestBase {
 	public static class MyOtherScalarFunction extends ScalarFunction {
 		public String eval(Integer i) {
 			return String.valueOf(i);
+		}
+	}
+
+	/**
+	 * Test database used to assert on database of different class.
+	 */
+	public static class TestDatabase implements CatalogDatabase {
+		@Override
+		public Map<String, String> getProperties() {
+			return null;
+		}
+
+		@Override
+		public String getComment() {
+			return null;
+		}
+
+		@Override
+		public CatalogDatabase copy() {
+			return null;
+		}
+
+		@Override
+		public Optional<String> getDescription() {
+			return Optional.empty();
+		}
+
+		@Override
+		public Optional<String> getDetailedDescription() {
+			return Optional.empty();
+		}
+	}
+
+	/**
+	 * Test table used to assert on table of different class.
+	 */
+	public static class TestTable implements CatalogBaseTable {
+
+		@Override
+		public Map<String, String> getProperties() {
+			return null;
+		}
+
+		@Override
+		public TableSchema getSchema() {
+			return null;
+		}
+
+		@Override
+		public String getComment() {
+			return null;
+		}
+
+		@Override
+		public CatalogBaseTable copy() {
+			return null;
+		}
+
+		@Override
+		public Optional<String> getDescription() {
+			return Optional.empty();
+		}
+
+		@Override
+		public Optional<String> getDetailedDescription() {
+			return Optional.empty();
+		}
+	}
+
+	/**
+	 * Test partition used to assert on partition of different class.
+	 */
+	public static class TestPartition implements CatalogPartition {
+		@Override
+		public Map<String, String> getProperties() {
+			return null;
+		}
+
+		@Override
+		public CatalogPartition copy() {
+			return null;
+		}
+
+		@Override
+		public Optional<String> getDescription() {
+			return Optional.empty();
+		}
+
+		@Override
+		public Optional<String> getDetailedDescription() {
+			return Optional.empty();
 		}
 	}
 


### PR DESCRIPTION
Mirror of apache flink#8514
## What is the purpose of the change

This PR supports alterations in catalogs to check existing object and new object are of the same class. 

Most of them currently don't, e.g. you can alter an existing generic table with a new hive table in GenericInMemoryCatalog.

## Brief change log

  - changed the following alteration API to check existing object and new object are of the same class
    - HiveCatalog: alterDatabase(), alterTable()
    - GenericInMemoryCatalog: alterDatabase(), alterTable(), alterFunction(),  alterPartition()

## Verifying this change

This change added tests and can be verified as follows:

added unit tests `testAlterDb_differentTypedDb()`, `testAlterTable_differentTypedTable()`, `testAlterFunction_differentTypedFunction()`  in `CatalogTestBase`, and `testAlterPartition_differentTypedPartition()` in `GenericInMemoryCatalogTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

