### PR TITLE
Mirror of apache flink#8570

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateDescriptor.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.state;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -27,6 +28,9 @@ import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -37,6 +41,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -52,6 +57,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  */
 @PublicEvolving
 public abstract class StateDescriptor<S extends State, T> implements Serializable {
+	private static final Logger LOG = LoggerFactory.getLogger(StateDescriptor.class);
 
 	/**
 	 * An enumeration of the types of supported states. Used to identify the state type
@@ -82,8 +88,7 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 	/** The serializer for the type. May be eagerly initialized in the constructor,
 	 * or lazily once the {@link #initializeSerializerUnlessSet(ExecutionConfig)} method
 	 * is called. */
-	@Nullable
-	protected TypeSerializer<T> serializer;
+	private final AtomicReference<TypeSerializer<T>> serializerAtomicReference = new AtomicReference<>();
 
 	/** The type information describing the value type. Only used to if the serializer
 	 * is created lazily. */
@@ -114,7 +119,7 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 	 */
 	protected StateDescriptor(String name, TypeSerializer<T> serializer, @Nullable T defaultValue) {
 		this.name = checkNotNull(name, "name must not be null");
-		this.serializer = checkNotNull(serializer, "serializer must not be null");
+		this.serializerAtomicReference.set(checkNotNull(serializer, "serializer must not be null"));
 		this.defaultValue = defaultValue;
 	}
 
@@ -175,6 +180,7 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 	 */
 	public T getDefaultValue() {
 		if (defaultValue != null) {
+			TypeSerializer<T> serializer = serializerAtomicReference.get();
 			if (serializer != null) {
 				return serializer.copy(defaultValue);
 			} else {
@@ -191,8 +197,19 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 	 * calling {@link #initializeSerializerUnlessSet(ExecutionConfig)}.
 	 */
 	public TypeSerializer<T> getSerializer() {
+		TypeSerializer<T> serializer = serializerAtomicReference.get();
 		if (serializer != null) {
 			return serializer.duplicate();
+		} else {
+			throw new IllegalStateException("Serializer not yet initialized.");
+		}
+	}
+
+	@VisibleForTesting
+	final TypeSerializer<T> getOriginalSerializer() {
+		TypeSerializer<T> serializer = serializerAtomicReference.get();
+		if (serializer != null) {
+			return serializer;
 		} else {
 			throw new IllegalStateException("Serializer not yet initialized.");
 		}
@@ -272,7 +289,7 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 	 * @return True if the serializers have been initialized, false otherwise.
 	 */
 	public boolean isSerializerInitialized() {
-		return serializer != null;
+		return serializerAtomicReference.get() != null;
 	}
 
 	/**
@@ -281,14 +298,14 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 	 * @param executionConfig The execution config to use when creating the serializer.
 	 */
 	public void initializeSerializerUnlessSet(ExecutionConfig executionConfig) {
-		if (serializer == null) {
+		if (serializerAtomicReference.get() == null) {
 			checkState(typeInfo != null, "no serializer and no type info");
-
-			// instantiate the serializer
-			serializer = typeInfo.createSerializer(executionConfig);
-
-			// we can drop the type info now, no longer needed
-			typeInfo  = null;
+			// try to instantiate and set the serializer
+			TypeSerializer<T> serializer = typeInfo.createSerializer(executionConfig);
+			// use cas to assure the singleton
+			if (!serializerAtomicReference.compareAndSet(null, serializer)) {
+				LOG.debug("Someone else beat us at initializing the serializer.");
+			}
 		}
 	}
 
@@ -320,7 +337,7 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 		return getClass().getSimpleName() +
 				"{name=" + name +
 				", defaultValue=" + defaultValue +
-				", serializer=" + serializer +
+				", serializer=" + serializerAtomicReference.get() +
 				(isQueryable() ? ", queryableStateName=" + queryableStateName + "" : "") +
 				'}';
 	}
@@ -340,6 +357,9 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 			// we don't have a default value
 			out.writeBoolean(false);
 		} else {
+			TypeSerializer<T> serializer = serializerAtomicReference.get();
+			checkNotNull(serializer, "Serializer not initialized.");
+
 			// we have a default value
 			out.writeBoolean(true);
 
@@ -370,6 +390,9 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 		// read the default value field
 		boolean hasDefaultValue = in.readBoolean();
 		if (hasDefaultValue) {
+			TypeSerializer<T> serializer = serializerAtomicReference.get();
+			checkNotNull(serializer, "Serializer not initialized.");
+
 			int size = in.readInt();
 
 			byte[] buffer = new byte[size];


### PR DESCRIPTION
Mirror of apache flink#8570
## What is the purpose of the change

This PR aims at making the lazy initialization of `StateDescriptor.serializer` thread safe, more details about what problem there will be w/o the fix please refer to [JIRA](https://issues.apache.org/jira/browse/FLINK-11987).

This PR supersedes [PR#8331](https://github.com/apache/flink/pull/8331) as per discussed there.

## Brief change log

Changes mainly inlcude:
* Use CAS when lazily initializing `serializer` in `StateDescriptor#initializeSerializerUnlessSet`, to make sure only one serializer will be used.
* Remove the nullify of `typeInfo` in `StateDescriptor#initializeSerializerUnlessSet` to prevent NPE as observed in `FlinkKafkaProducer011` from jira description.
* Added a new UT case in `StateDescriptorTest` to reproduce the problem and verify the fix.


## Verifying this change

Added a `testSerializerLazyInitializeInParallel` test case in `StateDescriptorTest` for verification.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (yes)
     - `StateDescriptor` is annotated with `<at>PublicEvolving` while changes here don't involve any modification on method/interface signatures.
  - The serializers: (yes)
     - The change here assures only one single serializer instance will be wrapped after lazy initialization while previously no such assurance.
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

