### PR TITLE
Mirror of apache flink#8644

### DIFF
--- a/flink-table/flink-sql-parser/pom.xml
+++ b/flink-table/flink-sql-parser/pom.xml
@@ -222,7 +222,7 @@ under the License.
 					<dependency>
 						<groupId>org.freemarker</groupId>
 						<artifactId>freemarker</artifactId>
-						<version>2.3.25-incubating</version>
+						<version>2.3.28</version>
 					</dependency>
 				</dependencies>
 				<executions>
@@ -236,25 +236,6 @@ under the License.
 							<cfgFile>${project.build.directory}/codegen/config.fmpp</cfgFile>
 							<outputDirectory>target/generated-sources</outputDirectory>
 							<templateDirectory>${project.build.directory}/codegen/templates</templateDirectory>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>1.5</version>
-				<executions>
-					<execution>
-						<id>add-generated-sources</id>
-						<phase>process-sources</phase>
-						<goals>
-							<goal>add-source</goal>
-						</goals>
-						<configuration>
-							<sources>
-								<source>${project.build.directory}/generated-sources</source>
-							</sources>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
Mirror of apache flink#8644
## What is the purpose of the change

Fix the flink-sql-parser compile error, before this patch, the CRON build throws error: 
`Could not find goal 'regex-property' in plugin org.codehaus.mojo:build-helper-maven-plugin:1.5 among available goals reserve-network-port, parse-version, maven-version, add-test-resource, add-test-source, add-resource, attach-artifact, add-source, remove-project-artifact`

with environment:
compile - scala 2.12
JDK: openjdk8 Java
PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.12"

## Brief change log

  - *remove plugin org.codehaus.mojo:build-helper-maven-plugin*

## Verifying this change

no tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

