### PR TITLE
Mirror of apache flink#8510

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/ApiExpressionUtils.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/ApiExpressionUtils.java
@@ -23,13 +23,11 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.typeutils.TimeIntervalTypeInfo;
 
 import java.util.Arrays;
 import java.util.Optional;
-
-import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.CAST;
-import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.TIMES;
 
 /**
  * Utilities for API-specific {@link Expression}s.
@@ -61,8 +59,8 @@ public final class ApiExpressionUtils {
 		return new ValueLiteralExpression(value, type);
 	}
 
-	public static TypeLiteralExpression typeLiteral(TypeInformation<?> type) {
-		return new TypeLiteralExpression(type);
+	public static TypeLiteralExpression typeLiteral(DataType dataType) {
+		return new TypeLiteralExpression(dataType);
 	}
 
 	public static SymbolExpression symbol(TableSymbol symbol) {
@@ -85,17 +83,7 @@ public final class ApiExpressionUtils {
 		// check for constant
 		return ExpressionUtils.extractValue(e, BasicTypeInfo.INT_TYPE_INFO)
 			.map((v) -> (Expression) valueLiteral(v * multiplier, TimeIntervalTypeInfo.INTERVAL_MONTHS))
-			.orElse(
-				call(
-					CAST,
-					call(
-						TIMES,
-						e,
-						valueLiteral(multiplier)
-					),
-					typeLiteral(TimeIntervalTypeInfo.INTERVAL_MONTHS)
-				)
-			);
+			.orElseThrow(() -> new ValidationException("Only constant intervals are supported: " + e));
 	}
 
 	public static Expression toMilliInterval(Expression e, long multiplier) {
@@ -110,15 +98,7 @@ public final class ApiExpressionUtils {
 		} else if (longInterval.isPresent()) {
 			return longInterval.get();
 		}
-		return call(
-			CAST,
-			call(
-				TIMES,
-				e,
-				valueLiteral(multiplier)
-			),
-			typeLiteral(TimeIntervalTypeInfo.INTERVAL_MONTHS)
-		);
+		throw new ValidationException("Only constant intervals are supported:" + e);
 	}
 
 	public static Expression toRowInterval(Expression e) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/TypeLiteralExpression.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/TypeLiteralExpression.java
@@ -19,8 +19,7 @@
 package org.apache.flink.table.expressions;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.table.utils.TypeStringUtils;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.Preconditions;
 
 import java.util.Collections;
@@ -28,19 +27,19 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Expression that wraps {@link TypeInformation} as a literal.
+ * Expression that wraps {@link DataType} as a literal.
  */
 @PublicEvolving
 public final class TypeLiteralExpression implements Expression {
 
-	private final TypeInformation<?> type;
+	private final DataType dataType;
 
-	public TypeLiteralExpression(TypeInformation<?> type) {
-		this.type = Preconditions.checkNotNull(type);
+	public TypeLiteralExpression(DataType dataType) {
+		this.dataType = Preconditions.checkNotNull(dataType, "Data type must not be null.");
 	}
 
-	public TypeInformation<?> getType() {
-		return type;
+	public DataType getDataType() {
+		return dataType;
 	}
 
 	@Override
@@ -62,16 +61,16 @@ public final class TypeLiteralExpression implements Expression {
 			return false;
 		}
 		TypeLiteralExpression that = (TypeLiteralExpression) o;
-		return Objects.equals(type, that.type);
+		return dataType.equals(that.dataType);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(type);
+		return Objects.hash(dataType);
 	}
 
 	@Override
 	public String toString() {
-		return TypeStringUtils.writeTypeInfo(type);
+		return dataType.toString();
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/ExpressionBuilder.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/ExpressionBuilder.java
@@ -41,6 +41,7 @@ import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.PLUS
 import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.REINTERPRET_CAST;
 import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.TIMES;
 import static org.apache.flink.table.expressions.InternalFunctionDefinitions.THROW_EXCEPTION;
+import static org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType;
 
 /**
  * Builder for {@link Expression}s.
@@ -130,7 +131,7 @@ public class ExpressionBuilder {
 	}
 
 	public static TypeLiteralExpression typeLiteral(TypeInformation<?> type) {
-		return new TypeLiteralExpression(type);
+		return new TypeLiteralExpression(fromLegacyInfoToDataType(type));
 	}
 
 	public static Expression concat(Expression input1, Expression input2) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/RexNodeConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/expressions/RexNodeConverter.java
@@ -48,6 +48,7 @@ import java.util.stream.Collectors;
 import static org.apache.calcite.sql.type.SqlTypeName.VARCHAR;
 import static org.apache.flink.table.calcite.FlinkTypeFactory.toInternalType;
 import static org.apache.flink.table.type.TypeConverters.createInternalTypeFromTypeInfo;
+import static org.apache.flink.table.types.utils.TypeConversions.fromDataTypeToLegacyInfo;
 import static org.apache.flink.table.typeutils.TypeCheckUtils.isString;
 import static org.apache.flink.table.typeutils.TypeCheckUtils.isTemporal;
 import static org.apache.flink.table.typeutils.TypeCheckUtils.isTimeInterval;
@@ -88,7 +89,8 @@ public class RexNodeConverter implements ExpressionVisitor<RexNode> {
 			TypeLiteralExpression type = (TypeLiteralExpression) call.getChildren().get(1);
 			return relBuilder.getRexBuilder().makeAbstractCast(
 					typeFactory.createTypeFromInternalType(
-							createInternalTypeFromTypeInfo(type.getType()),
+							createInternalTypeFromTypeInfo(
+								fromDataTypeToLegacyInfo(type.getDataType())),
 							child.getType().isNullable()),
 					child);
 		} else if (call.getFunctionDefinition().equals(BuiltInFunctionDefinitions.REINTERPRET_CAST)) {
@@ -97,7 +99,8 @@ public class RexNodeConverter implements ExpressionVisitor<RexNode> {
 			RexNode checkOverflow = call.getChildren().get(2).accept(this);
 			return relBuilder.getRexBuilder().makeReinterpretCast(
 					typeFactory.createTypeFromInternalType(
-							createInternalTypeFromTypeInfo(type.getType()),
+							createInternalTypeFromTypeInfo(
+								fromDataTypeToLegacyInfo(type.getDataType())),
 							child.getType().isNullable()),
 					child,
 					checkOverflow);

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/sources/TableSourceUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/sources/TableSourceUtil.scala
@@ -18,15 +18,6 @@
 
 package org.apache.flink.table.sources
 
-import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.api.common.typeutils.CompositeType
-import org.apache.flink.table.`type`.TypeConverters
-import org.apache.flink.table.api.{Types, ValidationException}
-import org.apache.flink.table.calcite.FlinkTypeFactory
-import org.apache.flink.table.`type`.InternalType
-import org.apache.flink.table.`type`.InternalTypes.{BYTE, PROCTIME_BATCH_MARKER, PROCTIME_INDICATOR, PROCTIME_STREAM_MARKER, ROWTIME_BATCH_MARKER, ROWTIME_INDICATOR, ROWTIME_STREAM_MARKER}
-import org.apache.flink.table.expressions.{BuiltInFunctionDefinitions, CallExpression, PlannerResolvedFieldReference, ResolvedFieldReference, RexNodeConverter, TypeLiteralExpression}
-
 import com.google.common.collect.ImmutableList
 import org.apache.calcite.plan.RelOptCluster
 import org.apache.calcite.rel.RelNode
@@ -34,6 +25,14 @@ import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.logical.LogicalValues
 import org.apache.calcite.rex.{RexLiteral, RexNode}
 import org.apache.calcite.tools.RelBuilder
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.common.typeutils.CompositeType
+import org.apache.flink.table.`type`.InternalTypes._
+import org.apache.flink.table.`type`.{InternalType, TypeConverters}
+import org.apache.flink.table.api.{Types, ValidationException}
+import org.apache.flink.table.calcite.FlinkTypeFactory
+import org.apache.flink.table.expressions._
+import org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType
 
 import scala.collection.JavaConversions._
 
@@ -277,7 +276,7 @@ object TableSourceUtil {
       // add cast to requested type and convert expression to RexNode
       val castExpression = new CallExpression(
         BuiltInFunctionDefinitions.CAST,
-        List(expression, new TypeLiteralExpression(resultType)))
+        List(expression, new TypeLiteralExpression(fromLegacyInfoToDataType(resultType))))
       val rexExpression = castExpression.accept(new RexNodeConverter(relBuilder))
       relBuilder.clear()
       rexExpression

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/sources/tsextractors/ExistingField.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/sources/tsextractors/ExistingField.scala
@@ -18,14 +18,15 @@
 
 package org.apache.flink.table.sources.tsextractors
 
+import java.util
+
 import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.table.`type`.DecimalType
 import org.apache.flink.table.api.{Types, ValidationException}
 import org.apache.flink.table.descriptors.Rowtime
 import org.apache.flink.table.expressions._
-import org.apache.flink.table.`type`.DecimalType
+import org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType
 import org.apache.flink.table.typeutils.DecimalTypeInfo
-
-import java.util
 
 import scala.collection.JavaConversions._
 
@@ -80,13 +81,17 @@ final class ExistingField(val field: String) extends TimestampExtractor {
         )
         new CallExpression(
           BuiltInFunctionDefinitions.CAST,
-          List(innerDiv, new TypeLiteralExpression(Types.SQL_TIMESTAMP)))
+          List(
+            innerDiv,
+            new TypeLiteralExpression(fromLegacyInfoToDataType(Types.SQL_TIMESTAMP))))
       case Types.SQL_TIMESTAMP =>
         fieldReferenceExpr
       case Types.STRING =>
         new CallExpression(
           BuiltInFunctionDefinitions.CAST,
-          List(fieldReferenceExpr, new TypeLiteralExpression(Types.SQL_TIMESTAMP)))
+          List(
+            fieldReferenceExpr,
+            new TypeLiteralExpression(fromLegacyInfoToDataType(Types.SQL_TIMESTAMP))))
     }
   }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/ResolveCallByArgumentsRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/rules/ResolveCallByArgumentsRule.java
@@ -36,6 +36,7 @@ import java.util.stream.IntStream;
 
 import static java.util.Arrays.asList;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.typeLiteral;
+import static org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType;
 import static org.apache.flink.table.util.JavaScalaConversionUtil.toJava;
 
 /**
@@ -108,7 +109,9 @@ final class ResolveCallByArgumentsRule implements ResolverRule {
 			} else if (TypeCoercion.canSafelyCast(actualType, expectedType)) {
 				return new CallExpression(
 					BuiltInFunctionDefinitions.CAST,
-					asList(childExpression, typeLiteral(expectedType))
+					asList(
+						childExpression,
+						typeLiteral(fromLegacyInfoToDataType(expectedType)))
 				);
 			} else {
 				throw new ValidationException(String.format("Incompatible type of argument: %s Expected: %s",

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionConverter.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionConverter.scala
@@ -21,6 +21,7 @@ package org.apache.flink.table.expressions
 import org.apache.flink.table.api.{TableException, ValidationException}
 import org.apache.flink.table.expressions.BuiltInFunctionDefinitions._
 import org.apache.flink.table.expressions.{E => PlannerE, UUID => PlannerUUID}
+import org.apache.flink.table.types.utils.TypeConversions.fromDataTypeToLegacyInfo
 
 import _root_.scala.collection.JavaConverters._
 
@@ -39,7 +40,7 @@ class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExp
         assert(children.size == 2)
         return Cast(
           children.head.accept(this),
-          children(1).asInstanceOf[TypeLiteralExpression].getType)
+          fromDataTypeToLegacyInfo(children(1).asInstanceOf[TypeLiteralExpression].getDataType))
 
       case WINDOW_START =>
         assert(children.size == 1)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionParserImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionParserImpl.scala
@@ -23,6 +23,7 @@ import _root_.java.util.{List => JList}
 import org.apache.flink.api.common.typeinfo.{SqlTimeTypeInfo, TypeInformation}
 import org.apache.flink.table.api._
 import org.apache.flink.table.expressions.ApiExpressionUtils._
+import org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType
 
 import _root_.scala.collection.JavaConversions._
 import _root_.scala.language.implicitConversions
@@ -260,7 +261,7 @@ object PlannerExpressionParserImpl extends JavaTokenParsers
   lazy val suffixCast: PackratParser[Expression] =
     composite ~ "." ~ CAST ~ "(" ~ dataType ~ ")" ^^ {
       case e ~ _ ~ _ ~ _ ~ dt ~ _ =>
-        call(BuiltInFunctionDefinitions.CAST, e, typeLiteral(dt))
+        call(BuiltInFunctionDefinitions.CAST, e, typeLiteral(fromLegacyInfoToDataType(dt)))
     }
 
   lazy val suffixTrim: PackratParser[Expression] =
@@ -331,17 +332,26 @@ object PlannerExpressionParserImpl extends JavaTokenParsers
 
   lazy val suffixToDate: PackratParser[Expression] =
     composite <~ "." ~ TO_DATE ~ opt("()") ^^ { e =>
-      call(BuiltInFunctionDefinitions.CAST, e, typeLiteral(SqlTimeTypeInfo.DATE))
+      call(
+        BuiltInFunctionDefinitions.CAST,
+        e,
+        typeLiteral(fromLegacyInfoToDataType(SqlTimeTypeInfo.DATE)))
     }
 
   lazy val suffixToTimestamp: PackratParser[Expression] =
     composite <~ "." ~ TO_TIMESTAMP ~ opt("()") ^^ { e =>
-      call(BuiltInFunctionDefinitions.CAST, e, typeLiteral(SqlTimeTypeInfo.TIMESTAMP))
+      call(
+        BuiltInFunctionDefinitions.CAST,
+        e,
+        typeLiteral(fromLegacyInfoToDataType(SqlTimeTypeInfo.TIMESTAMP)))
     }
 
   lazy val suffixToTime: PackratParser[Expression] =
     composite <~ "." ~ TO_TIME ~ opt("()") ^^ { e =>
-      call(BuiltInFunctionDefinitions.CAST, e, typeLiteral(SqlTimeTypeInfo.TIME))
+      call(
+        BuiltInFunctionDefinitions.CAST,
+        e,
+        typeLiteral(fromLegacyInfoToDataType(SqlTimeTypeInfo.TIME)))
     }
 
   lazy val suffixTimeInterval : PackratParser[Expression] =
@@ -420,7 +430,10 @@ object PlannerExpressionParserImpl extends JavaTokenParsers
   lazy val prefixCast: PackratParser[Expression] =
     CAST ~ "(" ~ expression ~ "," ~ dataType ~ ")" ^^ {
       case _ ~ _ ~ e ~ _ ~ dt ~ _ =>
-        call(BuiltInFunctionDefinitions.CAST, e, typeLiteral(dt))
+        call(
+          BuiltInFunctionDefinitions.CAST,
+          e,
+          typeLiteral(fromLegacyInfoToDataType(dt)))
     }
 
   lazy val prefixIf: PackratParser[Expression] =
@@ -500,17 +513,26 @@ object PlannerExpressionParserImpl extends JavaTokenParsers
 
   lazy val prefixToDate: PackratParser[Expression] =
     TO_DATE ~ "(" ~> expression <~ ")" ^^ { e =>
-      call(BuiltInFunctionDefinitions.CAST, e, typeLiteral(SqlTimeTypeInfo.DATE))
+      call(
+        BuiltInFunctionDefinitions.CAST,
+        e,
+        typeLiteral(fromLegacyInfoToDataType(SqlTimeTypeInfo.DATE)))
     }
 
   lazy val prefixToTimestamp: PackratParser[Expression] =
     TO_TIMESTAMP ~ "(" ~> expression <~ ")" ^^ { e =>
-      call(BuiltInFunctionDefinitions.CAST, e, typeLiteral(SqlTimeTypeInfo.TIMESTAMP))
+      call(
+        BuiltInFunctionDefinitions.CAST,
+        e,
+        typeLiteral(fromLegacyInfoToDataType(SqlTimeTypeInfo.TIMESTAMP)))
     }
 
   lazy val prefixToTime: PackratParser[Expression] =
     TO_TIME ~ "(" ~> expression <~ ")" ^^ { e =>
-      call(BuiltInFunctionDefinitions.CAST, e, typeLiteral(SqlTimeTypeInfo.TIME))
+      call(
+        BuiltInFunctionDefinitions.CAST,
+        e,
+        typeLiteral(fromLegacyInfoToDataType(SqlTimeTypeInfo.TIME)))
     }
 
   lazy val prefixDistinct: PackratParser[Expression] =


### PR DESCRIPTION
Mirror of apache flink#8510
## What is the purpose of the change

This PR updates `ImplicitExpressionOperations#cast` and `TypeLiteralExpression`. The Java expression API remains untouched for now.

This PR builds on top of #8500.

## Brief change log

- Deprecate old `cast()`
- Update `TypeLiteralExpression`
- Use legacy conversion where applicable

## Verifying this change

This change is already covered by existing tests.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs

