### PR TITLE
Mirror of apache flink#8648

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferProvider.java
@@ -63,11 +63,4 @@ public interface BufferProvider {
 	 * Returns whether the buffer provider has been destroyed.
 	 */
 	boolean isDestroyed();
-
-	/**
-	 * Returns the size of the underlying memory segments. This is the maximum size a {@link Buffer}
-	 * instance can have.
-	 */
-	int getMemorySegmentSize();
-
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
@@ -165,11 +165,6 @@ class LocalBufferPool implements BufferPool {
 	}
 
 	@Override
-	public int getMemorySegmentSize() {
-		return networkBufferPool.getMemorySegmentSize();
-	}
-
-	@Override
 	public int getNumberOfRequiredMemorySegments() {
 		return numberOfRequiredMemorySegments;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -225,10 +225,6 @@ public class NetworkBufferPool implements BufferPoolFactory, MemorySegmentProvid
 		return isDestroyed;
 	}
 
-	public int getMemorySegmentSize() {
-		return memorySegmentSize;
-	}
-
 	public int getTotalNumberOfMemorySegments() {
 		return totalNumberOfMemorySegments;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
@@ -41,7 +41,7 @@ import java.util.Optional;
  * Factory for {@link ResultPartition} to use in {@link org.apache.flink.runtime.io.network.NetworkEnvironment}.
  */
 public class ResultPartitionFactory {
-	private static final Logger LOG = LoggerFactory.getLogger(ResultPartition.class);
+	private static final Logger LOG = LoggerFactory.getLogger(ResultPartitionFactory.class);
 
 	@Nonnull
 	private final ResultPartitionManager partitionManager;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
@@ -95,8 +95,6 @@ public abstract class InputGate implements AsyncDataInput<BufferOrEvent>, AutoCl
 
 	public abstract void sendTaskEvent(TaskEvent event) throws IOException;
 
-	public abstract int getPageSize();
-
 	/**
 	 * @return a future that is completed if there are more records available. If there are more
 	 * records available immediately, {@link #AVAILABLE} should be returned. Previously returned

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -243,16 +243,6 @@ public class SingleInputGate extends InputGate {
 		return bufferPool;
 	}
 
-	@Override
-	public int getPageSize() {
-		if (bufferPool != null) {
-			return bufferPool.getMemorySegmentSize();
-		}
-		else {
-			throw new IllegalStateException("Input gate has not been initialized with buffers.");
-		}
-	}
-
 	public int getNumberOfQueuedBuffers() {
 		// re-try 3 times, if fails, return 0 for "unknown"
 		for (int retry = 0; retry < 3; retry++) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
@@ -265,19 +265,6 @@ public class UnionInputGate extends InputGate {
 	}
 
 	@Override
-	public int getPageSize() {
-		int pageSize = -1;
-		for (InputGate gate : inputGates) {
-			if (pageSize == -1) {
-				pageSize = gate.getPageSize();
-			} else if (gate.getPageSize() != pageSize) {
-				throw new IllegalStateException("Found input gates with different page sizes.");
-			}
-		}
-		return pageSize;
-	}
-
-	@Override
 	public void setup() {
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
@@ -86,11 +86,6 @@ public class InputGateWithMetrics extends InputGate {
 	}
 
 	@Override
-	public int getPageSize() {
-		return inputGate.getPageSize();
-	}
-
-	@Override
 	public void close() throws Exception {
 		inputGate.close();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NetworkEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NetworkEnvironmentConfiguration.java
@@ -26,9 +26,7 @@ import org.apache.flink.configuration.NetworkEnvironmentOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.io.network.netty.NettyConfig;
-import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
-import org.apache.flink.util.MathUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,8 +34,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-
-import static org.apache.flink.util.MathUtils.checkedDownCast;
 
 /**
  * Configuration object for the network stack.
@@ -145,7 +141,7 @@ public class NetworkEnvironmentConfiguration {
 
 		final int dataport = getDataport(configuration);
 
-		final int pageSize = getPageSize(configuration);
+		final int pageSize = ConfigurationParserUtils.getPageSize(configuration);
 
 		final int numberOfNetworkBuffers = calculateNumberOfNetworkBuffers(configuration, maxJvmHeapMemory);
 
@@ -247,7 +243,7 @@ public class NetworkEnvironmentConfiguration {
 	 */
 	@SuppressWarnings("deprecation")
 	public static long calculateNetworkBufferMemory(long totalJavaMemorySize, Configuration config) {
-		final int segmentSize = getPageSize(config);
+		final int segmentSize = ConfigurationParserUtils.getPageSize(config);
 
 		final long networkBufBytes;
 		if (hasNewNetworkConfig(config)) {
@@ -292,7 +288,7 @@ public class NetworkEnvironmentConfiguration {
 		long networkBufMin = MemorySize.parse(config.getString(NetworkEnvironmentOptions.NETWORK_BUFFERS_MEMORY_MIN)).getBytes();
 		long networkBufMax = MemorySize.parse(config.getString(NetworkEnvironmentOptions.NETWORK_BUFFERS_MEMORY_MAX)).getBytes();
 
-		int pageSize = getPageSize(config);
+		int pageSize = ConfigurationParserUtils.getPageSize(config);
 
 		checkNewNetworkConfig(pageSize, networkBufFraction, networkBufMin, networkBufMax);
 
@@ -413,7 +409,7 @@ public class NetworkEnvironmentConfiguration {
 			final long networkMemorySize = calculateNewNetworkBufferMemory(configuration, maxJvmHeapMemory);
 
 			// tolerate offcuts between intended and allocated memory due to segmentation (will be available to the user-space memory)
-			long numberOfNetworkBuffersLong = networkMemorySize / getPageSize(configuration);
+			long numberOfNetworkBuffersLong = networkMemorySize / ConfigurationParserUtils.getPageSize(configuration);
 			if (numberOfNetworkBuffersLong > Integer.MAX_VALUE) {
 				throw new IllegalArgumentException("The given number of memory bytes (" + networkMemorySize
 					+ ") corresponds to more than MAX_INT pages.");
@@ -444,35 +440,17 @@ public class NetworkEnvironmentConfiguration {
 		if (!localTaskManagerCommunication) {
 			final InetSocketAddress taskManagerInetSocketAddress = new InetSocketAddress(taskManagerAddress, dataport);
 
-			nettyConfig = new NettyConfig(taskManagerInetSocketAddress.getAddress(), taskManagerInetSocketAddress.getPort(),
-				getPageSize(configuration), ConfigurationParserUtils.getSlot(configuration), configuration);
+			nettyConfig = new NettyConfig(
+				taskManagerInetSocketAddress.getAddress(),
+				taskManagerInetSocketAddress.getPort(),
+				ConfigurationParserUtils.getPageSize(configuration),
+				ConfigurationParserUtils.getSlot(configuration),
+				configuration);
 		} else {
 			nettyConfig = null;
 		}
 
 		return nettyConfig;
-	}
-
-	/**
-	 * Parses the configuration to get the page size and validates the value.
-	 *
-	 * @param configuration configuration object
-	 * @return size of memory segment
-	 */
-	public static int getPageSize(Configuration configuration) {
-		final int pageSize = checkedDownCast(MemorySize.parse(
-			configuration.getString(TaskManagerOptions.MEMORY_SEGMENT_SIZE)).getBytes());
-
-		// check page size of for minimum size
-		ConfigurationParserUtils.checkConfigParameter(pageSize >= MemoryManager.MIN_PAGE_SIZE, pageSize,
-			TaskManagerOptions.MEMORY_SEGMENT_SIZE.key(),
-			"Minimum memory segment size is " + MemoryManager.MIN_PAGE_SIZE);
-		// check page size for power of two
-		ConfigurationParserUtils.checkConfigParameter(MathUtils.isPowerOf2(pageSize), pageSize,
-			TaskManagerOptions.MEMORY_SEGMENT_SIZE.key(),
-			"Memory segment size must be a power of 2.");
-
-		return pageSize;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ConfigurationParserUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ConfigurationParserUtils.java
@@ -23,8 +23,11 @@ import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.memory.MemoryType;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.util.MathUtils;
 
 import static org.apache.flink.configuration.MemorySize.MemoryUnit.MEGA_BYTES;
+import static org.apache.flink.util.MathUtils.checkedDownCast;
 
 /**
  * Utility class to extract related parameters from {@link Configuration} and to
@@ -111,6 +114,28 @@ public class ConfigurationParserUtils {
 			"Number of task slots must be at least one.");
 
 		return slots;
+	}
+
+	/**
+	 * Parses the configuration to get the page size and validates the value.
+	 *
+	 * @param configuration configuration object
+	 * @return size of memory segment
+	 */
+	public static int getPageSize(Configuration configuration) {
+		final int pageSize = checkedDownCast(MemorySize.parse(
+			configuration.getString(TaskManagerOptions.MEMORY_SEGMENT_SIZE)).getBytes());
+
+		// check page size of for minimum size
+		ConfigurationParserUtils.checkConfigParameter(pageSize >= MemoryManager.MIN_PAGE_SIZE, pageSize,
+			TaskManagerOptions.MEMORY_SEGMENT_SIZE.key(),
+			"Minimum memory segment size is " + MemoryManager.MIN_PAGE_SIZE);
+		// check page size for power of two
+		ConfigurationParserUtils.checkConfigParameter(MathUtils.isPowerOf2(pageSize), pageSize,
+			TaskManagerOptions.MEMORY_SEGMENT_SIZE.key(),
+			"Memory segment size must be a power of 2.");
+
+		return pageSize;
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
@@ -61,7 +61,6 @@ public class NetworkBufferPoolTest extends TestLogger {
 			final int numBuffers = 10;
 
 			NetworkBufferPool globalPool = new NetworkBufferPool(numBuffers, bufferSize, 1);
-			assertEquals(bufferSize, globalPool.getMemorySegmentSize());
 			assertEquals(numBuffers, globalPool.getTotalNumberOfMemorySegments());
 			assertEquals(numBuffers, globalPool.getNumberOfAvailableMemorySegments());
 			assertEquals(0, globalPool.getNumberOfRegisteredBufferPools());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestBufferFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestBufferFactory.java
@@ -64,10 +64,6 @@ public class TestBufferFactory {
 		return numberOfCreatedBuffers;
 	}
 
-	public synchronized int getBufferSize() {
-		return bufferSize;
-	}
-
 	// ------------------------------------------------------------------------
 	// Static test helpers
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestPooledBufferProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestPooledBufferProvider.java
@@ -96,11 +96,6 @@ public class TestPooledBufferProvider implements BufferProvider {
 		return false;
 	}
 
-	@Override
-	public int getMemorySegmentSize() {
-		return bufferFactory.getBufferSize();
-	}
-
 	public int getNumberOfAvailableBuffers() {
 		return buffers.size();
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
@@ -51,7 +51,6 @@ import org.apache.flink.runtime.taskexecutor.rpc.RpcResultPartitionConsumableNot
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
 import org.apache.flink.runtime.taskexecutor.slot.TimerService;
 import org.apache.flink.runtime.taskmanager.CheckpointResponder;
-import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfiguration;
 import org.apache.flink.runtime.taskmanager.NoOpTaskManagerActions;
 import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.runtime.taskmanager.TaskManagerActions;
@@ -244,7 +243,9 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
 				InetAddress.getByName(testingRpcService.getAddress()), configuration.getInteger(NetworkEnvironmentOptions.DATA_PORT));
 
 			final NettyConfig nettyConfig = new NettyConfig(socketAddress.getAddress(), socketAddress.getPort(),
-				NetworkEnvironmentConfiguration.getPageSize(configuration), ConfigurationParserUtils.getSlot(configuration), configuration);
+				ConfigurationParserUtils.getPageSize(configuration),
+				ConfigurationParserUtils.getSlot(configuration),
+				configuration);
 
 			networkEnvironment =  new NetworkEnvironmentBuilder()
 				.setTaskManagerLocation(taskManagerLocation)

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CachedBufferBlocker.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CachedBufferBlocker.java
@@ -34,9 +34,6 @@ import java.util.ArrayDeque;
 @Internal
 public class CachedBufferBlocker implements BufferBlocker {
 
-	/** The page size, to estimate the total cached data size. */
-	private final int pageSize;
-
 	/** The number of bytes cached since the last roll over. */
 	private long bytesBlocked;
 
@@ -45,17 +42,14 @@ public class CachedBufferBlocker implements BufferBlocker {
 
 	/**
 	 * Creates a new buffer blocker, caching the buffers or events in memory queue.
-	 *
-	 * @param pageSize The page size used to estimate the cached size.
 	 */
-	public CachedBufferBlocker(int pageSize) {
-		this.pageSize = pageSize;
+	public CachedBufferBlocker() {
 		this.currentBuffers = new ArrayDeque<BufferOrEvent>();
 	}
 
 	@Override
 	public void add(BufferOrEvent boe) {
-		bytesBlocked += pageSize;
+		bytesBlocked += boe.getSize();
 
 		currentBuffers.add(boe);
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
@@ -56,7 +56,7 @@ public class InputProcessorUtil {
 			if (taskManagerConfig.getBoolean(NetworkEnvironmentOptions.NETWORK_CREDIT_MODEL)) {
 				barrierHandler = new BarrierBuffer(
 					inputGate,
-					new CachedBufferBlocker(inputGate.getPageSize()),
+					new CachedBufferBlocker(),
 					maxAlign,
 					taskName);
 			} else {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.NetworkEnvironmentOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.util.ConfigurationParserUtils;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 
@@ -62,7 +63,7 @@ public class InputProcessorUtil {
 			} else {
 				barrierHandler = new BarrierBuffer(
 					inputGate,
-					new BufferSpiller(ioManager, inputGate.getPageSize()),
+					new BufferSpiller(ioManager, ConfigurationParserUtils.getPageSize(taskManagerConfig)),
 					maxAlign,
 					taskName);
 			}

--- a/flink-streaming-java/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/StreamTestSingleInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/StreamTestSingleInputGate.java
@@ -79,7 +79,7 @@ public class StreamTestSingleInputGate<T> extends TestSingleInputGate {
 		inputQueues = new ConcurrentLinkedQueue[numInputChannels];
 
 		setupInputChannels();
-		inputGate.setBufferPool(new NoOpBufferPool(bufferSize));
+		inputGate.setBufferPool(new NoOpBufferPool());
 	}
 
 	@SuppressWarnings("unchecked")
@@ -224,19 +224,12 @@ public class StreamTestSingleInputGate<T> extends TestSingleInputGate {
 	}
 
 	private static class NoOpBufferPool implements BufferPool {
-		private int bufferSize;
 
-		public NoOpBufferPool(int bufferSize) {
-			this.bufferSize = bufferSize;
+		public NoOpBufferPool() {
 		}
 
 		@Override
 		public void lazyDestroy() {
-		}
-
-		@Override
-		public int getMemorySegmentSize() {
-			return bufferSize;
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferAlignmentLimitTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferAlignmentLimitTest.java
@@ -114,8 +114,8 @@ public class BarrierBufferAlignmentLimitTest {
 		};
 
 		// the barrier buffer has a limit that only 1000 bytes may be spilled in alignment
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
-		BarrierBuffer buffer = new BarrierBuffer(gate, new BufferSpiller(ioManager, gate.getPageSize()), 1000, "Testing");
+		MockInputGate gate = new MockInputGate(3, Arrays.asList(sequence));
+		BarrierBuffer buffer = new BarrierBuffer(gate, new BufferSpiller(ioManager, PAGE_SIZE), 1000, "Testing");
 
 		AbstractInvokable toNotify = mock(AbstractInvokable.class);
 		buffer.registerCheckpointEventHandler(toNotify);
@@ -208,8 +208,8 @@ public class BarrierBufferAlignmentLimitTest {
 		};
 
 		// the barrier buffer has a limit that only 1000 bytes may be spilled in alignment
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
-		BarrierBuffer buffer = new BarrierBuffer(gate, new BufferSpiller(ioManager, gate.getPageSize()), 500, "Testing");
+		MockInputGate gate = new MockInputGate(3, Arrays.asList(sequence));
+		BarrierBuffer buffer = new BarrierBuffer(gate, new BufferSpiller(ioManager, PAGE_SIZE), 500, "Testing");
 
 		AbstractInvokable toNotify = mock(AbstractInvokable.class);
 		buffer.registerCheckpointEventHandler(toNotify);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferMassiveRandomTest.java
@@ -62,7 +62,7 @@ public class BarrierBufferMassiveRandomTest {
 					new BufferPool[] { pool1, pool2 },
 					new BarrierGenerator[] { new CountBarrier(100000), new RandomBarrier(100000) });
 
-			BarrierBuffer barrierBuffer = new BarrierBuffer(myIG, new BufferSpiller(ioMan, myIG.getPageSize()));
+			BarrierBuffer barrierBuffer = new BarrierBuffer(myIG, new BufferSpiller(ioMan, PAGE_SIZE));
 
 			for (int i = 0; i < 2000000; i++) {
 				BufferOrEvent boe = barrierBuffer.pollNext().get();
@@ -185,11 +185,6 @@ public class BarrierBufferMassiveRandomTest {
 
 		@Override
 		public void sendTaskEvent(TaskEvent event) {}
-
-		@Override
-		public int getPageSize() {
-			return PAGE_SIZE;
-		}
 
 		@Override
 		public void setup() {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferTestBase.java
@@ -73,7 +73,7 @@ public abstract class BarrierBufferTestBase {
 	BarrierBuffer buffer;
 
 	protected BarrierBuffer createBarrierBuffer(int numberOfChannels, BufferOrEvent[] sequence) throws IOException {
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, numberOfChannels, Arrays.asList(sequence));
+		MockInputGate gate = new MockInputGate(numberOfChannels, Arrays.asList(sequence));
 		return createBarrierBuffer(gate);
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierTrackerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierTrackerTest.java
@@ -392,7 +392,7 @@ public class BarrierTrackerTest {
 	// ------------------------------------------------------------------------
 
 	private static BarrierTracker createBarrierTracker(int numberOfChannels, BufferOrEvent[] sequence) {
-		MockInputGate gate = new MockInputGate(PAGE_SIZE, numberOfChannels, Arrays.asList(sequence));
+		MockInputGate gate = new MockInputGate(numberOfChannels, Arrays.asList(sequence));
 		return new BarrierTracker(gate);
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CachedBufferBlockerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CachedBufferBlockerTest.java
@@ -36,7 +36,7 @@ public class CachedBufferBlockerTest extends BufferBlockerTestBase {
 
 	@Before
 	public void createBlocker() {
-		bufferBlocker = new CachedBufferBlocker(PAGE_SIZE);
+		bufferBlocker = new CachedBufferBlocker();
 	}
 
 	@After

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CreditBasedBarrierBufferTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CreditBasedBarrierBufferTest.java
@@ -32,7 +32,7 @@ public class CreditBasedBarrierBufferTest extends BarrierBufferTestBase {
 
 	@Override
 	public BarrierBuffer createBarrierBuffer(InputGate gate) throws IOException {
-		return new BarrierBuffer(gate, new CachedBufferBlocker(PAGE_SIZE));
+		return new BarrierBuffer(gate, new CachedBufferBlocker());
 	}
 
 	@Override
@@ -40,7 +40,7 @@ public class CreditBasedBarrierBufferTest extends BarrierBufferTestBase {
 		long expectedBuffered = 0;
 		for (BufferOrEvent boe : sequence) {
 			if (boe.isBuffer()) {
-				expectedBuffered += PAGE_SIZE;
+				expectedBuffered += boe.getSize();
 			}
 		}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
@@ -33,8 +33,6 @@ import java.util.Queue;
  */
 public class MockInputGate extends InputGate {
 
-	private final int pageSize;
-
 	private final int numberOfChannels;
 
 	private final Queue<BufferOrEvent> bufferOrEvents;
@@ -43,18 +41,12 @@ public class MockInputGate extends InputGate {
 
 	private int closedChannels;
 
-	public MockInputGate(int pageSize, int numberOfChannels, List<BufferOrEvent> bufferOrEvents) {
-		this.pageSize = pageSize;
+	MockInputGate(int numberOfChannels, List<BufferOrEvent> bufferOrEvents) {
 		this.numberOfChannels = numberOfChannels;
 		this.bufferOrEvents = new ArrayDeque<BufferOrEvent>(bufferOrEvents);
 		this.closed = new boolean[numberOfChannels];
 
 		isAvailable = AVAILABLE;
-	}
-
-	@Override
-	public int getPageSize() {
-		return pageSize;
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
@@ -47,7 +47,6 @@ import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.taskmanager.ConsumableNotifyingResultPartitionWriterDecorator;
 import org.apache.flink.runtime.taskmanager.InputGateWithMetrics;
-import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfiguration;
 import org.apache.flink.runtime.taskmanager.NoOpTaskActions;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
@@ -203,7 +202,7 @@ public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> {
 		final NettyConfig nettyConfig = new NettyConfig(
 			LOCAL_ADDRESS,
 			0,
-			NetworkEnvironmentConfiguration.getPageSize(config),
+			ConfigurationParserUtils.getPageSize(config),
 			// please note that the number of slots directly influences the number of netty threads!
 			ConfigurationParserUtils.getSlot(config),
 			config);


### PR DESCRIPTION
Mirror of apache flink#8648
## What is the purpose of the change

*Currently `InputGate#getPageSize` is only used for constructing `BarrierBuffer`. In order to make abstract `InputGate` simple and clean, we should remove unnecessary abstract methods from it.
Considering the page size could be parsed directly from configuration which could also visible while constructing `BarrierBuffer`, so it is reasonable to do so.*

## Brief change log

  - *Remove the parameter of page size from `CachedBufferBlocker` constructor*
  - *Refactor `getPageSize` utility from `NetworkEnvironmentConfiguration` to `ConfigurationParserUtils`*
  - *Remove `getPageSize` method from `InputGate`*
  -  *Remove `getMemorySegmentSize` method from `BufferProvider` interface*
  - *Remove unnecessary `getMemorySegmentSize` method from `NetworkBufferPool`*

## Verifying this change

*Covered by existing tests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
