### PR TITLE
Mirror of apache flink#8524

### DIFF
--- a/flink-metrics/flink-metrics-statsd/src/test/java/org/apache/flink/metrics/statsd/StatsDReporterTest.java
+++ b/flink-metrics/flink-metrics-statsd/src/test/java/org/apache/flink/metrics/statsd/StatsDReporterTest.java
@@ -327,8 +327,8 @@ public class StatsDReporterTest extends TestLogger {
 			long endTimeout = System.currentTimeMillis() + timeout;
 			long remainingTimeout = timeout;
 
-			while (numberLines > lines.size() && remainingTimeout > 0) {
-				synchronized (lines) {
+			synchronized (lines) {
+				while (numberLines > lines.size() && remainingTimeout > 0) {
 					try {
 						lines.wait(remainingTimeout);
 					} catch (InterruptedException e) {


### PR DESCRIPTION
Mirror of apache flink#8524
## What is the purpose of the change

* `StatsDReporterTest` is unstable, fix it

## Brief change log

* The reason of unstable is that, there is a race condition of `DatagramSocketReceiver.waitUntilNumLines`.
* We need to get the lock outside the loop since `Object.wait` might wake up without a notification. It might miss the notification when checking the loop condition caused by self wakeup.


## Verifying this change

* This change is already covered by existing tests
* I have verified it by looping executing `StatsDReporterTest.testStatsDMetersReportingOfNegativeValues`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

