### PR TITLE
Mirror of apache flink#8652

### DIFF
--- a/docs/_includes/generated/blob_server_configuration.html
+++ b/docs/_includes/generated/blob_server_configuration.html
@@ -8,14 +8,14 @@
     </thead>
     <tbody>
         <tr>
-            <td><h5>blob.client.socket.timeout</h5></td>
-            <td style="word-wrap: break-word;">300000</td>
-            <td>The socket timeout in milliseconds for the blob client.</td>
-        </tr>
-        <tr>
             <td><h5>blob.client.connect.timeout</h5></td>
             <td style="word-wrap: break-word;">0</td>
             <td>The connection timeout in milliseconds for the blob client.</td>
+        </tr>
+        <tr>
+            <td><h5>blob.client.socket.timeout</h5></td>
+            <td style="word-wrap: break-word;">300000</td>
+            <td>The socket timeout in milliseconds for the blob client.</td>
         </tr>
         <tr>
             <td><h5>blob.fetch.backlog</h5></td>

--- a/docs/_includes/generated/mesos_task_manager_configuration.html
+++ b/docs/_includes/generated/mesos_task_manager_configuration.html
@@ -13,6 +13,11 @@
             <td>Constraints for task placement on Mesos based on agent attributes. Takes a comma-separated list of key:value pairs corresponding to the attributes exposed by the target mesos agents. Example: az:eu-west-1a,series:t2</td>
         </tr>
         <tr>
+            <td><h5>mesos.resourcemanager.network.resource.name</h5></td>
+            <td style="word-wrap: break-word;">"network"</td>
+            <td>Network resource name on Mesos cluster.</td>
+        </tr>
+        <tr>
             <td><h5>mesos.resourcemanager.tasks.bootstrap-cmd</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>A command which is executed before the TaskManager is started.</td>
@@ -66,6 +71,11 @@
             <td><h5>mesos.resourcemanager.tasks.mem</h5></td>
             <td style="word-wrap: break-word;">1024</td>
             <td>Memory to assign to the Mesos workers in MB.</td>
+        </tr>
+        <tr>
+            <td><h5>mesos.resourcemanager.tasks.network.bandwidth</h5></td>
+            <td style="word-wrap: break-word;">0</td>
+            <td>Network bandwidth to assign to the Mesos workers in MB per sec.</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.tasks.taskmanager-cmd</h5></td>

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosEntrypointUtils.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosEntrypointUtils.java
@@ -109,13 +109,14 @@ public class MesosEntrypointUtils {
 		log.info("TaskManagers will be created with {} task slots",
 			taskManagerParameters.containeredParameters().numSlots());
 		log.info("TaskManagers will be started with container size {} MB, JVM heap size {} MB, " +
-				"JVM direct memory limit {} MB, {} cpus, {} gpus, disk space {} MB",
+				"JVM direct memory limit {} MB, {} cpus, {} gpus, disk space {} MB, network bandwidth {} MB / sec",
 			taskManagerParameters.containeredParameters().taskManagerTotalMemoryMB(),
 			taskManagerParameters.containeredParameters().taskManagerHeapSizeMB(),
 			taskManagerParameters.containeredParameters().taskManagerDirectMemoryLimitMB(),
 			taskManagerParameters.cpus(),
 			taskManagerParameters.gpus(),
-			taskManagerParameters.disk());
+			taskManagerParameters.disk(),
+			taskManagerParameters.network());
 
 		return taskManagerParameters;
 	}

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
@@ -140,7 +140,7 @@ public class LaunchableMesosWorker implements LaunchableTask {
 
 		@Override
 		public double getNetworkMbps() {
-			return 0.0;
+			return params.network();
 		}
 
 		@Override
@@ -223,6 +223,10 @@ public class LaunchableMesosWorker implements LaunchableTask {
 
 		if (taskRequest.getDisk() > 0.0) {
 			taskInfo.addAllResources(allocation.takeScalar("disk", taskRequest.getDisk(), roles));
+		}
+
+		if (taskRequest.getNetworkMbps() > 0.0) {
+			taskInfo.addAllResources(allocation.takeScalar("network", taskRequest.getNetworkMbps(), roles));
 		}
 
 		final Protos.CommandInfo.Builder cmd = taskInfo.getCommandBuilder();

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -64,6 +64,11 @@ public class MesosTaskManagerParameters {
 		.defaultValue(0)
 		.withDescription(Description.builder().text("Disk space to assign to the Mesos workers in MB.").build());
 
+	public static final ConfigOption<Integer> MESOS_RM_TASKS_NETWORK_MB_PER_SEC =
+		key("mesos.resourcemanager.tasks.networkBandwidth")
+			.defaultValue(0)
+			.withDescription(Description.builder().text("Network bandwidth to assign to the Mesos workers in MB per sec").build());
+
 	public static final ConfigOption<Double> MESOS_RM_TASKS_CPUS =
 		key("mesos.resourcemanager.tasks.cpus")
 		.defaultValue(0.0)
@@ -152,6 +157,8 @@ public class MesosTaskManagerParameters {
 
 	private final int disk;
 
+	private final int network;
+
 	private final ContainerType containerType;
 
 	private final Option<String> containerImageName;
@@ -178,6 +185,7 @@ public class MesosTaskManagerParameters {
 			double cpus,
 			int gpus,
 			int disk,
+			int network,
 			ContainerType containerType,
 			Option<String> containerImageName,
 			ContaineredTaskManagerParameters containeredParameters,
@@ -193,6 +201,7 @@ public class MesosTaskManagerParameters {
 		this.cpus = cpus;
 		this.gpus = gpus;
 		this.disk = disk;
+		this.network = network;
 		this.containerType = Preconditions.checkNotNull(containerType);
 		this.containerImageName = Preconditions.checkNotNull(containerImageName);
 		this.containeredParameters = Preconditions.checkNotNull(containeredParameters);
@@ -225,6 +234,13 @@ public class MesosTaskManagerParameters {
 	 */
 	public int disk() {
 		return disk;
+	}
+
+	/**
+	 * Get the network bandwidth in MB to use for the TaskManager Process.
+	 */
+	public int network() {
+		return network;
 	}
 
 	/**
@@ -353,6 +369,8 @@ public class MesosTaskManagerParameters {
 
 		int disk = flinkConfig.getInteger(MESOS_RM_TASKS_DISK_MB);
 
+		int network = flinkConfig.getInteger(MESOS_RM_TASKS_NETWORK_MB_PER_SEC);
+
 		// parse the containerization parameters
 		String imageName = flinkConfig.getString(MESOS_RM_CONTAINER_IMAGE_NAME);
 
@@ -398,6 +416,7 @@ public class MesosTaskManagerParameters {
 			cpus,
 			gpus,
 			disk,
+			network,
 			containerType,
 			Option.apply(imageName),
 			containeredParameters,

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -65,9 +65,14 @@ public class MesosTaskManagerParameters {
 		.withDescription(Description.builder().text("Disk space to assign to the Mesos workers in MB.").build());
 
 	public static final ConfigOption<Integer> MESOS_RM_TASKS_NETWORK_MB_PER_SEC =
-		key("mesos.resourcemanager.tasks.networkBandwidth")
+		key("mesos.resourcemanager.tasks.network.bandwidth")
 			.defaultValue(0)
-			.withDescription(Description.builder().text("Network bandwidth to assign to the Mesos workers in MB per sec").build());
+			.withDescription(Description.builder().text("Network bandwidth to assign to the Mesos workers in MB per sec.").build());
+
+	public static final ConfigOption<String> MESOS_RM_NETWORK_RESOURCE_NAME =
+		key("mesos.resourcemanager.network.resource.name")
+			.defaultValue("network")
+			.withDescription(Description.builder().text("Network resource name on Mesos cluster.").build());
 
 	public static final ConfigOption<Double> MESOS_RM_TASKS_CPUS =
 		key("mesos.resourcemanager.tasks.cpus")

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/scheduler/Offer.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/scheduler/Offer.java
@@ -62,6 +62,10 @@ public class Offer implements VirtualMachineLease {
 	private final List<Range> portRanges;
 
 	public Offer(Protos.Offer offer) {
+		this(offer, "network");
+	}
+
+	public Offer(Protos.Offer offer, String networkResourceName) {
 		this.offer = checkNotNull(offer);
 		this.hostname = offer.getHostname();
 		this.vmID = offer.getSlaveId().getValue();
@@ -98,7 +102,7 @@ public class Offer implements VirtualMachineLease {
 
 		this.cpuCores = aggregatedScalarResourceMap.remove("cpus");
 		this.memoryMB = aggregatedScalarResourceMap.remove("mem");
-		this.networkMbps = aggregatedScalarResourceMap.remove("network");
+		this.networkMbps = aggregatedScalarResourceMap.remove(networkResourceName);
 		this.diskMB = aggregatedScalarResourceMap.remove("disk");
 		this.aggregatedScalarResourceMap = Collections.unmodifiableMap(aggregatedScalarResourceMap);
 		this.portRanges = Collections.unmodifiableList(aggregateRangesResource(rangesResourceMap, "ports"));

--- a/flink-mesos/src/main/scala/org/apache/flink/mesos/scheduler/LaunchCoordinator.scala
+++ b/flink-mesos/src/main/scala/org/apache/flink/mesos/scheduler/LaunchCoordinator.scala
@@ -24,13 +24,14 @@ import akka.actor.{Actor, ActorRef, FSM, Props}
 import com.netflix.fenzo._
 import com.netflix.fenzo.functions.Action1
 import grizzled.slf4j.Logger
-import org.apache.flink.api.java.tuple.{Tuple2=>FlinkTuple2}
+import org.apache.flink.api.java.tuple.{Tuple2 => FlinkTuple2}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.mesos.Utils
+import org.apache.flink.mesos.runtime.clusterframework.MesosTaskManagerParameters
 import org.apache.flink.mesos.scheduler.LaunchCoordinator._
 import org.apache.flink.mesos.scheduler.messages._
 import org.apache.flink.mesos.util.MesosResourceAllocation
-import org.apache.mesos.{SchedulerDriver, Protos}
+import org.apache.mesos.{Protos, SchedulerDriver}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.{Map => MutableMap}
@@ -148,17 +149,24 @@ class LaunchCoordinator(
       goto(Suspended) using data.copy(newLeases = Nil)
 
     case Event(offers: ResourceOffers, data: GatherData) =>
-      val leases = offers.offers().asScala.map(new Offer(_))
+      val mesosRmNetworkResourceName = MesosTaskManagerParameters.MESOS_RM_NETWORK_RESOURCE_NAME
+      val networkResourceName = config.getString(mesosRmNetworkResourceName)
+      val leases = offers.offers().asScala.map(new Offer(_, networkResourceName))
       if(LOG.isInfoEnabled) {
-        val (cpus, gpus, mem) = leases.foldLeft((0.0,0.0,0.0)) {
-          (z,o) => (z._1 + o.cpuCores(), z._2 + o.gpus(), z._3 + o.memoryMB())
+        val (cpus, gpus, mem, network) = leases.foldLeft((0.0,0.0,0.0,0.0)) {
+          (z,o) => (
+            z._1 + o.cpuCores(),
+            z._2 + o.gpus(),
+            z._3 + o.memoryMB(),
+            z._4 + o.networkMbps()
+          )
         }
-        LOG.info(s"Received offer(s) of $mem MB, $cpus cpus, $gpus gpus:")
+        LOG.info(s"Received offer(s) of $mem MB, $cpus cpus, $gpus gpus, $network mb/sec:")
         for(l <- leases) {
           val reservations = l.getResources.asScala.map(_.getRole).toSet
           LOG.info(
             s"  ${l.getId} from ${l.hostname()} of ${l.memoryMB()} MB," +
-            s" ${l.cpuCores()} cpus, ${l.gpus()} gpus" +
+            s" ${l.cpuCores()} cpus, ${l.gpus()} gpus, ${l.networkMbps()} mb/sec" +
             s" for ${reservations.mkString("[", ",", "]")}")
         }
       }

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -279,7 +279,7 @@ public class MesosResourceManagerTest extends TestLogger {
 			ContaineredTaskManagerParameters containeredParams =
 				new ContaineredTaskManagerParameters(1024, 768, 256, 4, new HashMap<String, String>());
 			MesosTaskManagerParameters tmParams = new MesosTaskManagerParameters(
-				1.0, 1, 0, MesosTaskManagerParameters.ContainerType.MESOS, Option.<String>empty(), containeredParams,
+				1.0, 1, 0, 0, MesosTaskManagerParameters.ContainerType.MESOS, Option.<String>empty(), containeredParams,
 				Collections.<Protos.Volume>emptyList(), Collections.<Protos.Parameter>emptyList(), false,
 				Collections.<ConstraintEvaluator>emptyList(), "", Option.<String>empty(),
 				Option.<String>empty(), Collections.<String>emptyList());


### PR DESCRIPTION
Mirror of apache flink#8652
## What is the purpose of the change

Flink will be able to support network bandwidth customization. Since network resource is not standardized in Mesos we should specify the network resource name in config. By default we use name: 'network' which is used in Fenzo.

Network configuration is optional.

## Brief change log

  - *Added configuration for the network bandwidth usage*
  - *Added configuration for the network resource name on Mesos*


## Verifying this change

It is a configuration logic. The potential test would have at least the same complexity as implementation.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / *no*)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (yes / *no*)
  - The serializers: (yes / *no* / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / *no* / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (*yes* / no / don't know)
  - The S3 file system connector: (yes / *no* / don't know)

## Documentation

  - Does this pull request introduce a new feature? (*yes* / no)
  - If yes, how is the feature documented? (not applicable / *docs* / JavaDocs / not documented)

