### PR TITLE
Mirror of apache flink#8566

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
@@ -204,12 +204,22 @@ public class NetworkEnvironment {
 	}
 
 	/**
-	 * Query unreleased partitions.
+	 * Report unreleased partitions.
+	 *
+	 * <p>Partitions are released in the following cases:
+	 * <ol>
+	 *     <li>{@link ResultPartitionWriter#fail(Throwable)} and {@link ResultPartitionWriter#close()} are called
+	 *     if the production has failed.</li>
+	 *     <li>{@link ResultPartitionWriter#finish()} and {@link ResultPartitionWriter#close()} are called
+	 *     if the production is done. The actual release can take some time
+	 *     if 'the end of consumption' confirmation is being awaited implicitly
+	 *     or the partition is later released by {@code releasePartitions(Collection<ResultPartitionID>)}.</li>
+	 *     <li>{@code releasePartitions(Collection<ResultPartitionID>)} is called,
+	 *     e.g. when the production is done but the final release happens externally.</li>
+	 * </ol>
 	 *
 	 * @return collection of partitions which still occupy some resources locally on this task executor
-	 * and have not been released yet. The partition can be released either with {@link ResultPartitionWriter#fail(Throwable)}
-	 * or {@link ResultPartitionWriter#finish()} and then with {@link ResultPartitionWriter#close()} after fail or finish.
-	 * Another way is to release them externally by calling {@code releasePartitions(Collection<ResultPartitionID>)}.
+	 * and have been not released yet.
 	 */
 	public Collection<ResultPartitionID> getUnreleasedPartitions() {
 		return resultPartitionManager.getUnreleasedPartitions();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.metrics.InputBufferPoolUsageGauge;
 import org.apache.flink.runtime.io.network.metrics.InputBuffersGauge;
@@ -172,6 +173,7 @@ public class NetworkEnvironment {
 	//  Properties
 	// --------------------------------------------------------------------------------------------
 
+	@VisibleForTesting
 	public ResultPartitionManager getResultPartitionManager() {
 		return resultPartitionManager;
 	}
@@ -199,6 +201,18 @@ public class NetworkEnvironment {
 		for (ResultPartitionID partitionId : partitionIds) {
 			resultPartitionManager.releasePartition(partitionId, null);
 		}
+	}
+
+	/**
+	 * Query unreleased partitions.
+	 *
+	 * @return collection of partitions which still occupy some resources locally on this task executor
+	 * and have not been released yet. The partition can be released either with {@link ResultPartitionWriter#fail(Throwable)}
+	 * or {@link ResultPartitionWriter#finish()} and then with {@link ResultPartitionWriter#close()} after fail or finish.
+	 * Another way is to release them externally by calling {@code releasePartitions(Collection<ResultPartitionID>)}.
+	 */
+	public Collection<ResultPartitionID> getUnreleasedPartitions() {
+		return resultPartitionManager.getUnreleasedPartitions();
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManager.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -122,14 +123,9 @@ public class ResultPartitionManager implements ResultPartitionProvider {
 		}
 	}
 
-	public boolean areAllPartitionsReleased() {
+	public Collection<ResultPartitionID> getUnreleasedPartitions() {
 		synchronized (registeredPartitions) {
-			for (ResultPartition partition : registeredPartitions.values()) {
-				if (!partition.isReleased()) {
-					return false;
-				}
-			}
-			return true;
+			return registeredPartitions.keySet();
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManager.java
@@ -107,19 +107,17 @@ public class ResultPartitionManager implements ResultPartitionProvider {
 	// ------------------------------------------------------------------------
 
 	void onConsumedPartition(ResultPartition partition) {
-		final ResultPartition previous;
-
 		LOG.debug("Received consume notification from {}.", partition);
 
 		synchronized (registeredPartitions) {
-			previous = registeredPartitions.remove(partition.getPartitionId());
-		}
-
-		// Release the partition if it was successfully removed
-		if (partition == previous) {
-			partition.release();
-
-			LOG.debug("Released {}.", partition);
+			final ResultPartition previous = registeredPartitions.remove(partition.getPartitionId());
+			// Release the partition if it was successfully removed
+			if (partition == previous) {
+				partition.release();
+				ResultPartitionID partitionId = partition.getPartitionId();
+				LOG.debug("Released partition {} produced by {}.",
+					partitionId.getPartitionId(), partitionId.getProducerId());
+			}
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -275,7 +275,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 	@Override
 	public CompletableFuture<Boolean> canBeReleased() {
 		return CompletableFuture.completedFuture(
-			taskExecutorServices.getNetworkEnvironment().getResultPartitionManager().areAllPartitionsReleased());
+			taskExecutorServices.getNetworkEnvironment().getUnreleasedPartitions().isEmpty());
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
Mirror of apache flink#8566
## What is the purpose of the change

At the moment NetworkEnvironment.getResultPartitionManager is used to query TaskExecutor whether all partitions are released. We should hide this direct access to ResultPartitionManager behind a Shuffle API method call: NetworkEnvironment.getUnreleasedPartitions.

## Brief change log

 - Refactor `ResultPartitionManager.areAllPartitionsReleased` to `getUnreleasedPartitions`
 - Add `NetworkEnvironment.getUnreleasedPartitions`

## Verifying this change

Trivial refactor covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

