### PR TITLE
Mirror of apache flink#8543

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -104,6 +104,9 @@ public abstract class ExecutionEnvironment {
 	/** The environment of the context (local by default, cluster if invoked through command line). */
 	private static ExecutionEnvironmentFactory contextEnvironmentFactory;
 
+	/** The ThreadLocal used to store {@link ExecutionEnvironmentFactory}. */
+	private static ThreadLocal<ExecutionEnvironmentFactory> contextEnvironmentFactoryThreadLocal = new ThreadLocal<>();
+
 	/** The default parallelism used by local environments. */
 	private static int defaultLocalDop = Runtime.getRuntime().availableProcessors();
 
@@ -1061,8 +1064,12 @@ public abstract class ExecutionEnvironment {
 	 * @return The execution environment of the context in which the program is executed.
 	 */
 	public static ExecutionEnvironment getExecutionEnvironment() {
+
 		return contextEnvironmentFactory == null ?
-				createLocalEnvironment() : contextEnvironmentFactory.createExecutionEnvironment();
+				(contextEnvironmentFactoryThreadLocal.get() == null ?
+					createLocalEnvironment() :
+					contextEnvironmentFactoryThreadLocal.get().createExecutionEnvironment()) :
+				contextEnvironmentFactory.createExecutionEnvironment();
 	}
 
 	/**
@@ -1253,6 +1260,7 @@ public abstract class ExecutionEnvironment {
 	 */
 	protected static void initializeContextEnvironment(ExecutionEnvironmentFactory ctx) {
 		contextEnvironmentFactory = Preconditions.checkNotNull(ctx);
+		contextEnvironmentFactoryThreadLocal.set(contextEnvironmentFactory);
 	}
 
 	/**
@@ -1262,6 +1270,7 @@ public abstract class ExecutionEnvironment {
 	 */
 	protected static void resetContextEnvironment() {
 		contextEnvironmentFactory = null;
+		contextEnvironmentFactoryThreadLocal.remove();
 	}
 
 	/**


### PR DESCRIPTION
Mirror of apache flink#8543
## What is the purpose of the change

Fix race condition when concurrently running uploaded jars via REST.


## Brief change log

* Introduce a _ThreadLocal_ field to store _ExecutionEnvironmentFactory_ 
* When _contextEnvironmentFactory_ is null, use _ThreadLocal_ to get Factory.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)

cc <at>tillrohrmann 
