### PR TITLE
Mirror of apache flink#8529

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/TaskInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/TaskInfo.java
@@ -31,6 +31,7 @@ public class TaskInfo {
 
 	private final String taskName;
 	private final String taskNameWithSubtasks;
+	private final String taskNameWithSubtaskAndId;
 	private final String allocationIDAsString;
 	private final int maxNumberOfParallelSubtasks;
 	private final int indexOfSubtask;
@@ -45,6 +46,8 @@ public class TaskInfo {
 		int attemptNumber) {
 		this(
 			taskName,
+			taskName + " (" + (indexOfSubtask + 1) + '/' + numberOfParallelSubtasks + ')',
+			taskName + " (" + (indexOfSubtask + 1) + '/' + numberOfParallelSubtasks + ')',
 			maxNumberOfParallelSubtasks,
 			indexOfSubtask,
 			numberOfParallelSubtasks,
@@ -54,6 +57,8 @@ public class TaskInfo {
 
 	public TaskInfo(
 		String taskName,
+		String taskNameWithSubtasks,
+		String taskNameWithSubtaskAndId,
 		int maxNumberOfParallelSubtasks,
 		int indexOfSubtask,
 		int numberOfParallelSubtasks,
@@ -67,11 +72,12 @@ public class TaskInfo {
 		checkArgument(indexOfSubtask < numberOfParallelSubtasks, "Task index must be less than parallelism.");
 		checkArgument(attemptNumber >= 0, "Attempt number must be a non-negative number.");
 		this.taskName = checkNotNull(taskName, "Task Name must not be null.");
+		this.taskNameWithSubtasks = checkNotNull(taskNameWithSubtasks);
+		this.taskNameWithSubtaskAndId = checkNotNull(taskNameWithSubtaskAndId);
 		this.maxNumberOfParallelSubtasks = maxNumberOfParallelSubtasks;
 		this.indexOfSubtask = indexOfSubtask;
 		this.numberOfParallelSubtasks = numberOfParallelSubtasks;
 		this.attemptNumber = attemptNumber;
-		this.taskNameWithSubtasks = taskName + " (" + (indexOfSubtask + 1) + '/' + numberOfParallelSubtasks + ')';
 		this.allocationIDAsString = checkNotNull(allocationIDAsString);
 	}
 
@@ -130,6 +136,15 @@ public class TaskInfo {
 	 */
 	public String getTaskNameWithSubtasks() {
 		return this.taskNameWithSubtasks;
+	}
+
+	/**
+	 * Returns the name of the task, appended with the subtask indicator and execution attempt id.
+	 *
+	 * @return The name of the task, with subtask indicator and execution id.
+	 */
+	public String getTaskNameWithSubtaskAndId() {
+		return taskNameWithSubtaskAndId;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
@@ -96,8 +96,6 @@ public abstract class InputGate implements AutoCloseable {
 
 	public abstract void sendTaskEvent(TaskEvent event) throws IOException;
 
-	public abstract int getPageSize();
-
 	/**
 	 * @return a future that is completed if there are more records available. If there more records
 	 * available immediately, {@link #AVAILABLE} should be returned.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
@@ -76,8 +76,6 @@ public abstract class InputGate implements AutoCloseable {
 
 	public abstract int getNumberOfInputChannels();
 
-	public abstract String getOwningTaskName();
-
 	public abstract boolean isFinished();
 
 	public abstract void requestPartitions() throws IOException, InterruptedException;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -284,11 +284,6 @@ public class SingleInputGate extends InputGate {
 		return 0;
 	}
 
-	@Override
-	public String getOwningTaskName() {
-		return owningTaskName;
-	}
-
 	// ------------------------------------------------------------------------
 	// Setup/Life-cycle
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -254,16 +254,6 @@ public class SingleInputGate extends InputGate {
 		return bufferPool;
 	}
 
-	@Override
-	public int getPageSize() {
-		if (bufferPool != null) {
-			return bufferPool.getMemorySegmentSize();
-		}
-		else {
-			throw new IllegalStateException("Input gate has not been initialized with buffers.");
-		}
-	}
-
 	public int getNumberOfQueuedBuffers() {
 		// re-try 3 times, if fails, return 0 for "unknown"
 		for (int retry = 0; retry < 3; retry++) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
@@ -137,12 +137,6 @@ public class UnionInputGate extends InputGate {
 	}
 
 	@Override
-	public String getOwningTaskName() {
-		// all input gates have the same owning task
-		return inputGates[0].getOwningTaskName();
-	}
-
-	@Override
 	public boolean isFinished() {
 		for (InputGate inputGate : inputGates) {
 			if (!inputGate.isFinished()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
@@ -259,19 +259,6 @@ public class UnionInputGate extends InputGate {
 	}
 
 	@Override
-	public int getPageSize() {
-		int pageSize = -1;
-		for (InputGate gate : inputGates) {
-			if (pageSize == -1) {
-				pageSize = gate.getPageSize();
-			} else if (gate.getPageSize() != pageSize) {
-				throw new IllegalStateException("Found input gates with different page sizes.");
-			}
-		}
-		return pageSize;
-	}
-
-	@Override
 	public void setup() {
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -311,8 +311,13 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 		Preconditions.checkArgument(0 <= attemptNumber, "The attempt number must be positive.");
 		Preconditions.checkArgument(0 <= targetSlotNumber, "The target slot number must be positive.");
 
+		this.taskNameWithSubtask = taskInformation.getTaskName() +
+			" (" + (subtaskIndex + 1) + '/' + taskInformation.getNumberOfSubtasks() + ')';
+		final String taskNameWithSubtaskAndId = taskNameWithSubtask + " (" + executionAttemptID + ')';
 		this.taskInfo = new TaskInfo(
 				taskInformation.getTaskName(),
+				taskNameWithSubtask,
+				taskNameWithSubtaskAndId,
 				taskInformation.getMaxNumberOfSubtaks(),
 				subtaskIndex,
 				taskInformation.getNumberOfSubtasks(),
@@ -323,7 +328,6 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 		this.vertexId = taskInformation.getJobVertexId();
 		this.executionId  = Preconditions.checkNotNull(executionAttemptID);
 		this.allocationId = Preconditions.checkNotNull(slotAllocationId);
-		this.taskNameWithSubtask = taskInfo.getTaskNameWithSubtasks();
 		this.jobConfiguration = jobInformation.getJobConfiguration();
 		this.taskConfiguration = taskInformation.getTaskConfiguration();
 		this.requiredJarFiles = jobInformation.getRequiredJarFileBlobKeys();
@@ -359,8 +363,6 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 		this.executor = Preconditions.checkNotNull(executor);
 
 		// create the reader and writer structures
-
-		final String taskNameWithSubtaskAndId = taskNameWithSubtask + " (" + executionId + ')';
 
 		// add metrics for buffers
 		final MetricGroup buffersGroup = metrics.getIOMetricGroup().addGroup("buffers");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -598,7 +598,7 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 
 			LOG.info("Registering task at network: {}.", this);
 
-			setupPartionsAndGates(producedPartitions, inputGates);
+			setupPartitionsAndGates(producedPartitions, inputGates);
 
 			for (ResultPartition partition : producedPartitions) {
 				taskEventDispatcher.registerPartition(partition.getPartitionId());
@@ -828,7 +828,7 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 	}
 
 	@VisibleForTesting
-	public static void setupPartionsAndGates(
+	public static void setupPartitionsAndGates(
 		ResultPartitionWriter[] producedPartitions, InputGate[] inputGates) throws IOException {
 
 		for (ResultPartitionWriter partition : producedPartitions) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
@@ -64,7 +64,7 @@ public class NetworkEnvironmentTest {
 	public ExpectedException expectedException = ExpectedException.none();
 
 	/**
-	 * Verifies that {@link Task#setupPartionsAndGates(ResultPartitionWriter[], InputGate[])}} sets up (un)bounded buffer pool
+	 * Verifies that {@link Task#setupPartitionsAndGates(ResultPartitionWriter[], InputGate[])}} sets up (un)bounded buffer pool
 	 * instances for various types of input and output channels.
 	 */
 	@Test
@@ -87,7 +87,7 @@ public class NetworkEnvironmentTest {
 		SingleInputGate ig4 = createSingleInputGate(network, ResultPartitionType.PIPELINED_BOUNDED, 8);
 		final SingleInputGate[] inputGates = new SingleInputGate[] {ig1, ig2, ig3, ig4};
 
-		Task.setupPartionsAndGates(resultPartitions, inputGates);
+		Task.setupPartitionsAndGates(resultPartitions, inputGates);
 
 		// verify buffer pools for the result partitions
 		assertEquals(rp1.getNumberOfSubpartitions(), rp1.getBufferPool().getNumberOfRequiredMemorySegments());
@@ -128,7 +128,7 @@ public class NetworkEnvironmentTest {
 	}
 
 	/**
-	 * Verifies that {@link Task#setupPartionsAndGates(ResultPartitionWriter[], InputGate[])}} sets up (un)bounded buffer pool
+	 * Verifies that {@link Task#setupPartitionsAndGates(ResultPartitionWriter[], InputGate[])}} sets up (un)bounded buffer pool
 	 * instances for various types of input and output channels working with the bare minimum of
 	 * required buffers.
 	 */
@@ -148,7 +148,7 @@ public class NetworkEnvironmentTest {
 	}
 
 	/**
-	 * Verifies that {@link Task#setupPartionsAndGates(ResultPartitionWriter[], InputGate[])}} fails if the bare minimum of
+	 * Verifies that {@link Task#setupPartitionsAndGates(ResultPartitionWriter[], InputGate[])}} fails if the bare minimum of
 	 * required buffers is not available (we are one buffer short).
 	 */
 	@Test
@@ -208,7 +208,7 @@ public class NetworkEnvironmentTest {
 			createRemoteInputChannel(ig3, 3, rp4, connManager, network.getNetworkBufferPool());
 		}
 
-		Task.setupPartionsAndGates(resultPartitions, inputGates);
+		Task.setupPartitionsAndGates(resultPartitions, inputGates);
 
 		// verify buffer pools for the result partitions
 		assertEquals(Integer.MAX_VALUE, rp1.getBufferPool().getMaxNumberOfMemorySegments());
@@ -250,16 +250,16 @@ public class NetworkEnvironmentTest {
 
 	/**
 	 * Helper to create spy of a {@link SingleInputGate} for use by a {@link Task} inside
-	 * {@link Task#setupPartionsAndGates(ResultPartitionWriter[], InputGate[])}}.
+	 * {@link Task#setupPartitionsAndGates(ResultPartitionWriter[], InputGate[])}}.
 	 *
 	 * @param network
-	 * 	    network enviroment to create buffer pool factory for {@link SingleInputGate}
+	 * 	    network environment to create buffer pool factory for {@link SingleInputGate}
 	 * @param partitionType
 	 * 		the consumed partition type
 	 * @param numberOfChannels
 	 * 		the number of input channels
 	 *
-	 * @return input gate with some fake settiFngs
+	 * @return input gate with some fake settings
 	 */
 	private SingleInputGate createSingleInputGate(
 		NetworkEnvironment network, ResultPartitionType partitionType, int numberOfChannels) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierBuffer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierBuffer.java
@@ -79,6 +79,8 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 	 */
 	private final long maxBufferedBytes;
 
+	private final String taskName;
+
 	/**
 	 * The sequence of buffers/events that has been unblocked and must now be consumed before
 	 * requesting further data from the input gate.
@@ -122,8 +124,8 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 	 *
 	 * @throws IOException Thrown, when the spilling to temp files cannot be initialized.
 	 */
-	public BarrierBuffer(InputGate inputGate, BufferBlocker bufferBlocker) throws IOException {
-		this (inputGate, bufferBlocker, -1);
+	public BarrierBuffer(InputGate inputGate, BufferBlocker bufferBlocker) {
+		this (inputGate, bufferBlocker, -1, "");
 	}
 
 	/**
@@ -139,8 +141,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 	 *
 	 * @throws IOException Thrown, when the spilling to temp files cannot be initialized.
 	 */
-	public BarrierBuffer(InputGate inputGate, BufferBlocker bufferBlocker, long maxBufferedBytes)
-			throws IOException {
+	public BarrierBuffer(InputGate inputGate, BufferBlocker bufferBlocker, long maxBufferedBytes, String taskName) {
 		checkArgument(maxBufferedBytes == -1 || maxBufferedBytes > 0);
 
 		this.inputGate = inputGate;
@@ -150,6 +151,8 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 
 		this.bufferBlocker = checkNotNull(bufferBlocker);
 		this.queuedBuffered = new ArrayDeque<BufferOrEventSequence>();
+
+		this.taskName = taskName;
 	}
 
 	// ------------------------------------------------------------------------
@@ -213,7 +216,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 	}
 
 	private void completeBufferedSequence() throws IOException {
-		LOG.debug("{}: Finished feeding back buffered data.", inputGate.getOwningTaskName());
+		LOG.debug("{}: Finished feeding back buffered data.", taskName);
 
 		currentBuffered.cleanup();
 		currentBuffered = queuedBuffered.pollFirst();
@@ -249,7 +252,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 				// we did not complete the current checkpoint, another started before
 				LOG.warn("{}: Received checkpoint barrier for checkpoint {} before completing current checkpoint {}. " +
 						"Skipping current checkpoint.",
-					inputGate.getOwningTaskName(),
+					taskName,
 					barrierId,
 					currentCheckpointId);
 
@@ -283,7 +286,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 			// actually trigger checkpoint
 			if (LOG.isDebugEnabled()) {
 				LOG.debug("{}: Received all barriers, triggering checkpoint {} at {}.",
-					inputGate.getOwningTaskName(),
+					taskName,
 					receivedBarrier.getId(),
 					receivedBarrier.getTimestamp());
 			}
@@ -314,9 +317,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 			if (barrierId == currentCheckpointId) {
 				// cancel this alignment
 				if (LOG.isDebugEnabled()) {
-					LOG.debug("{}: Checkpoint {} canceled, aborting alignment.",
-						inputGate.getOwningTaskName(),
-						barrierId);
+					LOG.debug("{}: Checkpoint {} canceled, aborting alignment.", taskName, barrierId);
 				}
 
 				releaseBlocksAndResetBarriers();
@@ -326,7 +327,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 				// we canceled the next which also cancels the current
 				LOG.warn("{}: Received cancellation barrier for checkpoint {} before completing current checkpoint {}. " +
 						"Skipping current checkpoint.",
-					inputGate.getOwningTaskName(),
+					taskName,
 					barrierId,
 					currentCheckpointId);
 
@@ -357,9 +358,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 			latestAlignmentDurationNanos = 0L;
 
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("{}: Checkpoint {} canceled, skipping alignment.",
-					inputGate.getOwningTaskName(),
-					barrierId);
+				LOG.debug("{}: Checkpoint {} canceled, skipping alignment.", taskName, barrierId);
 			}
 
 			notifyAbortOnCancellationBarrier(barrierId);
@@ -414,7 +413,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 		if (maxBufferedBytes > 0 && (numQueuedBytes + bufferBlocker.getBytesBlocked()) > maxBufferedBytes) {
 			// exceeded our limit - abort this checkpoint
 			LOG.info("{}: Checkpoint {} aborted because alignment volume limit ({} bytes) exceeded.",
-				inputGate.getOwningTaskName(),
+				taskName,
 				currentCheckpointId,
 				maxBufferedBytes);
 
@@ -458,9 +457,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 		startOfAlignmentTimestamp = System.nanoTime();
 
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("{}: Starting stream alignment for checkpoint {}.",
-				inputGate.getOwningTaskName(),
-				checkpointId);
+			LOG.debug("{}: Starting stream alignment for checkpoint {}.", taskName, checkpointId);
 		}
 	}
 
@@ -486,9 +483,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 			numBarriersReceived++;
 
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("{}: Received barrier from channel {}.",
-					inputGate.getOwningTaskName(),
-					channelIndex);
+				LOG.debug("{}: Received barrier from channel {}.", taskName, channelIndex);
 			}
 		}
 		else {
@@ -501,8 +496,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 	 * Makes sure the just written data is the next to be consumed.
 	 */
 	private void releaseBlocksAndResetBarriers() throws IOException {
-		LOG.debug("{}: End of stream alignment, feeding buffered data back.",
-			inputGate.getOwningTaskName());
+		LOG.debug("{}: End of stream alignment, feeding buffered data back.", taskName);
 
 		for (int i = 0; i < blockedChannels.length; i++) {
 			blockedChannels[i] = false;
@@ -519,8 +513,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 			// uncommon case: buffered data pending
 			// push back the pending data, if we have any
 			LOG.debug("{}: Checkpoint skipped via buffered data:" +
-					"Pushing back current alignment buffers and feeding back new alignment data first.",
-				inputGate.getOwningTaskName());
+					"Pushing back current alignment buffers and feeding back new alignment data first.", taskName);
 
 			// since we did not fully drain the previous sequence, we need to allocate a new buffer for this one
 			BufferOrEventSequence bufferedNow = bufferBlocker.rollOverWithoutReusingResources();
@@ -534,7 +527,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("{}: Size of buffered data: {} bytes",
-				inputGate.getOwningTaskName(),
+				taskName,
 				currentBuffered == null ? 0L : currentBuffered.size());
 		}
 
@@ -577,7 +570,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 	@Override
 	public String toString() {
 		return String.format("%s: last checkpoint: %d, current barriers: %d, closed channels: %d",
-			inputGate.getOwningTaskName(),
+			taskName,
 			currentCheckpointId,
 			numBarriersReceived,
 			numClosedChannels);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
@@ -41,7 +41,8 @@ public class InputProcessorUtil {
 			CheckpointingMode checkpointMode,
 			IOManager ioManager,
 			InputGate inputGate,
-			Configuration taskManagerConfig) throws IOException {
+			Configuration taskManagerConfig,
+			String taskName) throws IOException {
 
 		CheckpointBarrierHandler barrierHandler;
 		if (checkpointMode == CheckpointingMode.EXACTLY_ONCE) {
@@ -53,9 +54,11 @@ public class InputProcessorUtil {
 			}
 
 			if (taskManagerConfig.getBoolean(NetworkEnvironmentOptions.NETWORK_CREDIT_MODEL)) {
-				barrierHandler = new BarrierBuffer(inputGate, new CachedBufferBlocker(inputGate.getPageSize()), maxAlign);
+				barrierHandler = new BarrierBuffer(
+					inputGate, new CachedBufferBlocker(inputGate.getPageSize()), maxAlign, taskName);
 			} else {
-				barrierHandler = new BarrierBuffer(inputGate, new BufferSpiller(ioManager, inputGate.getPageSize()), maxAlign);
+				barrierHandler = new BarrierBuffer(
+					inputGate, new BufferSpiller(ioManager, inputGate.getPageSize()), maxAlign, taskName);
 			}
 		} else if (checkpointMode == CheckpointingMode.AT_LEAST_ONCE) {
 			barrierHandler = new BarrierTracker(inputGate);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.NetworkEnvironmentOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfiguration;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 
@@ -53,12 +54,13 @@ public class InputProcessorUtil {
 					+ " must be positive or -1 (infinite)");
 			}
 
+			int pageSize = NetworkEnvironmentConfiguration.getPageSize(taskManagerConfig);
 			if (taskManagerConfig.getBoolean(NetworkEnvironmentOptions.NETWORK_CREDIT_MODEL)) {
 				barrierHandler = new BarrierBuffer(
-					inputGate, new CachedBufferBlocker(inputGate.getPageSize()), maxAlign, taskName);
+					inputGate, new CachedBufferBlocker(pageSize), maxAlign, taskName);
 			} else {
 				barrierHandler = new BarrierBuffer(
-					inputGate, new BufferSpiller(ioManager, inputGate.getPageSize()), maxAlign, taskName);
+					inputGate, new BufferSpiller(ioManager, pageSize), maxAlign, taskName);
 			}
 		} else if (checkpointMode == CheckpointingMode.AT_LEAST_ONCE) {
 			barrierHandler = new BarrierTracker(inputGate);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
@@ -121,12 +121,13 @@ public class StreamInputProcessor<IN> {
 			StreamStatusMaintainer streamStatusMaintainer,
 			OneInputStreamOperator<IN, ?> streamOperator,
 			TaskIOMetricGroup metrics,
-			WatermarkGauge watermarkGauge) throws IOException {
+			WatermarkGauge watermarkGauge,
+			String taskName) throws IOException {
 
 		InputGate inputGate = InputGateUtil.createInputGate(inputGates);
 
 		this.barrierHandler = InputProcessorUtil.createCheckpointBarrierHandler(
-			checkpointedTask, checkpointMode, ioManager, inputGate, taskManagerConfig);
+			checkpointedTask, checkpointMode, ioManager, inputGate, taskManagerConfig, taskName);
 
 		this.lock = checkNotNull(lock);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
@@ -140,12 +140,13 @@ public class StreamTwoInputProcessor<IN1, IN2> {
 			TwoInputStreamOperator<IN1, IN2, ?> streamOperator,
 			TaskIOMetricGroup metrics,
 			WatermarkGauge input1WatermarkGauge,
-			WatermarkGauge input2WatermarkGauge) throws IOException {
+			WatermarkGauge input2WatermarkGauge,
+			String taskName) throws IOException {
 
 		final InputGate inputGate = InputGateUtil.createInputGate(inputGates1, inputGates2);
 
 		this.barrierHandler = InputProcessorUtil.createCheckpointBarrierHandler(
-			checkpointedTask, checkpointMode, ioManager, inputGate, taskManagerConfig);
+			checkpointedTask, checkpointMode, ioManager, inputGate, taskManagerConfig, taskName);
 
 		this.lock = checkNotNull(lock);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -88,7 +88,8 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 					getStreamStatusMaintainer(),
 					this.headOperator,
 					getEnvironment().getMetricGroup().getIOMetricGroup(),
-					inputWatermarkGauge);
+					inputWatermarkGauge,
+					getEnvironment().getTaskInfo().getTaskNameWithSubtaskAndId());
 		}
 		headOperator.getMetricGroup().gauge(MetricNames.IO_CURRENT_INPUT_WATERMARK, this.inputWatermarkGauge);
 		// wrap watermark gauge since registered metrics must be unique

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
@@ -98,7 +98,8 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends StreamTask<OUT, TwoInputS
 				this.headOperator,
 				getEnvironment().getMetricGroup().getIOMetricGroup(),
 				input1WatermarkGauge,
-				input2WatermarkGauge);
+				input2WatermarkGauge,
+				getEnvironment().getTaskInfo().getTaskNameWithSubtaskAndId());
 
 		headOperator.getMetricGroup().gauge(MetricNames.IO_CURRENT_INPUT_WATERMARK, minInputWatermarkGauge);
 		headOperator.getMetricGroup().gauge(MetricNames.IO_CURRENT_INPUT_1_WATERMARK, input1WatermarkGauge);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferAlignmentLimitTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferAlignmentLimitTest.java
@@ -115,7 +115,7 @@ public class BarrierBufferAlignmentLimitTest {
 
 		// the barrier buffer has a limit that only 1000 bytes may be spilled in alignment
 		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
-		BarrierBuffer buffer = new BarrierBuffer(gate, new BufferSpiller(ioManager, gate.getPageSize()), 1000);
+		BarrierBuffer buffer = new BarrierBuffer(gate, new BufferSpiller(ioManager, gate.getPageSize()), 1000, "");
 
 		AbstractInvokable toNotify = mock(AbstractInvokable.class);
 		buffer.registerCheckpointEventHandler(toNotify);
@@ -209,7 +209,7 @@ public class BarrierBufferAlignmentLimitTest {
 
 		// the barrier buffer has a limit that only 1000 bytes may be spilled in alignment
 		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
-		BarrierBuffer buffer = new BarrierBuffer(gate, new BufferSpiller(ioManager, gate.getPageSize()), 500);
+		BarrierBuffer buffer = new BarrierBuffer(gate, new BufferSpiller(ioManager, gate.getPageSize()), 500, "");
 
 		AbstractInvokable toNotify = mock(AbstractInvokable.class);
 		buffer.registerCheckpointEventHandler(toNotify);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferAlignmentLimitTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferAlignmentLimitTest.java
@@ -114,8 +114,8 @@ public class BarrierBufferAlignmentLimitTest {
 		};
 
 		// the barrier buffer has a limit that only 1000 bytes may be spilled in alignment
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
-		BarrierBuffer buffer = new BarrierBuffer(gate, new BufferSpiller(ioManager, gate.getPageSize()), 1000, "");
+		MockInputGate gate = new MockInputGate(3, Arrays.asList(sequence));
+		BarrierBuffer buffer = new BarrierBuffer(gate, new BufferSpiller(ioManager, PAGE_SIZE), 1000, "");
 
 		AbstractInvokable toNotify = mock(AbstractInvokable.class);
 		buffer.registerCheckpointEventHandler(toNotify);
@@ -208,8 +208,8 @@ public class BarrierBufferAlignmentLimitTest {
 		};
 
 		// the barrier buffer has a limit that only 1000 bytes may be spilled in alignment
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
-		BarrierBuffer buffer = new BarrierBuffer(gate, new BufferSpiller(ioManager, gate.getPageSize()), 500, "");
+		MockInputGate gate = new MockInputGate(3, Arrays.asList(sequence));
+		BarrierBuffer buffer = new BarrierBuffer(gate, new BufferSpiller(ioManager, PAGE_SIZE), 500, "");
 
 		AbstractInvokable toNotify = mock(AbstractInvokable.class);
 		buffer.registerCheckpointEventHandler(toNotify);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferMassiveRandomTest.java
@@ -138,29 +138,17 @@ public class BarrierBufferMassiveRandomTest {
 		private int currentChannel = 0;
 		private long c = 0;
 
-		private final String owningTaskName;
-
 		public RandomGeneratingInputGate(BufferPool[] bufferPools, BarrierGenerator[] barrierGens) {
-			this(bufferPools, barrierGens, "TestTask");
-		}
-
-		public RandomGeneratingInputGate(BufferPool[] bufferPools, BarrierGenerator[] barrierGens, String owningTaskName) {
 			this.numberOfChannels = bufferPools.length;
 			this.currentBarriers = new int[numberOfChannels];
 			this.bufferPools = bufferPools;
 			this.barrierGens = barrierGens;
-			this.owningTaskName = owningTaskName;
 			this.isAvailable = AVAILABLE;
 		}
 
 		@Override
 		public int getNumberOfInputChannels() {
 			return numberOfChannels;
-		}
-
-		@Override
-		public String getOwningTaskName() {
-			return owningTaskName;
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferMassiveRandomTest.java
@@ -62,7 +62,7 @@ public class BarrierBufferMassiveRandomTest {
 					new BufferPool[] { pool1, pool2 },
 					new BarrierGenerator[] { new CountBarrier(100000), new RandomBarrier(100000) });
 
-			BarrierBuffer barrierBuffer = new BarrierBuffer(myIG, new BufferSpiller(ioMan, myIG.getPageSize()));
+			BarrierBuffer barrierBuffer = new BarrierBuffer(myIG, new BufferSpiller(ioMan, PAGE_SIZE));
 
 			for (int i = 0; i < 2000000; i++) {
 				BufferOrEvent boe = barrierBuffer.getNextNonBlocked();
@@ -185,11 +185,6 @@ public class BarrierBufferMassiveRandomTest {
 
 		@Override
 		public void sendTaskEvent(TaskEvent event) {}
-
-		@Override
-		public int getPageSize() {
-			return PAGE_SIZE;
-		}
 
 		@Override
 		public void setup() {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferTestBase.java
@@ -88,7 +88,7 @@ public abstract class BarrierBufferTestBase {
 			createBuffer(0, PAGE_SIZE), createEndOfPartition(0)
 		};
 
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, 1, Arrays.asList(sequence));
+		MockInputGate gate = new MockInputGate(1, Arrays.asList(sequence));
 		BarrierBuffer buffer = createBarrierHandler(gate);
 
 		for (BufferOrEvent boe : sequence) {
@@ -116,7 +116,7 @@ public abstract class BarrierBufferTestBase {
 			createBuffer(1, PAGE_SIZE), createEndOfPartition(1), createBuffer(2, PAGE_SIZE), createEndOfPartition(2)
 		};
 
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, 4, Arrays.asList(sequence));
+		MockInputGate gate = new MockInputGate(4, Arrays.asList(sequence));
 		BarrierBuffer buffer = createBarrierHandler(gate);
 
 		for (BufferOrEvent boe : sequence) {
@@ -147,7 +147,7 @@ public abstract class BarrierBufferTestBase {
 			createBuffer(0, PAGE_SIZE), createEndOfPartition(0)
 		};
 
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, 1, Arrays.asList(sequence));
+		MockInputGate gate = new MockInputGate(1, Arrays.asList(sequence));
 		BarrierBuffer buffer = createBarrierHandler(gate);
 
 		ValidatingCheckpointHandler handler = new ValidatingCheckpointHandler();
@@ -205,7 +205,7 @@ public abstract class BarrierBufferTestBase {
 			createEndOfPartition(0), createEndOfPartition(1), createEndOfPartition(2)
 		};
 
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+		MockInputGate gate = new MockInputGate(3, Arrays.asList(sequence));
 		BarrierBuffer buffer = createBarrierHandler(gate);
 
 		ValidatingCheckpointHandler handler = new ValidatingCheckpointHandler();
@@ -306,7 +306,7 @@ public abstract class BarrierBufferTestBase {
 			createBuffer(2, PAGE_SIZE), createEndOfPartition(2), createBuffer(0, PAGE_SIZE), createEndOfPartition(0)
 		};
 
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+		MockInputGate gate = new MockInputGate(3, Arrays.asList(sequence));
 		BarrierBuffer buffer = createBarrierHandler(gate);
 
 		ValidatingCheckpointHandler handler = new ValidatingCheckpointHandler();
@@ -389,7 +389,7 @@ public abstract class BarrierBufferTestBase {
 			createBuffer(0, PAGE_SIZE), createEndOfPartition(0)
 		};
 
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+		MockInputGate gate = new MockInputGate(3, Arrays.asList(sequence));
 		BarrierBuffer buffer = createBarrierHandler(gate);
 
 		ValidatingCheckpointHandler handler = new ValidatingCheckpointHandler();
@@ -489,7 +489,7 @@ public abstract class BarrierBufferTestBase {
 			createBuffer(0, PAGE_SIZE), createEndOfPartition(0)
 		};
 
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+		MockInputGate gate = new MockInputGate(3, Arrays.asList(sequence));
 		BarrierBuffer buffer = createBarrierHandler(gate);
 
 		AbstractInvokable toNotify = mock(AbstractInvokable.class);
@@ -581,7 +581,7 @@ public abstract class BarrierBufferTestBase {
 			createBuffer(0, PAGE_SIZE), createEndOfPartition(0)
 		};
 
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+		MockInputGate gate = new MockInputGate(3, Arrays.asList(sequence));
 		BarrierBuffer buffer = createBarrierHandler(gate);
 
 		ValidatingCheckpointHandler handler = new ValidatingCheckpointHandler();
@@ -678,7 +678,7 @@ public abstract class BarrierBufferTestBase {
 			createBuffer(0, PAGE_SIZE), createEndOfPartition(0)
 		};
 
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+		MockInputGate gate = new MockInputGate(3, Arrays.asList(sequence));
 		BarrierBuffer buffer = createBarrierHandler(gate);
 
 		// checkpoint 1
@@ -741,7 +741,7 @@ public abstract class BarrierBufferTestBase {
 			createBuffer(2, PAGE_SIZE), createEndOfPartition(2), createBuffer(0, PAGE_SIZE), createEndOfPartition(0)
 		};
 
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+		MockInputGate gate = new MockInputGate(3, Arrays.asList(sequence));
 		BarrierBuffer buffer = createBarrierHandler(gate);
 
 		ValidatingCheckpointHandler handler = new ValidatingCheckpointHandler();
@@ -801,7 +801,7 @@ public abstract class BarrierBufferTestBase {
 			createEndOfPartition(3)
 		};
 
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, 4, Arrays.asList(sequence));
+		MockInputGate gate = new MockInputGate(4, Arrays.asList(sequence));
 
 		BarrierBuffer buffer = createBarrierHandler(gate);
 
@@ -861,7 +861,7 @@ public abstract class BarrierBufferTestBase {
 			createEndOfPartition(0)
 		};
 
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+		MockInputGate gate = new MockInputGate(3, Arrays.asList(sequence));
 		BarrierBuffer buffer = createBarrierHandler(gate);
 
 		// data after first checkpoint
@@ -903,7 +903,7 @@ public abstract class BarrierBufferTestBase {
 			createBuffer(0, PAGE_SIZE)
 		};
 
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, 1, Arrays.asList(sequence));
+		MockInputGate gate = new MockInputGate(1, Arrays.asList(sequence));
 		BarrierBuffer buffer = createBarrierHandler(gate);
 
 		AbstractInvokable toNotify = mock(AbstractInvokable.class);
@@ -966,7 +966,7 @@ public abstract class BarrierBufferTestBase {
 			/* 37 */ createBuffer(0, PAGE_SIZE)
 		};
 
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+		MockInputGate gate = new MockInputGate(3, Arrays.asList(sequence));
 		BarrierBuffer buffer = createBarrierHandler(gate);
 
 		AbstractInvokable toNotify = mock(AbstractInvokable.class);
@@ -1059,7 +1059,7 @@ public abstract class BarrierBufferTestBase {
 			/* 16 */ createBuffer(0, PAGE_SIZE), createBuffer(1, PAGE_SIZE), createBuffer(2, PAGE_SIZE)
 		};
 
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+		MockInputGate gate = new MockInputGate(3, Arrays.asList(sequence));
 		BarrierBuffer buffer = createBarrierHandler(gate);
 
 		AbstractInvokable toNotify = mock(AbstractInvokable.class);
@@ -1149,7 +1149,7 @@ public abstract class BarrierBufferTestBase {
 			/* 18 */ createBuffer(0, PAGE_SIZE), createBuffer(1, PAGE_SIZE), createBuffer(2, PAGE_SIZE)
 		};
 
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+		MockInputGate gate = new MockInputGate(3, Arrays.asList(sequence));
 		BarrierBuffer buffer = createBarrierHandler(gate);
 
 		AbstractInvokable toNotify = mock(AbstractInvokable.class);
@@ -1233,7 +1233,7 @@ public abstract class BarrierBufferTestBase {
 			/* 16 */ createBuffer(0, PAGE_SIZE), createBuffer(1, PAGE_SIZE), createBuffer(2, PAGE_SIZE)
 		};
 
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+		MockInputGate gate = new MockInputGate(3, Arrays.asList(sequence));
 		BarrierBuffer buffer = createBarrierHandler(gate);
 
 		AbstractInvokable toNotify = mock(AbstractInvokable.class);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierTrackerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierTrackerTest.java
@@ -49,14 +49,12 @@ import static org.mockito.Mockito.verify;
  */
 public class BarrierTrackerTest {
 
-	private static final int PAGE_SIZE = 512;
-
 	@Test
 	public void testSingleChannelNoBarriers() {
 		try {
 			BufferOrEvent[] sequence = { createBuffer(0), createBuffer(0), createBuffer(0) };
 
-			MockInputGate gate = new MockInputGate(PAGE_SIZE, 1, Arrays.asList(sequence));
+			MockInputGate gate = new MockInputGate(1, Arrays.asList(sequence));
 			BarrierTracker tracker = new BarrierTracker(gate);
 
 			for (BufferOrEvent boe : sequence) {
@@ -80,7 +78,7 @@ public class BarrierTrackerTest {
 					createBuffer(1), createBuffer(1), createBuffer(2)
 			};
 
-			MockInputGate gate = new MockInputGate(PAGE_SIZE, 4, Arrays.asList(sequence));
+			MockInputGate gate = new MockInputGate(4, Arrays.asList(sequence));
 			BarrierTracker tracker = new BarrierTracker(gate);
 
 			for (BufferOrEvent boe : sequence) {
@@ -109,7 +107,7 @@ public class BarrierTrackerTest {
 					createBuffer(0)
 			};
 
-			MockInputGate gate = new MockInputGate(PAGE_SIZE, 1, Arrays.asList(sequence));
+			MockInputGate gate = new MockInputGate(1, Arrays.asList(sequence));
 			BarrierTracker tracker = new BarrierTracker(gate);
 
 			CheckpointSequenceValidator validator =
@@ -144,7 +142,7 @@ public class BarrierTrackerTest {
 					createBuffer(0)
 			};
 
-			MockInputGate gate = new MockInputGate(PAGE_SIZE, 1, Arrays.asList(sequence));
+			MockInputGate gate = new MockInputGate(1, Arrays.asList(sequence));
 			BarrierTracker tracker = new BarrierTracker(gate);
 
 			CheckpointSequenceValidator validator =
@@ -188,7 +186,7 @@ public class BarrierTrackerTest {
 					createBuffer(0)
 			};
 
-			MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+			MockInputGate gate = new MockInputGate(3, Arrays.asList(sequence));
 			BarrierTracker tracker = new BarrierTracker(gate);
 
 			CheckpointSequenceValidator validator =
@@ -236,7 +234,7 @@ public class BarrierTrackerTest {
 					createBuffer(0)
 			};
 
-			MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+			MockInputGate gate = new MockInputGate(3, Arrays.asList(sequence));
 			BarrierTracker tracker = new BarrierTracker(gate);
 
 			CheckpointSequenceValidator validator =
@@ -320,7 +318,7 @@ public class BarrierTrackerTest {
 					createBuffer(1), createBuffer(0), createBuffer(2)
 			};
 
-			MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+			MockInputGate gate = new MockInputGate(3, Arrays.asList(sequence));
 			BarrierTracker tracker = new BarrierTracker(gate);
 
 			CheckpointSequenceValidator validator =
@@ -356,7 +354,7 @@ public class BarrierTrackerTest {
 				createBuffer(0)
 		};
 
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, 1, Arrays.asList(sequence));
+		MockInputGate gate = new MockInputGate(1, Arrays.asList(sequence));
 		BarrierTracker tracker = new BarrierTracker(gate);
 
 		// negative values mean an expected cancellation call!
@@ -412,7 +410,7 @@ public class BarrierTrackerTest {
 				createBuffer(0)
 		};
 
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+		MockInputGate gate = new MockInputGate(3, Arrays.asList(sequence));
 		BarrierTracker tracker = new BarrierTracker(gate);
 
 		// negative values mean an expected cancellation call!
@@ -450,7 +448,7 @@ public class BarrierTrackerTest {
 			createBuffer(0)
 		};
 
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+		MockInputGate gate = new MockInputGate(3, Arrays.asList(sequence));
 		BarrierTracker tracker = new BarrierTracker(gate);
 		AbstractInvokable statefulTask = mock(AbstractInvokable.class);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
@@ -33,8 +33,6 @@ import java.util.Queue;
  */
 public class MockInputGate extends InputGate {
 
-	private final int pageSize;
-
 	private final int numberOfChannels;
 
 	private final Queue<BufferOrEvent> bufferOrEvents;
@@ -43,18 +41,12 @@ public class MockInputGate extends InputGate {
 
 	private int closedChannels;
 
-	public MockInputGate(int pageSize, int numberOfChannels, List<BufferOrEvent> bufferOrEvents) {
-		this.pageSize = pageSize;
+	public MockInputGate(int numberOfChannels, List<BufferOrEvent> bufferOrEvents) {
 		this.numberOfChannels = numberOfChannels;
 		this.bufferOrEvents = new ArrayDeque<BufferOrEvent>(bufferOrEvents);
 		this.closed = new boolean[numberOfChannels];
 
 		isAvailable = AVAILABLE;
-	}
-
-	@Override
-	public int getPageSize() {
-		return pageSize;
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
@@ -43,18 +43,11 @@ public class MockInputGate extends InputGate {
 
 	private int closedChannels;
 
-	private final String owningTaskName;
-
 	public MockInputGate(int pageSize, int numberOfChannels, List<BufferOrEvent> bufferOrEvents) {
-		this(pageSize, numberOfChannels, bufferOrEvents, "MockTask");
-	}
-
-	public MockInputGate(int pageSize, int numberOfChannels, List<BufferOrEvent> bufferOrEvents, String owningTaskName) {
 		this.pageSize = pageSize;
 		this.numberOfChannels = numberOfChannels;
 		this.bufferOrEvents = new ArrayDeque<BufferOrEvent>(bufferOrEvents);
 		this.closed = new boolean[numberOfChannels];
-		this.owningTaskName = owningTaskName;
 
 		isAvailable = AVAILABLE;
 	}
@@ -71,11 +64,6 @@ public class MockInputGate extends InputGate {
 	@Override
 	public int getNumberOfInputChannels() {
 		return numberOfChannels;
-	}
-
-	@Override
-	public String getOwningTaskName() {
-		return owningTaskName;
 	}
 
 	@Override


### PR DESCRIPTION
Mirror of apache flink#8529
## What is the purpose of the change

*In order to make abstract `InputGate` simple for extending new implementations in shuffle service architecture, we could remove unnecessary methods from it.*

*Currently `InputGate#getOwningTaskName` is only used for debugging log in `BarrierBuffer` and `StreamInputProcessor`. This task name could be got from `Environment#getTaskInfo` and then be passed into the constructor of `BarrierBuffer/StreamInputProcessor` for use.*

*`InputGate#getPageSize` is only used for `BarrierBuffer` constructor. We could remove this method and the page size could also be got form task manager configuration instead.*

## Brief change log

  - *Add the full task name in the `TaskInfo`*
  - *Remove `getOwningTaskName` and `getPageSize` from `InputGate` abstract methods*
  - *Refactor the related process to get task name and page size for `BarrierBuffer` and `StreamInputProcessor`*

## Verifying this change

covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
