### PR TITLE
Mirror of apache flink#8655

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/LocalReferenceExpression.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/LocalReferenceExpression.java
@@ -18,7 +18,8 @@
 
 package org.apache.flink.table.expressions;
 
-import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.Preconditions;
 
 import java.util.Collections;
@@ -30,23 +31,24 @@ import java.util.Objects;
  * That entity does not come from any of the Operations input. It might be for example a group
  * window in window aggregation.
  */
+@Internal
 public class LocalReferenceExpression implements Expression {
 
 	private final String name;
 
-	private final TypeInformation<?> resultType;
+	private final DataType dataType;
 
-	public LocalReferenceExpression(String name, TypeInformation<?> resultType) {
+	public LocalReferenceExpression(String name, DataType dataType) {
 		this.name = Preconditions.checkNotNull(name);
-		this.resultType = Preconditions.checkNotNull(resultType);
+		this.dataType = Preconditions.checkNotNull(dataType);
 	}
 
 	public String getName() {
 		return name;
 	}
 
-	public TypeInformation<?> getResultType() {
-		return resultType;
+	public DataType getOutputDataType() {
+		return dataType;
 	}
 
 	@Override
@@ -68,13 +70,13 @@ public class LocalReferenceExpression implements Expression {
 			return false;
 		}
 		LocalReferenceExpression that = (LocalReferenceExpression) o;
-		return Objects.equals(name, that.name) &&
-			Objects.equals(resultType, that.resultType);
+		return name.equals(that.name) &&
+			dataType.equals(that.dataType);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(name, resultType);
+		return Objects.hash(name, dataType);
 	}
 
 	@Override

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/operations/TableOperationTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/operations/TableOperationTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.operations;
 
-import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.expressions.BuiltInFunctionDefinitions;
@@ -43,7 +42,7 @@ public class TableOperationTest {
 		TableSchema schema = TableSchema.builder().field("a", DataTypes.INT()).build();
 
 		ProjectTableOperation tableOperation = new ProjectTableOperation(
-			Collections.singletonList(new FieldReferenceExpression("a", Types.INT, 0, 0)),
+			Collections.singletonList(new FieldReferenceExpression("a", DataTypes.INT(), 0, 0)),
 			new CatalogTableOperation(
 				Arrays.asList("cat1", "db1", "tab1"),
 				schema), schema);
@@ -65,7 +64,7 @@ public class TableOperationTest {
 	@Test
 	public void testWindowAggregationSummaryString() {
 		TableSchema schema = TableSchema.builder().field("a", DataTypes.INT()).build();
-		FieldReferenceExpression field = new FieldReferenceExpression("a", Types.INT, 0, 0);
+		FieldReferenceExpression field = new FieldReferenceExpression("a", DataTypes.INT(), 0, 0);
 		WindowAggregateTableOperation tableOperation = new WindowAggregateTableOperation(
 			Collections.singletonList(field),
 			Collections.singletonList(new CallExpression(BuiltInFunctionDefinitions.SUM,

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/FieldReferenceExpression.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/FieldReferenceExpression.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.expressions;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.Preconditions;
 
 import java.util.Collections;
@@ -39,7 +39,7 @@ public final class FieldReferenceExpression implements Expression {
 
 	private final String name;
 
-	private final TypeInformation<?> resultType;
+	private final DataType dataType;
 
 	/**
 	 * index of an input the field belongs to.
@@ -54,13 +54,13 @@ public final class FieldReferenceExpression implements Expression {
 
 	public FieldReferenceExpression(
 			String name,
-			TypeInformation<?> resultType,
+			DataType dataType,
 			int inputIndex,
 			int fieldIndex) {
 		Preconditions.checkArgument(inputIndex >= 0, "Index of input should be a positive number");
 		Preconditions.checkArgument(fieldIndex >= 0, "Index of field should be a positive number");
-		this.name = Preconditions.checkNotNull(name);
-		this.resultType = Preconditions.checkNotNull(resultType);
+		this.name = Preconditions.checkNotNull(name, "Field name must not be null.");
+		this.dataType = Preconditions.checkNotNull(dataType, "Field data type must not be null.");
 		this.inputIndex = inputIndex;
 		this.fieldIndex = fieldIndex;
 	}
@@ -69,8 +69,8 @@ public final class FieldReferenceExpression implements Expression {
 		return name;
 	}
 
-	public TypeInformation<?> getResultType() {
-		return resultType;
+	public DataType getOutputDataType() {
+		return dataType;
 	}
 
 	public int getInputIndex() {
@@ -100,15 +100,15 @@ public final class FieldReferenceExpression implements Expression {
 			return false;
 		}
 		FieldReferenceExpression that = (FieldReferenceExpression) o;
-		return Objects.equals(name, that.name) &&
-			Objects.equals(resultType, that.resultType) &&
+		return name.equals(that.name) &&
+			dataType.equals(that.dataType) &&
 			inputIndex == that.inputIndex &&
 			fieldIndex == that.fieldIndex;
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(name, resultType, inputIndex, fieldIndex);
+		return Objects.hash(name, dataType, inputIndex, fieldIndex);
 	}
 
 	@Override

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/expressions/ExpressionTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/expressions/ExpressionTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.expressions;
 
-import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.functions.ScalarFunction;
@@ -141,7 +140,7 @@ public class ExpressionTest {
 				new CallExpression(
 					EQUALS,
 					asList(
-						new FieldReferenceExpression("field", Types.INT, 0, 0),
+						new FieldReferenceExpression("field", DataTypes.INT(), 0, 0),
 						new CallExpression(
 							new ScalarFunctionDefinition("dummy", DUMMY_FUNCTION),
 							singletonList(new ValueLiteralExpression(nestedValue, DataTypes.INT()))

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/logical/BatchLogicalWindowAggregateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/logical/BatchLogicalWindowAggregateRule.scala
@@ -23,10 +23,10 @@ import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.table.calcite.FlinkTypeFactory.toInternalType
 import org.apache.flink.table.expressions.FieldReferenceExpression
 import org.apache.flink.table.plan.nodes.calcite.LogicalWindowAggregate
-
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.logical.{LogicalAggregate, LogicalProject}
 import org.apache.calcite.rex._
+import org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType
 
 /**
   * Planner rule that transforms simple [[LogicalAggregate]] on a [[LogicalProject]]
@@ -59,7 +59,7 @@ class BatchLogicalWindowAggregateRule
         FlinkTypeFactory.isTimeIndicatorType(c.getType) =>
         new FieldReferenceExpression(
           rowType.getFieldList.get(windowExprIdx).getName,
-          createExternalTypeInfoFromInternalType(toInternalType(c.getType)),
+          fromLegacyInfoToDataType(createExternalTypeInfoFromInternalType(toInternalType(c.getType))),
           0, // only one input, should always be 0
           windowExprIdx)
       case ref: RexInputRef =>
@@ -68,7 +68,7 @@ class BatchLogicalWindowAggregateRule
         val fieldType = rowType.getFieldList.get(ref.getIndex).getType
         new FieldReferenceExpression(
           fieldName,
-          createExternalTypeInfoFromInternalType(toInternalType(fieldType)),
+          fromLegacyInfoToDataType(createExternalTypeInfoFromInternalType(toInternalType(fieldType))),
           0, // only one input, should always be 0
           ref.getIndex)
     }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/logical/LogicalWindowAggregateRuleBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/logical/LogicalWindowAggregateRuleBase.scala
@@ -36,6 +36,7 @@ import org.apache.flink.table.expressions.{FieldReferenceExpression, WindowRefer
 import org.apache.flink.table.functions.sql.FlinkSqlOperatorTable
 import org.apache.flink.table.plan.logical.{LogicalWindow, SessionGroupWindow, SlidingGroupWindow, TumblingGroupWindow}
 import org.apache.flink.table.plan.nodes.calcite.LogicalWindowAggregate
+import org.apache.flink.table.types.utils.TypeConversions.fromDataTypeToLegacyInfo
 
 import _root_.scala.collection.JavaConversions._
 
@@ -174,7 +175,8 @@ abstract class LogicalWindowAggregateRuleBase(description: String)
       }
 
     val timeField = getTimeFieldReference(windowExpr.getOperands.get(0), windowExprIdx, rowType)
-    val resultType = Some(createInternalTypeFromTypeInfo(timeField.getResultType))
+    val resultType =
+      Some(createInternalTypeFromTypeInfo(fromDataTypeToLegacyInfo(timeField.getOutputDataType)))
     val windowRef = WindowReference("w$", resultType)
     windowExpr.getOperator match {
       case FlinkSqlOperatorTable.TUMBLE =>

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/logical/StreamLogicalWindowAggregateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/logical/StreamLogicalWindowAggregateRule.scala
@@ -24,11 +24,11 @@ import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.table.calcite.FlinkTypeFactory.toInternalType
 import org.apache.flink.table.expressions.FieldReferenceExpression
 import org.apache.flink.table.plan.nodes.calcite.LogicalWindowAggregate
-
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.logical.{LogicalAggregate, LogicalProject}
 import org.apache.calcite.rex._
 import org.apache.calcite.sql.`type`.SqlTypeName
+import org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType
 
 /**
   * Planner rule that transforms simple [[LogicalAggregate]] on a [[LogicalProject]]
@@ -70,13 +70,13 @@ class StreamLogicalWindowAggregateRule
         FlinkTypeFactory.isTimeIndicatorType(c.getType) =>
         new FieldReferenceExpression(
           rowType.getFieldList.get(windowExprIdx).getName,
-          createExternalTypeInfoFromInternalType(toInternalType(c.getType)),
+          fromLegacyInfoToDataType(createExternalTypeInfoFromInternalType(toInternalType(c.getType))),
           0, // only one input, should always be 0
           windowExprIdx)
       case v: RexInputRef if FlinkTypeFactory.isTimeIndicatorType(v.getType) =>
         new FieldReferenceExpression(
           rowType.getFieldList.get(v.getIndex).getName,
-          createExternalTypeInfoFromInternalType(toInternalType(v.getType)),
+          fromLegacyInfoToDataType(createExternalTypeInfoFromInternalType(toInternalType(v.getType))),
           0, // only one input, should always be 0
           v.getIndex)
       case _ =>

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/stream/StreamExecGroupWindowAggregateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/stream/StreamExecGroupWindowAggregateRule.scala
@@ -24,7 +24,7 @@ import org.apache.flink.table.plan.`trait`.FlinkRelDistribution
 import org.apache.flink.table.plan.nodes.FlinkConventions
 import org.apache.flink.table.plan.nodes.logical.FlinkLogicalWindowAggregate
 import org.apache.flink.table.plan.nodes.physical.stream.StreamExecGroupWindowAggregate
-import org.apache.flink.table.plan.util.AggregateUtil.{isRowtimeIndicatorType, timeFieldIndex}
+import org.apache.flink.table.plan.util.AggregateUtil.{isRowtimeAttribute, timeFieldIndex}
 import org.apache.flink.table.plan.util.WindowEmitStrategy
 
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
@@ -76,7 +76,7 @@ class StreamExecGroupWindowAggregateRule
     val emitStrategy = WindowEmitStrategy(config, agg.getWindow)
 
     val timeField = agg.getWindow.timeAttribute
-    val inputTimestampIndex = if (isRowtimeIndicatorType(timeField.getResultType)) {
+    val inputTimestampIndex = if (isRowtimeAttribute(timeField)) {
       timeFieldIndex(inputRowType, relBuilderFactory.create(cluster, null), timeField)
     } else {
       -1

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/AggregateUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/AggregateUtil.scala
@@ -47,6 +47,7 @@ import org.apache.flink.table.functions.{AggregateFunction, UserDefinedFunction}
 import org.apache.flink.table.plan.`trait`.RelModifiedMonotonicity
 import org.apache.flink.table.runtime.bundle.trigger.CountBundleTrigger
 import org.apache.flink.table.types.logical.LogicalTypeRoot
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot
 import org.apache.flink.table.typeutils._
 
@@ -701,14 +702,12 @@ object AggregateUtil extends Enumeration {
     (propPos._1, propPos._2, propPos._3)
   }
 
-  def isRowtimeIndicatorType(fieldType: TypeInformation[_]): Boolean = fieldType match {
-    case typeInfo: TimeIndicatorTypeInfo => typeInfo.isEventTime
-    case _ => false
+  def isRowtimeAttribute(field: FieldReferenceExpression): Boolean = {
+    LogicalTypeChecks.isRowtimeAttribute(field.getOutputDataType.getLogicalType)
   }
 
-  def isProctimeIndicatorType(fieldType: TypeInformation[_]): Boolean = fieldType match {
-    case typeInfo: TimeIndicatorTypeInfo => !typeInfo.isEventTime
-    case _ => false
+  def isProctimeAttribute(field: FieldReferenceExpression): Boolean = {
+    LogicalTypeChecks.isProctimeAttribute(field.getOutputDataType.getLogicalType)
   }
 
   def hasTimeIntervalType(intervalType: ValueLiteralExpression): Boolean = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/WindowEmitStrategy.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/WindowEmitStrategy.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.plan.util
 import org.apache.flink.table.api.window.TimeWindow
 import org.apache.flink.table.api.{TableConfig, TableException}
 import org.apache.flink.table.plan.logical.{LogicalWindow, SessionGroupWindow}
-import org.apache.flink.table.plan.util.AggregateUtil.isRowtimeIndicatorType
+import org.apache.flink.table.plan.util.AggregateUtil.isRowtimeAttribute
 import org.apache.flink.table.runtime.window.triggers._
 
 import java.time.Duration
@@ -115,7 +115,7 @@ class WindowEmitStrategy(
 
 object WindowEmitStrategy {
   def apply(tableConfig: TableConfig, window: LogicalWindow): WindowEmitStrategy = {
-    val isEventTime = isRowtimeIndicatorType(window.timeAttribute.getResultType)
+    val isEventTime = isRowtimeAttribute(window.timeAttribute)
     val isSessionWindow = window.isInstanceOf[SessionGroupWindow]
 
     val allowLateness = if (isSessionWindow) {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/sources/tsextractors/ExistingField.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/sources/tsextractors/ExistingField.scala
@@ -21,12 +21,10 @@ package org.apache.flink.table.sources.tsextractors
 import java.util
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.table.`type`.DecimalType
 import org.apache.flink.table.api.{Types, ValidationException}
 import org.apache.flink.table.descriptors.Rowtime
 import org.apache.flink.table.expressions._
 import org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType
-import org.apache.flink.table.typeutils.DecimalTypeInfo
 
 import scala.collection.JavaConversions._
 
@@ -66,7 +64,7 @@ final class ExistingField(val field: String) extends TimestampExtractor {
 
     val fieldReferenceExpr = new FieldReferenceExpression(
       fieldAccess.name,
-      fieldAccess.resultType,
+      fromLegacyInfoToDataType(fieldAccess.resultType),
       0,
       fieldAccess.fieldIndex)
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdHandlerTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/metadata/FlinkRelMdHandlerTestBase.scala
@@ -38,7 +38,8 @@ import org.apache.calcite.sql.fun.{SqlCountAggFunction, SqlStdOperatorTable}
 import org.apache.calcite.sql.parser.SqlParserPos
 import org.apache.calcite.tools.FrameworkConfig
 import org.apache.calcite.util.{DateString, ImmutableBitSet, TimeString, TimestampString}
-import org.apache.flink.table.`type`.{InternalType, InternalTypes, TypeConverters}
+import org.apache.flink.table.`type`.TypeConverters.createExternalTypeInfoFromInternalType
+import org.apache.flink.table.`type`.{InternalType, InternalTypes}
 import org.apache.flink.table.api.{TableConfig, TableException}
 import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
 import org.apache.flink.table.calcite.{FlinkCalciteCatalogReader, FlinkRelBuilder, FlinkTypeFactory}
@@ -59,6 +60,7 @@ import org.apache.flink.table.plan.schema.FlinkRelOptTable
 import org.apache.flink.table.plan.util.AggregateUtil.transformToStreamAggregateInfoList
 import org.apache.flink.table.plan.util._
 import org.apache.flink.table.runtime.rank.{ConstantRankRange, RankType, VariableRankRange}
+import org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType
 import org.apache.flink.table.util.CountAggFunction
 import org.junit.{Before, BeforeClass}
 
@@ -951,7 +953,8 @@ class FlinkRelMdHandlerTestBase {
       windowRef,
       new FieldReferenceExpression(
         "rowtime",
-        TypeConverters.createExternalTypeInfoFromInternalType(InternalTypes.ROWTIME_INDICATOR),
+        fromLegacyInfoToDataType(
+          createExternalTypeInfoFromInternalType(InternalTypes.ROWTIME_INDICATOR)),
         0,
         4),
       intervalOfMillis(900000)

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/ExpressionResolver.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/ExpressionResolver.java
@@ -53,6 +53,8 @@ import java.util.stream.Collectors;
 
 import scala.Some;
 
+import static org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType;
+
 /**
  * Tries to resolve all unresolved expressions such as {@link UnresolvedReferenceExpression}
  * or calls such as {@link BuiltInFunctionDefinitions#OVER}.
@@ -213,7 +215,9 @@ public class ExpressionResolver {
 					.accept(bridgeConverter)
 					.resultType();
 
-			localReferences.put(windowName, new LocalReferenceExpression(windowName, windowType));
+			localReferences.put(
+				windowName,
+				new LocalReferenceExpression(windowName, fromLegacyInfoToDataType(windowType)));
 		}
 	}
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/lookups/FieldReferenceLookup.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/expressions/lookups/FieldReferenceLookup.java
@@ -90,7 +90,7 @@ public class FieldReferenceLookup {
 		return IntStream.range(0, tableSchema.getFieldCount())
 			.mapToObj(i -> new FieldReferenceExpression(
 				tableSchema.getFieldName(i).get(),
-				tableSchema.getFieldType(i).get(),
+				tableSchema.getFieldDataType(i).get(),
 				inputIdx,
 				i))
 			.collect(Collectors.toMap(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/AggregateOperationFactory.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/operations/AggregateOperationFactory.java
@@ -70,7 +70,10 @@ import static org.apache.flink.table.operations.WindowAggregateTableOperation.Re
 import static org.apache.flink.table.operations.WindowAggregateTableOperation.ResolvedGroupWindow.WindowType.TUMBLE;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.BIGINT;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.INTERVAL_DAY_TIME;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isRowtimeAttribute;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isTimeAttribute;
 
 /**
  * Utility class for creating a valid {@link AggregateTableOperation} or {@link WindowAggregateTableOperation}.
@@ -257,12 +260,15 @@ public class AggregateOperationFactory {
 		}
 
 		FieldReferenceExpression timeField = (FieldReferenceExpression) timeFieldExpr;
-		validateTimeAttributeType(timeField);
+
+		final LogicalType timeFieldType = timeField.getOutputDataType().getLogicalType();
+
+		validateTimeAttributeType(timeFieldType);
+
 		return timeField;
 	}
 
-	private void validateTimeAttributeType(FieldReferenceExpression timeField) {
-		TypeInformation<?> timeFieldType = timeField.getResultType();
+	private void validateTimeAttributeType(LogicalType timeFieldType) {
 		if (isStreaming) {
 			validateStreamTimeAttribute(timeFieldType);
 		} else {
@@ -270,15 +276,15 @@ public class AggregateOperationFactory {
 		}
 	}
 
-	private void validateBatchTimeAttribute(TypeInformation<?> timeFieldType) {
-		if (!(timeFieldType instanceof SqlTimeTypeInfo || timeFieldType == LONG_TYPE_INFO)) {
+	private void validateBatchTimeAttribute(LogicalType timeFieldType) {
+		if (!(hasRoot(timeFieldType, TIMESTAMP_WITHOUT_TIME_ZONE) || hasRoot(timeFieldType, BIGINT))) {
 			throw new ValidationException("A group window expects a time attribute for grouping " +
 				"in a batch environment.");
 		}
 	}
 
-	private void validateStreamTimeAttribute(TypeInformation<?> timeFieldType) {
-		if (!(timeFieldType instanceof TimeIndicatorTypeInfo)) {
+	private void validateStreamTimeAttribute(LogicalType timeFieldType) {
+		if (!hasRoot(timeFieldType, TIMESTAMP_WITHOUT_TIME_ZONE) || !isTimeAttribute(timeFieldType)) {
 			throw new ValidationException("A group window expects a time attribute for grouping " +
 				"in a stream environment.");
 		}
@@ -291,6 +297,7 @@ public class AggregateOperationFactory {
 		ValueLiteralExpression windowSize = getAsValueLiteral(window.getSize(),
 			"A tumble window expects a size value literal.");
 
+		final LogicalType timeFieldType = timeField.getOutputDataType().getLogicalType();
 		final LogicalType windowSizeType = windowSize.getDataType().getLogicalType();
 
 		if (!hasRoot(windowSizeType, BIGINT) && !hasRoot(windowSizeType, INTERVAL_DAY_TIME)) {
@@ -298,7 +305,7 @@ public class AggregateOperationFactory {
 				"Tumbling window expects a size literal of a day-time interval or BIGINT type.");
 		}
 
-		validateWindowIntervalType(timeField, windowSizeType);
+		validateWindowIntervalType(timeFieldType, windowSizeType);
 
 		return ResolvedGroupWindow.tumblingWindow(
 			windowName,
@@ -315,6 +322,7 @@ public class AggregateOperationFactory {
 		ValueLiteralExpression windowSlide = getAsValueLiteral(window.getSlide(),
 			"A sliding window expects a slide value literal.");
 
+		final LogicalType timeFieldType = timeField.getOutputDataType().getLogicalType();
 		final LogicalType windowSizeType = windowSize.getDataType().getLogicalType();
 		final LogicalType windowSlideType = windowSlide.getDataType().getLogicalType();
 
@@ -327,7 +335,7 @@ public class AggregateOperationFactory {
 			throw new ValidationException("A sliding window expects the same type of size and slide.");
 		}
 
-		validateWindowIntervalType(timeField, windowSizeType);
+		validateWindowIntervalType(timeFieldType, windowSizeType);
 
 		return ResolvedGroupWindow.slidingWindow(
 			windowName,
@@ -356,8 +364,9 @@ public class AggregateOperationFactory {
 			windowGap);
 	}
 
-	private void validateWindowIntervalType(FieldReferenceExpression timeField, LogicalType intervalType) {
-		if (isRowTimeIndicator(timeField) && hasRoot(intervalType, BIGINT)) {
+	private void validateWindowIntervalType(LogicalType timeFieldType, LogicalType intervalType) {
+		if (hasRoot(intervalType, TIMESTAMP_WITHOUT_TIME_ZONE) && isRowtimeAttribute(timeFieldType) &&
+				hasRoot(intervalType, BIGINT)) {
 			// unsupported row intervals on event-time
 			throw new ValidationException(
 				"Event-time grouping windows on row intervals in a stream environment " +
@@ -370,11 +379,6 @@ public class AggregateOperationFactory {
 			throw new ValidationException(exceptionMessage);
 		}
 		return (ValueLiteralExpression) expression;
-	}
-
-	private boolean isRowTimeIndicator(FieldReferenceExpression field) {
-		return field.getResultType() instanceof TimeIndicatorTypeInfo &&
-			((TimeIndicatorTypeInfo) field.getResultType()).isEventTime();
 	}
 
 	private void validateWindowProperties(List<Expression> windowProperties, ResolvedGroupWindow window) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/TableOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/TableOperationConverter.java
@@ -95,6 +95,7 @@ import static org.apache.flink.table.expressions.BuiltInFunctionDefinitions.AS;
 import static org.apache.flink.table.expressions.ExpressionUtils.extractValue;
 import static org.apache.flink.table.expressions.ExpressionUtils.isFunctionOfType;
 import static org.apache.flink.table.expressions.FunctionDefinition.Type.AGGREGATE_FUNCTION;
+import static org.apache.flink.table.types.utils.TypeConversions.fromDataTypeToLegacyInfo;
 
 /**
  * Converter from Flink's specific relational representation: {@link TableOperation} to Calcite's specific relational
@@ -337,7 +338,7 @@ public class TableOperationConverter extends TableOperationDefaultVisitor<RelNod
 		}
 
 		private LogicalWindow toLogicalWindow(ResolvedGroupWindow window) {
-			TypeInformation<?> windowType = window.getTimeAttribute().getResultType();
+			TypeInformation<?> windowType = fromDataTypeToLegacyInfo(window.getTimeAttribute().getOutputDataType());
 			WindowReference windowReference = new WindowReference(window.getAlias(), new Some<>(windowType));
 			switch (window.getType()) {
 				case SLIDE:

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionConverter.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionConverter.scala
@@ -756,7 +756,7 @@ class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExp
   override def visitFieldReference(fieldReference: FieldReferenceExpression): PlannerExpression = {
     PlannerResolvedFieldReference(
       fieldReference.getName,
-      fieldReference.getResultType)
+      fromDataTypeToLegacyInfo(fieldReference.getOutputDataType))
   }
 
   override def visitUnresolvedReference(fieldReference: UnresolvedReferenceExpression)
@@ -804,7 +804,7 @@ class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExp
 
   private def translateWindowReference(reference: Expression): PlannerExpression = reference match {
     case expr : LocalReferenceExpression =>
-      WindowReference(expr.getName, Some(expr.getResultType))
+      WindowReference(expr.getName, Some(fromDataTypeToLegacyInfo(expr.getOutputDataType)))
     //just because how the datastream is converted to table
     case expr: UnresolvedReferenceExpression =>
       UnresolvedFieldReference(expr.getName)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/operations/OperationTreeBuilder.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/operations/OperationTreeBuilder.scala
@@ -287,7 +287,7 @@ class OperationTreeBuilder(private val tableEnv: TableEnvImpl) {
       .withLocalReferences(
         new LocalReferenceExpression(
           resolvedWindow.getAlias,
-          resolvedWindow.getTimeAttribute.getResultType))
+          resolvedWindow.getTimeAttribute.getOutputDataType))
       .build
 
     val convertedGroupings = resolverWithWindowReferences.resolve(groupingExpressions)
@@ -327,7 +327,7 @@ class OperationTreeBuilder(private val tableEnv: TableEnvImpl) {
       .withLocalReferences(
         new LocalReferenceExpression(
           resolvedWindow.getAlias,
-          resolvedWindow.getTimeAttribute.getResultType))
+          resolvedWindow.getTimeAttribute.getOutputDataType))
       .build
 
     val convertedGroupings = resolverWithWindowReferences.resolve(newGroupingExpressions)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/logical/LogicalCorrelateToTemporalTableJoinRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/logical/LogicalCorrelateToTemporalTableJoinRule.scala
@@ -24,17 +24,17 @@ import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.core.TableFunctionScan
 import org.apache.calcite.rel.logical.LogicalCorrelate
 import org.apache.calcite.rex._
-import org.apache.flink.table.api.{Types, ValidationException}
-import org.apache.flink.table.calcite.FlinkTypeFactory.{isProctimeIndicatorType, isTimeIndicatorType}
+import org.apache.flink.table.api.ValidationException
+import org.apache.flink.table.calcite.FlinkRelBuilder
 import org.apache.flink.table.expressions.{FieldReferenceExpression, _}
 import org.apache.flink.table.functions.utils.TableSqlFunction
 import org.apache.flink.table.functions.{TemporalTableFunction, TemporalTableFunctionImpl}
 import org.apache.flink.table.operations.TableOperation
-import org.apache.flink.table.plan.TableOperationConverter
 import org.apache.flink.table.plan.logical.rel.LogicalTemporalTableJoin
 import org.apache.flink.table.plan.util.RexDefaultVisitor
+import org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.{hasRoot, isProctimeAttribute}
 import org.apache.flink.util.Preconditions.checkState
-import org.apache.flink.table.calcite.FlinkRelBuilder
 
 class LogicalCorrelateToTemporalTableJoinRule
   extends RelOptRule(
@@ -47,13 +47,16 @@ class LogicalCorrelateToTemporalTableJoinRule
   private def extractNameFromTimeAttribute(timeAttribute: Expression): String = {
     timeAttribute match {
       case f : FieldReferenceExpression
-        if f.getResultType == Types.LONG ||
-          f.getResultType == Types.SQL_TIMESTAMP ||
-          isTimeIndicatorType(f.getResultType) =>
+          if hasRoot(f.getOutputDataType.getLogicalType, TIMESTAMP_WITHOUT_TIME_ZONE) =>
         f.getName
       case _ => throw new ValidationException(
         s"Invalid timeAttribute [$timeAttribute] in TemporalTableFunction")
     }
+  }
+
+  private def isProctimeReference(temporalTableFunction: TemporalTableFunctionImpl): Boolean = {
+    val fieldRef = temporalTableFunction.getTimeAttribute.asInstanceOf[FieldReferenceExpression]
+    isProctimeAttribute(fieldRef.getOutputDataType.getLogicalType)
   }
 
   private def extractNameFromPrimaryKeyAttribute(expression: Expression): String = {
@@ -101,8 +104,7 @@ class LogicalCorrelateToTemporalTableJoinRule
           extractNameFromPrimaryKeyAttribute(rightTemporalTableFunction.getPrimaryKey))
 
         relBuilder.push(
-          if (isProctimeIndicatorType(rightTemporalTableFunction.getTimeAttribute
-            .asInstanceOf[FieldReferenceExpression].getResultType)) {
+          if (isProctimeReference(rightTemporalTableFunction)) {
             LogicalTemporalTableJoin.createProctime(
               rexBuilder,
               cluster,

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/expressions/rules/VerifyNoUnresolvedExpressionsRuleTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/expressions/rules/VerifyNoUnresolvedExpressionsRuleTest.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.expressions.rules;
 
-import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.FieldReferenceExpression;
@@ -54,7 +54,7 @@ public class VerifyNoUnresolvedExpressionsRuleTest {
 	public void testUnresolvedReferenceIsCatched() {
 		List<Expression> expressions = asList(
 			unresolvedRef("field"),
-			new FieldReferenceExpression("resolvedField", Types.INT, 0, 0));
+			new FieldReferenceExpression("resolvedField", DataTypes.INT(), 0, 0));
 		resolverRule.apply(expressions, resolutionContext);
 	}
 
@@ -62,14 +62,14 @@ public class VerifyNoUnresolvedExpressionsRuleTest {
 	public void testNestedUnresolvedReferenceIsCatched() {
 		List<Expression> expressions = asList(
 			call(AS, unresolvedRef("field"), valueLiteral("fieldAlias")),
-			new FieldReferenceExpression("resolvedField", Types.INT, 0, 0));
+			new FieldReferenceExpression("resolvedField", DataTypes.INT(), 0, 0));
 		resolverRule.apply(expressions, resolutionContext);
 	}
 
 	@Test(expected = TableException.class)
 	public void testFlattenCallIsCatched() {
 		List<Expression> expressions = singletonList(
-			call(FLATTEN, new FieldReferenceExpression("resolvedField", Types.INT, 0, 0))
+			call(FLATTEN, new FieldReferenceExpression("resolvedField", DataTypes.INT(), 0, 0))
 		);
 		resolverRule.apply(expressions, resolutionContext);
 	}
@@ -78,7 +78,7 @@ public class VerifyNoUnresolvedExpressionsRuleTest {
 	public void testUnresolvedOverWindowIsCatched() {
 		List<Expression> expressions = singletonList(
 			call(OVER,
-				call(COUNT, new FieldReferenceExpression("resolvedField", Types.INT, 0, 0)),
+				call(COUNT, new FieldReferenceExpression("resolvedField", DataTypes.INT(), 0, 0)),
 				new UnresolvedReferenceExpression("w")
 			)
 		);
@@ -88,7 +88,7 @@ public class VerifyNoUnresolvedExpressionsRuleTest {
 	@Test(expected = TableException.class)
 	public void testLookupCallIsCatched() {
 		List<Expression> expressions = singletonList(
-			lookupCall("unresolvedCall", new FieldReferenceExpression("resolvedField", Types.INT, 0, 0))
+			lookupCall("unresolvedCall", new FieldReferenceExpression("resolvedField", DataTypes.INT(), 0, 0))
 		);
 		resolverRule.apply(expressions, resolutionContext);
 	}

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/sql/TemporalTableJoinTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/sql/TemporalTableJoinTest.scala
@@ -50,7 +50,7 @@ class TemporalTableJoinTest extends TableTestBase {
       "o_amount * rate as rate " +
       "FROM Orders AS o, " +
       "LATERAL TABLE (Rates(o_rowtime)) AS r " +
-      "WHERE currency = o_currency";
+      "WHERE currency = o_currency"
 
     util.printSql(sqlQuery)
   }
@@ -81,7 +81,7 @@ class TemporalTableJoinTest extends TableTestBase {
         "LATERAL TABLE (Rates(o_rowtime)) AS r " +
         "WHERE currency = o_currency OR secondary_key = o_secondary_key), " +
         "Table3 " +
-      "WHERE t3_secondary_key = secondary_key";
+      "WHERE t3_secondary_key = secondary_key"
 
     util.printSql(sqlQuery)
   }
@@ -95,7 +95,7 @@ class TemporalTableJoinTest extends TableTestBase {
       "o_amount * rate as rate " +
       "FROM Orders AS o, " +
       "LATERAL TABLE (Rates(TIMESTAMP '2016-06-27 10:10:42.123')) AS r " +
-      "WHERE currency = o_currency";
+      "WHERE currency = o_currency"
 
     util.printSql(sqlQuery)
   }
@@ -105,7 +105,7 @@ class TemporalTableJoinTest extends TableTestBase {
     expectedException.expect(classOf[TableException])
     expectedException.expectMessage(startsWith("Cannot generate a valid execution plan"))
 
-    val sqlQuery = "SELECT * FROM LATERAL TABLE (Rates(TIMESTAMP '2016-06-27 10:10:42.123'))";
+    val sqlQuery = "SELECT * FROM LATERAL TABLE (Rates(TIMESTAMP '2016-06-27 10:10:42.123'))"
 
     util.printSql(sqlQuery)
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/TemporalTableJoinTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/TemporalTableJoinTest.scala
@@ -22,10 +22,11 @@ import java.sql.Timestamp
 
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{TableSchema, Types, ValidationException}
+import org.apache.flink.table.api.{DataTypes, TableSchema, ValidationException}
 import org.apache.flink.table.expressions.{Expression, FieldReferenceExpression}
 import org.apache.flink.table.functions.{TemporalTableFunction, TemporalTableFunctionImpl}
 import org.apache.flink.table.plan.logical.rel.LogicalTemporalTableJoin._
+import org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType
 import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo.{PROCTIME_INDICATOR, ROWTIME_INDICATOR}
 import org.apache.flink.table.utils.TableTestUtil._
 import org.apache.flink.table.utils._
@@ -197,14 +198,14 @@ class TemporalTableJoinTest extends TableTestBase {
       proctime: Boolean = false): Unit = {
     val rates = inputRates.asInstanceOf[TemporalTableFunctionImpl]
     assertThat(rates.getPrimaryKey,
-      equalTo[Expression](new FieldReferenceExpression("currency", Types.STRING, 0, 0)))
+      equalTo[Expression](new FieldReferenceExpression("currency", DataTypes.STRING(), 0, 0)))
 
     val (timeFieldName, timeFieldType) =
       if (proctime) {
-        ("proctime", PROCTIME_INDICATOR)
+        ("proctime", fromLegacyInfoToDataType(PROCTIME_INDICATOR))
       }
       else {
-        ("rowtime", ROWTIME_INDICATOR)
+        ("rowtime", fromLegacyInfoToDataType(ROWTIME_INDICATOR))
       }
 
     assertThat(rates.getTimeAttribute,


### PR DESCRIPTION
Mirror of apache flink#8655
## What is the purpose of the change

This PR updates field references such as `FieldReferenceExpression` or `LocalFieldReference` to the new type system.

## Brief change log

- Updated expressions and tests.


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

