### PR TITLE
Mirror of apache flink#8563

### DIFF
--- a/docs/dev/stream/state/queryable_state.md
+++ b/docs/dev/stream/state/queryable_state.md
@@ -174,7 +174,7 @@ jar which must be explicitly included as a dependency in the `pom.xml` of your p
 </dependency>
 <dependency>
   <groupId>org.apache.flink</groupId>
-  <artifactId>flink-queryable-state-client-java{{ site.scala_version_suffix }}</artifactId>
+  <artifactId>flink-queryable-state-client-java</artifactId>
   <version>{{ site.version }}</version>
 </dependency>
 {% endhighlight %}

--- a/docs/dev/stream/state/queryable_state.zh.md
+++ b/docs/dev/stream/state/queryable_state.zh.md
@@ -174,7 +174,7 @@ jar which must be explicitly included as a dependency in the `pom.xml` of your p
 </dependency>
 <dependency>
   <groupId>org.apache.flink</groupId>
-  <artifactId>flink-queryable-state-client-java{{ site.scala_version_suffix }}</artifactId>
+  <artifactId>flink-queryable-state-client-java</artifactId>
   <version>{{ site.version }}</version>
 </dependency>
 {% endhighlight %}

--- a/flink-connectors/flink-connector-cassandra/pom.xml
+++ b/flink-connectors/flink-connector-cassandra/pom.xml
@@ -211,7 +211,7 @@ under the License.
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-tests_${scala.binary.version}</artifactId>
+			<artifactId>flink-tests</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-connectors/flink-connector-filesystem/pom.xml
+++ b/flink-connectors/flink-connector-filesystem/pom.xml
@@ -99,7 +99,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-tests_${scala.binary.version}</artifactId>
+			<artifactId>flink-tests</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 			<type>test-jar</type>

--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -30,7 +30,7 @@ under the License.
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-connector-hive_${scala.binary.version}</artifactId>
+	<artifactId>flink-connector-hive</artifactId>
 	<name>flink-connector-hive</name>
 
 	<packaging>jar</packaging>

--- a/flink-connectors/flink-connector-kafka-0.10/pom.xml
+++ b/flink-connectors/flink-connector-kafka-0.10/pom.xml
@@ -145,7 +145,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-tests_${scala.binary.version}</artifactId>
+			<artifactId>flink-tests</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>

--- a/flink-connectors/flink-connector-kafka-0.11/pom.xml
+++ b/flink-connectors/flink-connector-kafka-0.11/pom.xml
@@ -153,7 +153,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-tests_${scala.binary.version}</artifactId>
+			<artifactId>flink-tests</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>

--- a/flink-connectors/flink-connector-kafka-0.8/pom.xml
+++ b/flink-connectors/flink-connector-kafka-0.8/pom.xml
@@ -183,7 +183,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-tests_${scala.binary.version}</artifactId>
+			<artifactId>flink-tests</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>

--- a/flink-connectors/flink-connector-kafka-0.9/pom.xml
+++ b/flink-connectors/flink-connector-kafka-0.9/pom.xml
@@ -125,7 +125,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-tests_${scala.binary.version}</artifactId>
+			<artifactId>flink-tests</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>

--- a/flink-connectors/flink-connector-kafka-base/pom.xml
+++ b/flink-connectors/flink-connector-kafka-base/pom.xml
@@ -168,7 +168,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-tests_${scala.binary.version}</artifactId>
+			<artifactId>flink-tests</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>

--- a/flink-connectors/flink-connector-kafka/pom.xml
+++ b/flink-connectors/flink-connector-kafka/pom.xml
@@ -136,7 +136,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-tests_${scala.binary.version}</artifactId>
+			<artifactId>flink-tests</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>

--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -66,7 +66,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-tests_${scala.binary.version}</artifactId>
+			<artifactId>flink-tests</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 			<type>test-jar</type>

--- a/flink-connectors/flink-connector-nifi/pom.xml
+++ b/flink-connectors/flink-connector-nifi/pom.xml
@@ -61,7 +61,7 @@ under the License.
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-tests_${scala.binary.version}</artifactId>
+            <artifactId>flink-tests</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>

--- a/flink-connectors/flink-sql-connector-elasticsearch6/pom.xml
+++ b/flink-connectors/flink-sql-connector-elasticsearch6/pom.xml
@@ -41,6 +41,14 @@ under the License.
 			<artifactId>flink-connector-elasticsearch6_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<!--  Due to the scope of `provided` transitive dependencies problem,
+		we should copy this dependency here for the scala suffix check.	-->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-connectors/flink-sql-connector-kafka-0.10/pom.xml
+++ b/flink-connectors/flink-sql-connector-kafka-0.10/pom.xml
@@ -41,6 +41,14 @@ under the License.
 			<artifactId>flink-connector-kafka-0.10_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<!--  Due to the scope of `provided` transitive dependencies problem,
+		we should copy this dependency here for the scala suffix check.	-->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-connectors/flink-sql-connector-kafka-0.11/pom.xml
+++ b/flink-connectors/flink-sql-connector-kafka-0.11/pom.xml
@@ -41,6 +41,14 @@ under the License.
 			<artifactId>flink-connector-kafka-0.11_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<!--  Due to the scope of `provided` transitive dependencies problem,
+		we should copy this dependency here for the scala suffix check.	-->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-connectors/flink-sql-connector-kafka-0.9/pom.xml
+++ b/flink-connectors/flink-sql-connector-kafka-0.9/pom.xml
@@ -41,6 +41,14 @@ under the License.
 			<artifactId>flink-connector-kafka-0.9_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<!--  Due to the scope of `provided` transitive dependencies problem,
+		we should copy this dependency here for the scala suffix check.	-->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-connectors/flink-sql-connector-kafka/pom.xml
+++ b/flink-connectors/flink-sql-connector-kafka/pom.xml
@@ -41,6 +41,14 @@ under the License.
 			<artifactId>flink-connector-kafka_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<!--  Due to the scope of `provided` transitive dependencies problem,
+		we should copy this dependency here for the scala suffix check.	-->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-end-to-end-tests/flink-queryable-state-test/pom.xml
+++ b/flink-end-to-end-tests/flink-queryable-state-test/pom.xml
@@ -47,7 +47,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-queryable-state-client-java_${scala.binary.version}</artifactId>
+			<artifactId>flink-queryable-state-client-java</artifactId>
 			<version>${project.version}</version>
 			<!-- compile scope since it is used by the client jar -->
 		</dependency>

--- a/flink-fs-tests/pom.xml
+++ b/flink-fs-tests/pom.xml
@@ -27,7 +27,7 @@ under the License.
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-fs-tests_${scala.binary.version}</artifactId>
+	<artifactId>flink-fs-tests</artifactId>
 	<name>flink-fs-tests</name>
 
 	<packaging>jar</packaging>

--- a/flink-libraries/flink-cep-scala/pom.xml
+++ b/flink-libraries/flink-cep-scala/pom.xml
@@ -82,7 +82,7 @@ under the License.
 
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-tests_${scala.binary.version}</artifactId>
+            <artifactId>flink-tests</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
             <type>test-jar</type>

--- a/flink-libraries/flink-gelly-examples/pom.xml
+++ b/flink-libraries/flink-gelly-examples/pom.xml
@@ -106,7 +106,7 @@
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-tests_${scala.binary.version}</artifactId>
+			<artifactId>flink-tests</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-libraries/flink-gelly-scala/pom.xml
+++ b/flink-libraries/flink-gelly-scala/pom.xml
@@ -80,7 +80,7 @@ under the License.
         
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-tests_${scala.binary.version}</artifactId>
+            <artifactId>flink-tests</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
             <type>test-jar</type>

--- a/flink-queryable-state/flink-queryable-state-client-java/pom.xml
+++ b/flink-queryable-state/flink-queryable-state-client-java/pom.xml
@@ -30,7 +30,7 @@ under the License.
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-queryable-state-client-java_${scala.binary.version}</artifactId>
+	<artifactId>flink-queryable-state-client-java</artifactId>
 	<name>flink-queryable-state-client-java</name>
 	<packaging>jar</packaging>
 

--- a/flink-queryable-state/flink-queryable-state-runtime/pom.xml
+++ b/flink-queryable-state/flink-queryable-state-runtime/pom.xml
@@ -54,7 +54,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-queryable-state-client-java_${scala.binary.version}</artifactId>
+			<artifactId>flink-queryable-state-client-java</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -52,7 +52,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-queryable-state-client-java_${scala.binary.version}</artifactId>
+			<artifactId>flink-queryable-state-client-java</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 

--- a/flink-streaming-scala/pom.xml
+++ b/flink-streaming-scala/pom.xml
@@ -93,7 +93,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-tests_${scala.binary.version}</artifactId>
+			<artifactId>flink-tests</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 			<type>test-jar</type>

--- a/flink-table/flink-table-api-scala/pom.xml
+++ b/flink-table/flink-table-api-scala/pom.xml
@@ -47,5 +47,19 @@ under the License.
 			<artifactId>flink-table-api-java</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.scala-lang</groupId>
+			<artifactId>scala-reflect</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.scala-lang</groupId>
+			<artifactId>scala-library</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.scala-lang</groupId>
+			<artifactId>scala-compiler</artifactId>
+		</dependency>
 	</dependencies>
 </project>

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -219,7 +219,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-tests_${scala.binary.version}</artifactId>
+			<artifactId>flink-tests</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>

--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -30,7 +30,7 @@ under the License.
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-tests_${scala.binary.version}</artifactId>
+	<artifactId>flink-tests</artifactId>
 	<name>flink-tests</name>
 
 	<packaging>jar</packaging>

--- a/flink-yarn-tests/pom.xml
+++ b/flink-yarn-tests/pom.xml
@@ -33,7 +33,7 @@ under the License.
 	We need the YARN fat jar build by flink-dist for the tests.
 	-->
 	
-	<artifactId>flink-yarn-tests_${scala.binary.version}</artifactId>
+	<artifactId>flink-yarn-tests</artifactId>
 	<name>flink-yarn-tests</name>
 	<packaging>jar</packaging>
 

--- a/tools/verify_scala_suffixes.sh
+++ b/tools/verify_scala_suffixes.sh
@@ -142,7 +142,7 @@ echo
 echo "Checking Scala-free modules:"
 
 for module in $clean; do
-    out=`find . -maxdepth 3 -name 'pom.xml' -not -path '*target*' -exec grep "${module}_\d\+\.\d\+</artifactId>" "{}" \;`
+    out=`find . -maxdepth 3 -name 'pom.xml' -not -path '*target*' -exec grep "${module}_\\${scala.binary.version}</artifactId>" "{}" \;`
     if [[ "$out" == "" ]]; then
         printf "$GREEN OK $NC $module\n"
     else


### PR DESCRIPTION
Mirror of apache flink#8563
## What is the purpose of the change
I find a shell issue in `verify_scala_suffixes.sh`(line 145) as follows:

`grep "${module}_\d\+\.\d\+</artifactId>" "{}"`

This code want to find out all modules that the module's `artifactId`  with a `scala_binary_version` suffix. 
but the problem is our all `artifactId` value is in the pattern of `XXX_${scala.binary.version}`, such as:

`<artifactId>flink-tests_${scala.binary.version}</artifactId>`

then the result always empty, so this check did not take effect.

So, we need to correct `artifactId `of some of the modules and correct the check logic for scala-free.

## Brief change log
  - remove the scala version suffix for connector-hive and queryable-state-client-java
  - add the scala dependencies for table-api-scala and flink-sql-connectors
  - correct the scala-free check logic in `verify_scala_suffixes.sh`

NOTE:
We have two ways handling of the connector:
 1. Improve the script to check any (compile) dependencies with a scala-suffix(which we mentioned above).
 2. Add the `flink-streaming-java` dependency wich  `provided`  scope for the corresponding connectors.

For approach 1, we should add check logic:
 1. The command of `dependency:tree` should add an option: ` -Dincludes=org.apache.flink:_2.1::  ` such as `org.apache.flink:flink-streaming-java_2.11`.
  2. The command of `grep ` also need to add the logic: `E "org.scala-lang| org.apache.flink:[^:]+_2\.1[0-9]"` , also for test `grep --invert-match "org.apache.flink:[^:]_2\.1[0-9]:.:.*:test"`.

For approach 2, we should add the dependency of `link-streaming-java` for `flink-sql-connector-elasticsearch6 flink-sql-connector-kafka flink-sql-connector-kafka-0.10 flink-sql-connector-kafka-0.11 flink-sql-connector-kafka-0.9`.  

For now, I think the change logic in approach 1 is a bit complex(a lot of filtering processing logic). So, I prefer the approach 2, due to even we add some new module in the future we should well know whether we should add the scala-suffix for the `artifactId`, then manually add dependencies on for the scala in the pom. 

So, in this PR I add the dependency of `link-streaming-java` for `flink-sql-connectors`.

## Verifying this change
This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
    1. correct the artifactId in `queryable_state.md/queryable_state.zh.md`.
  

