### PR TITLE
Mirror of apache flink#8511

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/Lockable.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/Lockable.java
@@ -68,10 +68,6 @@ public final class Lockable<T> {
 		return element;
 	}
 
-	public int getRefCounter() {
-		return refCounter;
-	}
-
 	@Override
 	public String toString() {
 		return "Lock{" +

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/Lockable.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/Lockable.java
@@ -68,6 +68,10 @@ public final class Lockable<T> {
 		return element;
 	}
 
+	public int getRefCounter() {
+		return refCounter;
+	}
+
 	@Override
 	public String toString() {
 		return "Lock{" +

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBufferAccessor.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBufferAccessor.java
@@ -247,9 +247,7 @@ public class SharedBufferAccessor<V> implements AutoCloseable {
 				break;
 			}
 
-			if (!curBufferNode.release()) {
-				sharedBuffer.upsertEntry(curNode, curBufferNode);
-			} else {
+			if (curBufferNode.release()) {
 				// first release the current node
 				sharedBuffer.removeEntry(curNode);
 				releaseEvent(curNode.getEventId());
@@ -260,6 +258,8 @@ public class SharedBufferAccessor<V> implements AutoCloseable {
 						nodesToExamine.push(targetId);
 					}
 				}
+			} else {
+				sharedBuffer.upsertEntry(curNode, curBufferNode);
 			}
 		}
 	}

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBufferTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBufferTest.java
@@ -280,4 +280,42 @@ public class SharedBufferTest extends TestLogger {
 		assertEquals(4, sharedBuffer.getSharedBufferNodeSize());
 	}
 
+	/**
+	 * Test releasing a node which has a long path to the terminal node (the node without an out-going edge).
+	 * @throws Exception if creating the shared buffer accessor fails.
+	 */
+	@Test
+	public void testReleaseNodesWithLongPath() throws Exception {
+		SharedBuffer<Event> sharedBuffer = TestSharedBuffer.createTestBuffer(Event.createTypeSerializer());
+
+		final int numberEvents = 100000;
+		Event[] events = new Event[numberEvents];
+		EventId[] eventIds = new EventId[numberEvents];
+		NodeId[] nodeIds = new NodeId[numberEvents];
+
+		final long timestamp = 1L;
+
+		for (int i = 0; i < numberEvents; i++) {
+			events[i] = new Event(i + 1, "e" + (i + 1), i);
+			eventIds[i] = sharedBuffer.registerEvent(events[i], timestamp);
+		}
+
+		try (SharedBufferAccessor<Event> sharedBufferAccessor = sharedBuffer.getAccessor()) {
+
+			for (int i = 0; i < numberEvents; i++) {
+				NodeId prevId = i == 0 ? null : nodeIds[i - 1];
+				nodeIds[i] = sharedBufferAccessor.put("n" + i, eventIds[i], prevId, DeweyNumber.fromString("1.0"));
+			}
+
+			NodeId lastNode = nodeIds[numberEvents - 1];
+			sharedBufferAccessor.releaseNode(lastNode);
+
+			for (int i = 0; i <numberEvents; i++) {
+				sharedBufferAccessor.releaseEvent(eventIds[i]);
+			}
+		}
+
+		assertTrue(sharedBuffer.isEmpty());
+	}
+
 }

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBufferTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBufferTest.java
@@ -310,7 +310,7 @@ public class SharedBufferTest extends TestLogger {
 			NodeId lastNode = nodeIds[numberEvents - 1];
 			sharedBufferAccessor.releaseNode(lastNode);
 
-			for (int i = 0; i <numberEvents; i++) {
+			for (int i = 0; i < numberEvents; i++) {
 				sharedBufferAccessor.releaseEvent(eventIds[i]);
 			}
 		}


### PR DESCRIPTION
Mirror of apache flink#8511
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Resolve issue FlINK-12319. The CEP job throws StackOverFlowError when releasing the nodes in the SharedBuffer. 

After investigation, it shows that the reason is that the logic for releasing nodes in the SharedBuffer is a recursive algorithm. The depth of the recursion depends on the diameter of the graph, which is proportional the number of buffered events (the graph is a line graph). 
In the experiments, the number of buffered events can be as many as 100,000, which will easily cause stack overflow.

Therefore, in this PR we change the logic from recursive to non-recursive. 


## Brief change log

  - Change the SharedAccessBuffer#releaseNode to a non-recursive algorithm.
  

## Verifying this change

This change is already covered by existing tests, such as SharedBufferTest#testSharedBuffer and SharedBufferTest#testClearingSharedBufferWithMultipleEdgesBetweenEntries.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

