### PR TITLE
Mirror of apache flink#8583

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/serialization/SimpleStringSchema.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/serialization/SimpleStringSchema.java
@@ -21,6 +21,8 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.nio.charset.Charset;
@@ -70,9 +72,10 @@ public class SimpleStringSchema implements DeserializationSchema<String>, Serial
 	//  Kafka Serialization
 	// ------------------------------------------------------------------------
 
+	@Nullable
 	@Override
 	public String deserialize(byte[] message) {
-		return new String(message, charset);
+		return message != null ? new String(message, charset) : null;
 	}
 
 	@Override

--- a/flink-core/src/test/java/org/apache/flink/api/common/serialization/SimpleStringSchemaTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/serialization/SimpleStringSchemaTest.java
@@ -27,6 +27,7 @@ import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * Tests for the {@link SimpleStringSchema}.
@@ -50,4 +51,13 @@ public class SimpleStringSchemaTest {
 
 		assertEquals(schema.getCharset(), copy.getCharset());
 	}
+
+	@Test
+	public void testDeserializeWithNullValue() {
+		final SimpleStringSchema schema = new SimpleStringSchema();
+		final String value = schema.deserialize(null);
+
+		assertNull(value);
+	}
+
 }


### PR DESCRIPTION
Mirror of apache flink#8583
My branch has been deleted unexpectly, so I open this one, for more detail, please see #7987 

## What is the purpose of the change

when kafka msg queue contains some records which value is null, `SimpleStringSchema` can't process these records.

for example, msg queue like bellow.
<table class="table table-bordered table-striped table-condensed">
    <tr>
        <td>msg</td>
        <td>null</td>
        <td>msg</td>
        <td>msg</td>
        <td>msg</td>
    </tr>
</table>

 for normal, use **SimpleStringSchema** to process msg queue data
```
env.addSource(new FlinkKafkaConsumer010("topic", new SimpleStringSchema(), properties));
```
 but, will get NullPointerException

```
java.lang.NullPointerException
	at java.lang.String.<init>(String.java:515)
	at org.apache.flink.api.common.serialization.SimpleStringSchema.deserialize(SimpleStringSchema.java:75)
	at org.apache.flink.api.common.serialization.SimpleStringSchema.deserialize(SimpleStringSchema.java:36)
```

