### PR TITLE
Mirror of apache flink#8630

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -687,7 +687,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 			}
 
 			else if (current == FINISHED || current == FAILED) {
-				// nothing to do any more. finished failed before it could be cancelled.
+				// nothing to do any more. finished/failed before it could be cancelled.
 				// in any case, the task is removed from the TaskManager already
 				sendReleaseIntermediateResultPartitionsRpcCall();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -1209,7 +1209,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 
 			if (!partitionIds.isEmpty()) {
 				// TODO For some tests this could be a problem when querying too early if all resources were released
-				taskManagerGateway.releasePartitions(partitionIds);
+				taskManagerGateway.releasePartitions(getVertex().getJobId(), partitionIds);
 			}
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/TaskManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/TaskManagerGateway.java
@@ -102,9 +102,10 @@ public interface TaskManagerGateway {
 	/**
 	 * Batch release intermediate result partitions.
 	 *
+	 * @param jobId id of the job that the partitions belong to
 	 * @param partitionIds partition ids to release
 	 */
-	void releasePartitions(Collection<ResultPartitionID> partitionIds);
+	void releasePartitions(JobID jobId, Collection<ResultPartitionID> partitionIds);
 
 	/**
 	 * Notify the given task about a completed checkpoint.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/RpcTaskManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/RpcTaskManagerGateway.java
@@ -88,8 +88,8 @@ public class RpcTaskManagerGateway implements TaskManagerGateway {
 	}
 
 	@Override
-	public void releasePartitions(Collection<ResultPartitionID> partitionIds) {
-		taskExecutorGateway.releasePartitions(partitionIds);
+	public void releasePartitions(JobID jobId, Collection<ResultPartitionID> partitionIds) {
+		taskExecutorGateway.releasePartitions(jobId, partitionIds);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -641,7 +641,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 	}
 
 	@Override
-	public void releasePartitions(Collection<ResultPartitionID> partitionIds) {
+	public void releasePartitions(JobID jobId, Collection<ResultPartitionID> partitionIds) {
 		try {
 			networkEnvironment.releasePartitions(partitionIds);
 		} catch (Throwable t) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -103,9 +103,10 @@ public interface TaskExecutorGateway extends RpcGateway {
 	/**
 	 * Batch release intermediate result partitions.
 	 *
+	 * @param jobId id of the job that the partitions belong to
 	 * @param partitionIds partition ids to release
 	 */
-	void releasePartitions(Collection<ResultPartitionID> partitionIds);
+	void releasePartitions(JobID jobId, Collection<ResultPartitionID> partitionIds);
 
 	/**
 	 * Trigger the checkpoint for the given task. The checkpoint is identified by the checkpoint ID

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
@@ -19,12 +19,16 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.checkpoint.JobManagerTaskRestore;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.instance.SimpleSlot;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmanager.scheduler.LocationPreferenceConstraint;
@@ -54,7 +58,9 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
 
+import static junit.framework.TestCase.assertNotNull;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -291,6 +297,81 @@ public class ExecutionTest extends TestLogger {
 
 		final Set<SlotRequestId> canceledSlotRequests = slotProvider.getCanceledSlotRequests();
 		assertThat(canceledSlotRequests, equalTo(slotRequests));
+	}
+
+	/**
+	 * Tests that the partitions are released in case of a execution cancellation after the execution is already finished.
+	 */
+	@Test
+	public void testPartitionReleaseOnCancelAfterFinished() throws Exception {
+		testPartitionReleaseAfterFinished(Execution::cancel);
+	}
+
+	/**
+	 * Tests that the partitions are released in case of a execution suspension after the execution is already finished.
+	 */
+	@Test
+	public void testPartitionReleaseOnSuspendAfterFinished() throws Exception {
+		testPartitionReleaseAfterFinished(Execution::suspend);
+	}
+
+	private void testPartitionReleaseAfterFinished(Consumer<Execution> postFinishedExecutionAction) throws Exception {
+		final Tuple2<JobID, Collection<ResultPartitionID>> releasedPartitions = Tuple2.of(null, null);
+		final SimpleAckingTaskManagerGateway taskManagerGateway = new SimpleAckingTaskManagerGateway();
+		taskManagerGateway.setReleasePartitionsConsumer(releasedPartitions::setFields);
+
+		final SimpleSlot slot = new SimpleSlot(
+			new SingleSlotTestingSlotOwner(),
+			new LocalTaskManagerLocation(),
+			0,
+			taskManagerGateway);
+
+		final JobVertex producerVertex = createNoOpJobVertex();
+		final JobVertex consumerVertex = createNoOpJobVertex();
+		consumerVertex.connectNewDataSetAsInput(producerVertex, DistributionPattern.ALL_TO_ALL, ResultPartitionType.BLOCKING);
+
+		final ProgrammedSlotProvider slotProvider = new ProgrammedSlotProvider(1);
+		slotProvider.addSlot(producerVertex.getID(), 0, CompletableFuture.completedFuture(slot));
+
+		ExecutionGraph executionGraph = ExecutionGraphTestUtils.createSimpleTestGraph(
+			new JobID(),
+			slotProvider,
+			new NoRestartStrategy(),
+			producerVertex,
+			consumerVertex);
+
+		executionGraph.start(TestingComponentMainThreadExecutorServiceAdapter.forMainThread());
+
+		ExecutionJobVertex executionJobVertex = executionGraph.getJobVertex(producerVertex.getID());
+		ExecutionVertex executionVertex = executionJobVertex.getTaskVertices()[0];
+
+		final Execution execution = executionVertex.getCurrentExecutionAttempt();
+
+		execution.allocateAndAssignSlotForExecution(
+			slotProvider,
+			false,
+			LocationPreferenceConstraint.ALL,
+			Collections.emptySet(),
+			TestingUtils.infiniteTime());
+
+		execution.deploy();
+		execution.switchToRunning();
+
+		// simulate a case where a cancel/suspend call is too slow and the task is already finished
+		// in this case we have to explicitly release the finished partition
+		// if the task were canceled properly the TM would release the partition automatically
+		execution.markFinished();
+		postFinishedExecutionAction.accept(execution);
+
+		assertEquals(executionGraph.getJobID(), releasedPartitions.f0);
+		assertEquals(executionVertex.getProducedPartitions().size(), releasedPartitions.f1.size());
+		for (ResultPartitionID partitionId : releasedPartitions.f1) {
+			IntermediateResultPartition intermediateResultPartition = executionVertex
+				.getProducedPartitions()
+				.get(partitionId.getPartitionId());
+			assertNotNull(intermediateResultPartition);
+			assertEquals(execution.getAttemptId(), partitionId.getProducerId());
+		}
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
@@ -300,7 +300,7 @@ public class ExecutionTest extends TestLogger {
 	}
 
 	/**
-	 * Tests that the partitions are released in case of a execution cancellation after the execution is already finished.
+	 * Tests that the partitions are released in case of an execution cancellation after the execution is already finished.
 	 */
 	@Test
 	public void testPartitionReleaseOnCancelAfterFinished() throws Exception {
@@ -308,7 +308,7 @@ public class ExecutionTest extends TestLogger {
 	}
 
 	/**
-	 * Tests that the partitions are released in case of a execution suspension after the execution is already finished.
+	 * Tests that the partitions are released in case of an execution suspension after the execution is already finished.
 	 */
 	@Test
 	public void testPartitionReleaseOnSuspendAfterFinished() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleAckingTaskManagerGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleAckingTaskManagerGateway.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.messages.StackTraceSampleResponse;
 import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
@@ -51,6 +52,8 @@ public class SimpleAckingTaskManagerGateway implements TaskManagerGateway {
 
 	private volatile BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>> freeSlotFunction;
 
+	private BiConsumer<JobID, Collection<ResultPartitionID>> releasePartitionsConsumer = (ignore1, ignore2) -> { };
+
 	public void setSubmitConsumer(Consumer<TaskDeploymentDescriptor> predicate) {
 		submitConsumer = predicate;
 	}
@@ -61,6 +64,10 @@ public class SimpleAckingTaskManagerGateway implements TaskManagerGateway {
 
 	public void setFreeSlotFunction(BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>> freeSlotFunction) {
 		this.freeSlotFunction = freeSlotFunction;
+	}
+
+	public void setReleasePartitionsConsumer(BiConsumer<JobID, Collection<ResultPartitionID>> releasePartitionsConsumer) {
+		this.releasePartitionsConsumer = releasePartitionsConsumer;
 	}
 
 	@Override
@@ -97,7 +104,8 @@ public class SimpleAckingTaskManagerGateway implements TaskManagerGateway {
 	}
 
 	@Override
-	public void releasePartitions(Collection<ResultPartitionID> partitionIds) {
+	public void releasePartitions(JobID jobId, Collection<ResultPartitionID> partitionIds) {
+		releasePartitionsConsumer.accept(jobId, partitionIds);
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
@@ -125,7 +125,7 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 	}
 
 	@Override
-	public void releasePartitions(Collection<ResultPartitionID> partitionIds) {
+	public void releasePartitions(JobID jobId, Collection<ResultPartitionID> partitionIds) {
 		// noop
 	}
 


### PR DESCRIPTION
Mirror of apache flink#8630
## What is the purpose of the change

Adds `JobID` as an argument to `TaskExecutorGateway#releasePartitions` to simplify bookkeeping on the taskmanager side.

Additionally adds tests for calls to said method originating in `Execution`.
