### PR TITLE
Mirror of apache flink#8640

### DIFF
--- a/docs/dev/connectors/guarantees.md
+++ b/docs/dev/connectors/guarantees.md
@@ -104,8 +104,8 @@ state updates) of Flink coupled with bundled sinks:
     </tr>
     <tr>
         <td>Kafka producer</td>
-        <td>at least once</td>
-        <td></td>
+        <td>at least once / exactly once</td>
+        <td>exactly once with transactional producers (v 0.11+)</td>
     </tr>
     <tr>
         <td>Cassandra sink</td>

--- a/docs/dev/connectors/guarantees.zh.md
+++ b/docs/dev/connectors/guarantees.zh.md
@@ -104,8 +104,8 @@ state updates) of Flink coupled with bundled sinks:
     </tr>
     <tr>
         <td>Kafka producer</td>
-        <td>at least once</td>
-        <td></td>
+        <td>at least once/ exactly once</td>
+        <td>exactly once with transactional producers (v 0.11+)</td>
     </tr>
     <tr>
         <td>Cassandra sink</td>


### PR DESCRIPTION
Mirror of apache flink#8640
## What is the purpose of the change

Since Flink 1.4.0, we provide exactly-once semantic on Kafka 0.11+, but the document is still not updated.

## Brief change log

- Add exactly-once semantics to guarantees of Kafka producer.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 

