### PR TITLE
Mirror of apache flink#8634

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/factories/TableFactoryUtil.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/factories/TableFactoryUtil.java
@@ -48,21 +48,27 @@ public class TableFactoryUtil {
 	public static <T> TableSource<T> findAndCreateTableSource(Descriptor descriptor) {
 		Map<String, String> properties = descriptor.toProperties();
 
-		TableSource tableSource;
+		return findAndCreateTableSource(properties);
+	}
+
+	/**
+	 * Returns a table source matching the properties.
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T> TableSource<T> findAndCreateTableSource(Map<String, String> properties) {
 		try {
-			tableSource = TableFactoryService
+			return TableFactoryService
 				.find(TableSourceFactory.class, properties)
 				.createTableSource(properties);
 		} catch (Throwable t) {
 			throw new TableException("findAndCreateTableSource failed.", t);
 		}
-
-		return tableSource;
 	}
 
 	/**
 	 * Returns a table sink matching the descriptor.
 	 */
+	@SuppressWarnings("unchecked")
 	public static <T> TableSink<T> findAndCreateTableSink(Descriptor descriptor) {
 		Map<String, String> properties = descriptor.toProperties();
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/catalog/DatabaseCalciteSchemaTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/catalog/DatabaseCalciteSchemaTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.TestExternalTableSourceFactory.TestExternalTableSource;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
+import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
+import org.apache.flink.table.plan.schema.TableSourceTable;
+
+import org.apache.calcite.schema.Table;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.table.catalog.TestExternalTableSourceFactory.TEST_EXTERNAL_CONNECTOR_TYPE;
+import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link DatabaseCalciteSchema}.
+ */
+public class DatabaseCalciteSchemaTest {
+	@Test
+	public void testCatalogTable() throws TableAlreadyExistException, DatabaseNotExistException {
+		String databaseName = "db";
+		GenericInMemoryCatalog catalog = new GenericInMemoryCatalog("cat", databaseName);
+		DatabaseCalciteSchema calciteSchema = new DatabaseCalciteSchema(
+			databaseName,
+			"cat",
+			catalog);
+
+		String tableName = "tab";
+		catalog.createTable(new ObjectPath(databaseName, tableName), new TestCatalogBaseTable(), false);
+		Table table = calciteSchema.getTable(tableName);
+
+		assertThat(table, instanceOf(TableSourceTable.class));
+		TableSourceTable tableSourceTable = (TableSourceTable) table;
+		assertThat(tableSourceTable.tableSource(), instanceOf(TestExternalTableSource.class));
+		assertThat(tableSourceTable.isStreaming(), is(true));
+	}
+
+	private static final class TestCatalogBaseTable extends GenericCatalogTable {
+		private TestCatalogBaseTable() {
+			super(TableSchema.builder().build(), new HashMap<>(), "");
+		}
+
+		@Override
+		public GenericCatalogTable copy() {
+			return this;
+		}
+
+		@Override
+		public Map<String, String> toProperties() {
+			Map<String, String> properties = new HashMap<>();
+			properties.put(CONNECTOR_TYPE, TEST_EXTERNAL_CONNECTOR_TYPE);
+			return properties;
+		}
+	}
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/catalog/TestExternalTableSourceFactory.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/catalog/TestExternalTableSourceFactory.java
@@ -62,7 +62,10 @@ public class TestExternalTableSourceFactory implements TableSourceFactory<Row> {
 		return new TestExternalTableSource();
 	}
 
-	private static class TestExternalTableSource implements StreamTableSource<Row>, BatchTableSource<Row> {
+	/**
+	 * Dummy table source for tests.
+	 */
+	public static class TestExternalTableSource implements StreamTableSource<Row>, BatchTableSource<Row> {
 		private final TableSchema tableSchema = new TableSchema(new String[0], new TypeInformation[0]);
 
 		@Override


### PR DESCRIPTION
Mirror of apache flink#8634
## What is the purpose of the change

The purpose is to create a `TableSource` out of properties extracted from `CatalogTable`

## Brief change log


  - Instantiating the `TableSource` in `DatabaseCalciteSchema`, the assumption is that you can instatiate only `StreamTableSource` out of `CatalogTable` (Batch tables for Blink planner will be a special kind of `BoundedTableSource`. The old `BatchTableSources` will not be supported.


## Verifying this change

This change added test:
* `DatabaseCalciteSchemaTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

