### PR TITLE
Mirror of apache flink#8582

### DIFF
--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/ConcurrentCounter.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/ConcurrentCounter.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A simple implementation of {@link Counter} that is thread-safe.
+ */
+public class ConcurrentCounter implements Counter {
+
+	/** the current count. */
+	private AtomicLong count = new AtomicLong();
+
+	/**
+	 * Increment the current count by 1.
+	 */
+	@Override
+	public void inc() {
+		count.getAndIncrement();
+	}
+
+	/**
+	 * Increment the current count by the given value.
+	 *
+	 * @param n value to increment the current count by
+	 */
+	@Override
+	public void inc(long n) {
+		count.getAndAdd(n);
+	}
+
+	/**
+	 * Decrement the current count by 1.
+	 */
+	@Override
+	public void dec() {
+		count.getAndDecrement();
+	}
+
+	/**
+	 * Decrement the current count by the given value.
+	 *
+	 * @param n value to decrement the current count by
+	 */
+	@Override
+	public void dec(long n) {
+		count.getAndAdd(-n);
+	}
+
+	/**
+	 * Returns the current count.
+	 *
+	 * @return current count
+	 */
+	@Override
+	public long getCount() {
+		return count.get();
+	}
+}

--- a/flink-metrics/flink-metrics-core/src/test/java/org/apache/flink/metrics/ConcurrentCounterTest.java
+++ b/flink-metrics/flink-metrics-core/src/test/java/org/apache/flink/metrics/ConcurrentCounterTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics;
+
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Tests for the {@link ConcurrentCounter}.
+ */
+public class ConcurrentCounterTest {
+
+	@Test
+	public void testConcurrentCount() throws Exception {
+		final int threadCount = 10;
+		final ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+		try {
+			final ConcurrentCounter counter = new ConcurrentCounter();
+			final CountDownLatch startSignel = new CountDownLatch(1);
+			final CountDownLatch doneSignal = new CountDownLatch(threadCount);
+			final AtomicBoolean failed = new AtomicBoolean(false);
+			final int loopTimes = 10;
+
+			for (int i = 0; i < threadCount; i++) {
+				executorService.submit(() -> {
+					try {
+						startSignel.await();
+					} catch (InterruptedException e) {
+						failed.set(true);
+					}
+					for (int j = 0; j < loopTimes; j++) {
+						counter.inc();
+						counter.dec(10L);
+						counter.dec();
+						counter.inc(20L);
+					}
+					doneSignal.countDown();
+				});
+			}
+
+			startSignel.countDown();
+			doneSignal.await();
+
+			assertFalse(failed.get());
+			final long result = 1L + 20L - 10L - 1L;
+			assertEquals(result * loopTimes * threadCount, counter.getCount());
+		} finally {
+			executorService.shutdown();
+		}
+	}
+}


### PR DESCRIPTION
Mirror of apache flink#8582
## What is the purpose of the change

* Implement a built-in thread-safe counter

## Brief change log

* Add a new implementation of `Counter` named `ConcurrentCounter` which is thread-safe

## Verifying this change

* This change added unit test case

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

