### PR TITLE
Mirror of apache flink#8629

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/stream/sql/join/JoinTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/stream/sql/join/JoinTest.xml
@@ -30,7 +30,7 @@ LogicalProject(a1=[$0], b1=[$3])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Join(joinType=[FullOuterJoin], where=[=(a1, b1)], select=[a1, b1], updateAsRetraction=[false], accMode=[AccRetract])
+Join(joinType=[FullOuterJoin], where=[=(a1, b1)], select=[a1, b1], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey], updateAsRetraction=[false], accMode=[AccRetract])
 :- Exchange(distribution=[hash[a1]], updateAsRetraction=[true], accMode=[Acc])
 :  +- Calc(select=[a1], updateAsRetraction=[true], accMode=[Acc])
 :     +- TableSourceScan(table=[[A, source: [TestTableSource(a1, a2, a3)]]], fields=[a1, a2, a3], updateAsRetraction=[true], accMode=[Acc])
@@ -55,7 +55,7 @@ LogicalProject(a1=[$0], b1=[$3])
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[a1, b1], updateAsRetraction=[false], accMode=[AccRetract])
-+- Join(joinType=[FullOuterJoin], where=[AND(=(a1, b1), >(a2, b2))], select=[a1, a2, b1, b2], updateAsRetraction=[false], accMode=[AccRetract])
++- Join(joinType=[FullOuterJoin], where=[AND(=(a1, b1), >(a2, b2))], select=[a1, a2, b1, b2], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey], updateAsRetraction=[false], accMode=[AccRetract])
    :- Exchange(distribution=[hash[a1]], updateAsRetraction=[true], accMode=[Acc])
    :  +- Calc(select=[a1, a2], updateAsRetraction=[true], accMode=[Acc])
    :     +- TableSourceScan(table=[[A, source: [TestTableSource(a1, a2, a3)]]], fields=[a1, a2, a3], updateAsRetraction=[true], accMode=[Acc])
@@ -85,7 +85,7 @@ LogicalProject(a1=[$1], b1=[$3])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Join(joinType=[FullOuterJoin], where=[=(a1, b1)], select=[a1, b1], updateAsRetraction=[false], accMode=[AccRetract])
+Join(joinType=[FullOuterJoin], where=[=(a1, b1)], select=[a1, b1], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey], updateAsRetraction=[false], accMode=[AccRetract])
 :- Exchange(distribution=[hash[a1]], updateAsRetraction=[false], accMode=[Acc])
 :  +- GroupAggregate(groupBy=[a1], select=[a1], updateAsRetraction=[false], accMode=[Acc])
 :     +- Exchange(distribution=[hash[a1]], updateAsRetraction=[true], accMode=[Acc])
@@ -120,7 +120,7 @@ LogicalProject(a1=[$1], b1=[$3])
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[a1, b1], updateAsRetraction=[false], accMode=[AccRetract])
-+- Join(joinType=[FullOuterJoin], where=[AND(=(a1, b1), >(a2, b2))], select=[a2, a1, b2, b1], updateAsRetraction=[false], accMode=[AccRetract])
++- Join(joinType=[FullOuterJoin], where=[AND(=(a1, b1), >(a2, b2))], select=[a2, a1, b2, b1], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey], updateAsRetraction=[false], accMode=[AccRetract])
    :- Exchange(distribution=[hash[a1]], updateAsRetraction=[false], accMode=[Acc])
    :  +- Calc(select=[a2, a1], updateAsRetraction=[false], accMode=[Acc])
    :     +- GroupAggregate(groupBy=[a1], select=[a1, SUM(a2) AS a2], updateAsRetraction=[false], accMode=[Acc])
@@ -153,7 +153,7 @@ LogicalProject(a1=[$1], b1=[$2])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Join(joinType=[FullOuterJoin], where=[=(a1, b1)], select=[a1, b1], updateAsRetraction=[false], accMode=[AccRetract])
+Join(joinType=[FullOuterJoin], where=[=(a1, b1)], select=[a1, b1], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[NoUniqueKey], updateAsRetraction=[false], accMode=[AccRetract])
 :- Exchange(distribution=[hash[a1]], updateAsRetraction=[false], accMode=[Acc])
 :  +- GroupAggregate(groupBy=[a1], select=[a1], updateAsRetraction=[false], accMode=[Acc])
 :     +- Exchange(distribution=[hash[a1]], updateAsRetraction=[true], accMode=[Acc])
@@ -183,7 +183,7 @@ LogicalProject(a1=[$1], b1=[$2])
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[a1, b1], updateAsRetraction=[false], accMode=[AccRetract])
-+- Join(joinType=[FullOuterJoin], where=[AND(=(a1, b1), >(a2, b2))], select=[a2, a1, b1, b2, b3], updateAsRetraction=[false], accMode=[AccRetract])
++- Join(joinType=[FullOuterJoin], where=[AND(=(a1, b1), >(a2, b2))], select=[a2, a1, b1, b2, b3], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[NoUniqueKey], updateAsRetraction=[false], accMode=[AccRetract])
    :- Exchange(distribution=[hash[a1]], updateAsRetraction=[false], accMode=[Acc])
    :  +- Calc(select=[a2, a1], updateAsRetraction=[false], accMode=[Acc])
    :     +- GroupAggregate(groupBy=[a1], select=[a1, SUM(a2) AS a2], updateAsRetraction=[false], accMode=[Acc])
@@ -216,7 +216,7 @@ LogicalProject(a1=[$1], a2=[$0], b1=[$3], b2=[$2])
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[a1, a2, b1, b2], updateAsRetraction=[false], accMode=[AccRetract])
-+- Join(joinType=[FullOuterJoin], where=[=(a2, b2)], select=[a2, a1, b2, b1], updateAsRetraction=[false], accMode=[AccRetract])
++- Join(joinType=[FullOuterJoin], where=[=(a2, b2)], select=[a2, a1, b2, b1], leftInputSpec=[HasUniqueKey], rightInputSpec=[HasUniqueKey], updateAsRetraction=[false], accMode=[AccRetract])
    :- Exchange(distribution=[hash[a2]], updateAsRetraction=[true], accMode=[AccRetract])
    :  +- Calc(select=[a2, a1], updateAsRetraction=[true], accMode=[AccRetract])
    :     +- GroupAggregate(groupBy=[a1], select=[a1, SUM(a2) AS a2], updateAsRetraction=[true], accMode=[AccRetract])
@@ -253,7 +253,7 @@ LogicalProject(a1=[$1], a2=[$0], b1=[$3], b2=[$2])
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[a1, a2, b1, b2], updateAsRetraction=[false], accMode=[AccRetract])
-+- Join(joinType=[FullOuterJoin], where=[AND(=(a2, b2), >(a1, b1))], select=[a2, a1, b2, b1], updateAsRetraction=[false], accMode=[AccRetract])
++- Join(joinType=[FullOuterJoin], where=[AND(=(a2, b2), >(a1, b1))], select=[a2, a1, b2, b1], leftInputSpec=[HasUniqueKey], rightInputSpec=[HasUniqueKey], updateAsRetraction=[false], accMode=[AccRetract])
    :- Exchange(distribution=[hash[a2]], updateAsRetraction=[true], accMode=[AccRetract])
    :  +- Calc(select=[a2, a1], updateAsRetraction=[true], accMode=[AccRetract])
    :     +- GroupAggregate(groupBy=[a1], select=[a1, SUM(a2) AS a2], updateAsRetraction=[true], accMode=[AccRetract])
@@ -283,7 +283,7 @@ LogicalProject(a1=[$0], b1=[$3])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Join(joinType=[InnerJoin], where=[=(a1, b1)], select=[a1, b1])
+Join(joinType=[InnerJoin], where=[=(a1, b1)], select=[a1, b1], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
 :- Exchange(distribution=[hash[a1]])
 :  +- Calc(select=[a1])
 :     +- TableSourceScan(table=[[A, source: [TestTableSource(a1, a2, a3)]]], fields=[a1, a2, a3])
@@ -313,7 +313,7 @@ LogicalProject(a1=[$1], b1=[$3])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Join(joinType=[InnerJoin], where=[=(a1, b1)], select=[a1, b1], updateAsRetraction=[false], accMode=[Acc])
+Join(joinType=[InnerJoin], where=[=(a1, b1)], select=[a1, b1], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey], updateAsRetraction=[false], accMode=[Acc])
 :- Exchange(distribution=[hash[a1]], updateAsRetraction=[false], accMode=[Acc])
 :  +- GroupAggregate(groupBy=[a1], select=[a1], updateAsRetraction=[false], accMode=[Acc])
 :     +- Exchange(distribution=[hash[a1]], updateAsRetraction=[true], accMode=[Acc])
@@ -324,30 +324,6 @@ Join(joinType=[InnerJoin], where=[=(a1, b1)], select=[a1, b1], updateAsRetractio
       +- Exchange(distribution=[hash[b1]], updateAsRetraction=[true], accMode=[Acc])
          +- Calc(select=[b1, b2], updateAsRetraction=[true], accMode=[Acc])
             +- TableSourceScan(table=[[B, source: [TestTableSource(b1, b2, b3)]]], fields=[b1, b2, b3], updateAsRetraction=[true], accMode=[Acc])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testInnerJoinWithMiniBatch">
-    <Resource name="sql">
-      <![CDATA[SELECT a1, b1 FROM A JOIN B ON a1 = b1]]>
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(a1=[$0], b1=[$3])
-+- LogicalJoin(condition=[=($0, $3)], joinType=[inner])
-   :- LogicalTableScan(table=[[A, source: [TestTableSource(a1, a2, a3)]]])
-   +- LogicalTableScan(table=[[B, source: [TestTableSource(b1, b2, b3)]]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-Join(joinType=[InnerJoin], where=[=(a1, b1)], select=[a1, b1], updateAsRetraction=[false], accMode=[Acc])
-:- Exchange(distribution=[hash[a1]], updateAsRetraction=[true], accMode=[Acc])
-:  +- Calc(select=[a1], updateAsRetraction=[true], accMode=[Acc])
-:     +- TableSourceScan(table=[[A, source: [TestTableSource(a1, a2, a3)]]], fields=[a1, a2, a3], updateAsRetraction=[true], accMode=[Acc])
-+- Exchange(distribution=[hash[b1]], updateAsRetraction=[true], accMode=[Acc])
-   +- Calc(select=[b1], updateAsRetraction=[true], accMode=[Acc])
-      +- TableSourceScan(table=[[B, source: [TestTableSource(b1, b2, b3)]]], fields=[b1, b2, b3], updateAsRetraction=[true], accMode=[Acc])
 ]]>
     </Resource>
   </TestCase>
@@ -371,7 +347,7 @@ LogicalProject(a1=[$1], b1=[$3])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Join(joinType=[LeftOuterJoin], where=[=(a1, b1)], select=[a1, b1], updateAsRetraction=[false], accMode=[AccRetract])
+Join(joinType=[LeftOuterJoin], where=[=(a1, b1)], select=[a1, b1], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey], updateAsRetraction=[false], accMode=[AccRetract])
 :- Exchange(distribution=[hash[a1]], updateAsRetraction=[false], accMode=[Acc])
 :  +- GroupAggregate(groupBy=[a1], select=[a1], updateAsRetraction=[false], accMode=[Acc])
 :     +- Exchange(distribution=[hash[a1]], updateAsRetraction=[true], accMode=[Acc])
@@ -406,7 +382,7 @@ LogicalProject(a1=[$1], a2=[$0], b1=[$3], b2=[$2])
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[a1, a2, b1, b2], updateAsRetraction=[false], accMode=[AccRetract])
-+- Join(joinType=[InnerJoin], where=[=(a2, b2)], select=[a2, a1, b2, b1], updateAsRetraction=[false], accMode=[AccRetract])
++- Join(joinType=[InnerJoin], where=[=(a2, b2)], select=[a2, a1, b2, b1], leftInputSpec=[HasUniqueKey], rightInputSpec=[HasUniqueKey], updateAsRetraction=[false], accMode=[AccRetract])
    :- Exchange(distribution=[hash[a2]], updateAsRetraction=[true], accMode=[AccRetract])
    :  +- Calc(select=[a2, a1], updateAsRetraction=[true], accMode=[AccRetract])
    :     +- GroupAggregate(groupBy=[a1], select=[a1, SUM(a2) AS a2], updateAsRetraction=[true], accMode=[AccRetract])
@@ -442,7 +418,7 @@ LogicalProject(i=[$0], j=[$1], t=[$2], i0=[$3], k=[$4])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Join(joinType=[FullOuterJoin], where=[AND(=(i, i0), =(i, k))], select=[i, j, t, i0, k])
+Join(joinType=[FullOuterJoin], where=[AND(=(i, i0), =(i, k))], select=[i, j, t, i0, k], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
 :- Exchange(distribution=[hash[i, i]])
 :  +- TableSourceScan(table=[[MyTable3, source: [TestTableSource(i, j, t)]]], fields=[i, j, t])
 +- Exchange(distribution=[hash[i, k]])
@@ -464,7 +440,7 @@ LogicalProject(a1=[$0], b1=[$3])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Join(joinType=[LeftOuterJoin], where=[=(a1, b1)], select=[a1, b1], updateAsRetraction=[false], accMode=[AccRetract])
+Join(joinType=[LeftOuterJoin], where=[=(a1, b1)], select=[a1, b1], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey], updateAsRetraction=[false], accMode=[AccRetract])
 :- Exchange(distribution=[hash[a1]], updateAsRetraction=[true], accMode=[Acc])
 :  +- Calc(select=[a1], updateAsRetraction=[true], accMode=[Acc])
 :     +- TableSourceScan(table=[[A, source: [TestTableSource(a1, a2, a3)]]], fields=[a1, a2, a3], updateAsRetraction=[true], accMode=[Acc])
@@ -489,7 +465,7 @@ LogicalProject(a1=[$0], b1=[$3])
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[a1, b1], updateAsRetraction=[false], accMode=[AccRetract])
-+- Join(joinType=[LeftOuterJoin], where=[AND(=(a1, b1), >(a2, b2))], select=[a1, a2, b1, b2], updateAsRetraction=[false], accMode=[AccRetract])
++- Join(joinType=[LeftOuterJoin], where=[AND(=(a1, b1), >(a2, b2))], select=[a1, a2, b1, b2], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey], updateAsRetraction=[false], accMode=[AccRetract])
    :- Exchange(distribution=[hash[a1]], updateAsRetraction=[true], accMode=[Acc])
    :  +- Calc(select=[a1, a2], updateAsRetraction=[true], accMode=[Acc])
    :     +- TableSourceScan(table=[[A, source: [TestTableSource(a1, a2, a3)]]], fields=[a1, a2, a3], updateAsRetraction=[true], accMode=[Acc])
@@ -520,7 +496,7 @@ LogicalProject(a1=[$1], b1=[$3])
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[a1, b1], updateAsRetraction=[false], accMode=[AccRetract])
-+- Join(joinType=[LeftOuterJoin], where=[AND(=(a1, b1), >(a2, b2))], select=[a2, a1, b2, b1], updateAsRetraction=[false], accMode=[AccRetract])
++- Join(joinType=[LeftOuterJoin], where=[AND(=(a1, b1), >(a2, b2))], select=[a2, a1, b2, b1], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey], updateAsRetraction=[false], accMode=[AccRetract])
    :- Exchange(distribution=[hash[a1]], updateAsRetraction=[false], accMode=[Acc])
    :  +- Calc(select=[a2, a1], updateAsRetraction=[false], accMode=[Acc])
    :     +- GroupAggregate(groupBy=[a1], select=[a1, SUM(a2) AS a2], updateAsRetraction=[false], accMode=[Acc])
@@ -557,7 +533,7 @@ LogicalProject(a1=[$1], a2=[$0], b1=[$3], b2=[$2])
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[a1, a2, b1, b2], updateAsRetraction=[false], accMode=[AccRetract])
-+- Join(joinType=[LeftOuterJoin], where=[=(a2, b2)], select=[a2, a1, b2, b1], updateAsRetraction=[false], accMode=[AccRetract])
++- Join(joinType=[LeftOuterJoin], where=[=(a2, b2)], select=[a2, a1, b2, b1], leftInputSpec=[HasUniqueKey], rightInputSpec=[HasUniqueKey], updateAsRetraction=[false], accMode=[AccRetract])
    :- Exchange(distribution=[hash[a2]], updateAsRetraction=[true], accMode=[AccRetract])
    :  +- Calc(select=[a2, a1], updateAsRetraction=[true], accMode=[AccRetract])
    :     +- GroupAggregate(groupBy=[a1], select=[a1, SUM(a2) AS a2], updateAsRetraction=[true], accMode=[AccRetract])
@@ -594,7 +570,7 @@ LogicalProject(a1=[$1], a2=[$0], b1=[$3], b2=[$2])
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[a1, a2, b1, b2], updateAsRetraction=[false], accMode=[AccRetract])
-+- Join(joinType=[LeftOuterJoin], where=[AND(=(a2, b2), >(a1, b1))], select=[a2, a1, b2, b1], updateAsRetraction=[false], accMode=[AccRetract])
++- Join(joinType=[LeftOuterJoin], where=[AND(=(a2, b2), >(a1, b1))], select=[a2, a1, b2, b1], leftInputSpec=[HasUniqueKey], rightInputSpec=[HasUniqueKey], updateAsRetraction=[false], accMode=[AccRetract])
    :- Exchange(distribution=[hash[a2]], updateAsRetraction=[true], accMode=[AccRetract])
    :  +- Calc(select=[a2, a1], updateAsRetraction=[true], accMode=[AccRetract])
    :     +- GroupAggregate(groupBy=[a1], select=[a1, SUM(a2) AS a2], updateAsRetraction=[true], accMode=[AccRetract])
@@ -627,7 +603,7 @@ LogicalProject(a1=[$1], b1=[$2])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Join(joinType=[LeftOuterJoin], where=[=(a1, b1)], select=[a1, b1], updateAsRetraction=[false], accMode=[AccRetract])
+Join(joinType=[LeftOuterJoin], where=[=(a1, b1)], select=[a1, b1], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[NoUniqueKey], updateAsRetraction=[false], accMode=[AccRetract])
 :- Exchange(distribution=[hash[a1]], updateAsRetraction=[false], accMode=[Acc])
 :  +- GroupAggregate(groupBy=[a1], select=[a1], updateAsRetraction=[false], accMode=[Acc])
 :     +- Exchange(distribution=[hash[a1]], updateAsRetraction=[true], accMode=[Acc])
@@ -657,7 +633,7 @@ LogicalProject(a1=[$1], b1=[$2])
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[a1, b1], updateAsRetraction=[false], accMode=[AccRetract])
-+- Join(joinType=[LeftOuterJoin], where=[AND(=(a1, b1), >(a2, b2))], select=[a2, a1, b1, b2, b3], updateAsRetraction=[false], accMode=[AccRetract])
++- Join(joinType=[LeftOuterJoin], where=[AND(=(a1, b1), >(a2, b2))], select=[a2, a1, b1, b2, b3], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[NoUniqueKey], updateAsRetraction=[false], accMode=[AccRetract])
    :- Exchange(distribution=[hash[a1]], updateAsRetraction=[false], accMode=[Acc])
    :  +- Calc(select=[a2, a1], updateAsRetraction=[false], accMode=[Acc])
    :     +- GroupAggregate(groupBy=[a1], select=[a1, SUM(a2) AS a2], updateAsRetraction=[false], accMode=[Acc])
@@ -685,7 +661,7 @@ LogicalProject(b=[$1], y=[$5])
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[b, y])
-+- Join(joinType=[LeftOuterJoin], where=[AND(=(a, z), $f3)], select=[a, b, $f3, y, z])
++- Join(joinType=[LeftOuterJoin], where=[AND(=(a, z), $f3)], select=[a, b, $f3, y, z], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
    :- Exchange(distribution=[hash[a]])
    :  +- Calc(select=[a, b, <(b, 2) AS $f3])
    :     +- TableSourceScan(table=[[t, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
@@ -710,7 +686,7 @@ LogicalProject(b=[$1], y=[$4])
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[b, y])
-+- Join(joinType=[LeftOuterJoin], where=[AND(=(a, z), <(b, x))], select=[a, b, x, y, z])
++- Join(joinType=[LeftOuterJoin], where=[AND(=(a, z), <(b, x))], select=[a, b, x, y, z], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
    :- Exchange(distribution=[hash[a]])
    :  +- Calc(select=[a, b])
    :     +- TableSourceScan(table=[[t, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
@@ -734,7 +710,7 @@ LogicalProject(a1=[$0], b1=[$3])
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[a1, b1], updateAsRetraction=[false], accMode=[AccRetract])
-+- Join(joinType=[RightOuterJoin], where=[AND(=(a1, b1), >(a2, b2))], select=[a1, a2, b1, b2], updateAsRetraction=[false], accMode=[AccRetract])
++- Join(joinType=[RightOuterJoin], where=[AND(=(a1, b1), >(a2, b2))], select=[a1, a2, b1, b2], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey], updateAsRetraction=[false], accMode=[AccRetract])
    :- Exchange(distribution=[hash[a1]], updateAsRetraction=[true], accMode=[Acc])
    :  +- Calc(select=[a1, a2], updateAsRetraction=[true], accMode=[Acc])
    :     +- TableSourceScan(table=[[A, source: [TestTableSource(a1, a2, a3)]]], fields=[a1, a2, a3], updateAsRetraction=[true], accMode=[Acc])
@@ -759,7 +735,7 @@ LogicalProject(b=[$1], y=[$4])
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[b, y])
-+- Join(joinType=[LeftOuterJoin], where=[=(a, z)], select=[a, b, y, z])
++- Join(joinType=[LeftOuterJoin], where=[=(a, z)], select=[a, b, y, z], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
    :- Exchange(distribution=[hash[a]])
    :  +- Calc(select=[a, b])
    :     +- TableSourceScan(table=[[t, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
@@ -784,7 +760,7 @@ LogicalProject(b=[$1], y=[$4])
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[b, y])
-+- Join(joinType=[RightOuterJoin], where=[=(a, z)], select=[a, b, y, z])
++- Join(joinType=[RightOuterJoin], where=[=(a, z)], select=[a, b, y, z], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
    :- Exchange(distribution=[hash[a]])
    :  +- Calc(select=[a, b])
    :     +- TableSourceScan(table=[[t, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
@@ -808,7 +784,7 @@ LogicalProject(a1=[$0], b1=[$3])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Join(joinType=[RightOuterJoin], where=[=(a1, b1)], select=[a1, b1], updateAsRetraction=[false], accMode=[AccRetract])
+Join(joinType=[RightOuterJoin], where=[=(a1, b1)], select=[a1, b1], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey], updateAsRetraction=[false], accMode=[AccRetract])
 :- Exchange(distribution=[hash[a1]], updateAsRetraction=[true], accMode=[Acc])
 :  +- Calc(select=[a1], updateAsRetraction=[true], accMode=[Acc])
 :     +- TableSourceScan(table=[[A, source: [TestTableSource(a1, a2, a3)]]], fields=[a1, a2, a3], updateAsRetraction=[true], accMode=[Acc])
@@ -838,7 +814,7 @@ LogicalProject(a1=[$1], b1=[$3])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Join(joinType=[RightOuterJoin], where=[=(a1, b1)], select=[a1, b1], updateAsRetraction=[false], accMode=[AccRetract])
+Join(joinType=[RightOuterJoin], where=[=(a1, b1)], select=[a1, b1], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey], updateAsRetraction=[false], accMode=[AccRetract])
 :- Exchange(distribution=[hash[a1]], updateAsRetraction=[false], accMode=[Acc])
 :  +- GroupAggregate(groupBy=[a1], select=[a1], updateAsRetraction=[false], accMode=[Acc])
 :     +- Exchange(distribution=[hash[a1]], updateAsRetraction=[true], accMode=[Acc])
@@ -873,7 +849,7 @@ LogicalProject(a1=[$1], a2=[$0], b1=[$3], b2=[$2])
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[a1, a2, b1, b2], updateAsRetraction=[false], accMode=[AccRetract])
-+- Join(joinType=[RightOuterJoin], where=[=(a2, b2)], select=[a2, a1, b2, b1], updateAsRetraction=[false], accMode=[AccRetract])
++- Join(joinType=[RightOuterJoin], where=[=(a2, b2)], select=[a2, a1, b2, b1], leftInputSpec=[HasUniqueKey], rightInputSpec=[HasUniqueKey], updateAsRetraction=[false], accMode=[AccRetract])
    :- Exchange(distribution=[hash[a2]], updateAsRetraction=[true], accMode=[AccRetract])
    :  +- Calc(select=[a2, a1], updateAsRetraction=[true], accMode=[AccRetract])
    :     +- GroupAggregate(groupBy=[a1], select=[a1, SUM(a2) AS a2], updateAsRetraction=[true], accMode=[AccRetract])
@@ -910,7 +886,7 @@ LogicalProject(a1=[$1], a2=[$0], b1=[$3], b2=[$2])
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[a1, a2, b1, b2], updateAsRetraction=[false], accMode=[AccRetract])
-+- Join(joinType=[RightOuterJoin], where=[AND(=(a2, b2), >(a1, b1))], select=[a2, a1, b2, b1], updateAsRetraction=[false], accMode=[AccRetract])
++- Join(joinType=[RightOuterJoin], where=[AND(=(a2, b2), >(a1, b1))], select=[a2, a1, b2, b1], leftInputSpec=[HasUniqueKey], rightInputSpec=[HasUniqueKey], updateAsRetraction=[false], accMode=[AccRetract])
    :- Exchange(distribution=[hash[a2]], updateAsRetraction=[true], accMode=[AccRetract])
    :  +- Calc(select=[a2, a1], updateAsRetraction=[true], accMode=[AccRetract])
    :     +- GroupAggregate(groupBy=[a1], select=[a1, SUM(a2) AS a2], updateAsRetraction=[true], accMode=[AccRetract])
@@ -943,7 +919,7 @@ LogicalProject(a1=[$1], b1=[$2])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Join(joinType=[RightOuterJoin], where=[=(a1, b1)], select=[a1, b1], updateAsRetraction=[false], accMode=[AccRetract])
+Join(joinType=[RightOuterJoin], where=[=(a1, b1)], select=[a1, b1], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[NoUniqueKey], updateAsRetraction=[false], accMode=[AccRetract])
 :- Exchange(distribution=[hash[a1]], updateAsRetraction=[false], accMode=[Acc])
 :  +- GroupAggregate(groupBy=[a1], select=[a1], updateAsRetraction=[false], accMode=[Acc])
 :     +- Exchange(distribution=[hash[a1]], updateAsRetraction=[true], accMode=[Acc])
@@ -973,7 +949,7 @@ LogicalProject(a1=[$1], b1=[$2])
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[a1, b1], updateAsRetraction=[false], accMode=[AccRetract])
-+- Join(joinType=[RightOuterJoin], where=[AND(=(a1, b1), >(a2, b2))], select=[a2, a1, b1, b2, b3], updateAsRetraction=[false], accMode=[AccRetract])
++- Join(joinType=[RightOuterJoin], where=[AND(=(a1, b1), >(a2, b2))], select=[a2, a1, b1, b2, b3], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[NoUniqueKey], updateAsRetraction=[false], accMode=[AccRetract])
    :- Exchange(distribution=[hash[a1]], updateAsRetraction=[false], accMode=[Acc])
    :  +- Calc(select=[a2, a1], updateAsRetraction=[false], accMode=[Acc])
    :     +- GroupAggregate(groupBy=[a1], select=[a1, SUM(a2) AS a2], updateAsRetraction=[false], accMode=[Acc])
@@ -1006,7 +982,7 @@ LogicalProject(a1=[$1], b1=[$3])
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[a1, b1], updateAsRetraction=[false], accMode=[AccRetract])
-+- Join(joinType=[RightOuterJoin], where=[AND(=(a1, b1), >(a2, b2))], select=[a2, a1, b2, b1], updateAsRetraction=[false], accMode=[AccRetract])
++- Join(joinType=[RightOuterJoin], where=[AND(=(a1, b1), >(a2, b2))], select=[a2, a1, b2, b1], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey], updateAsRetraction=[false], accMode=[AccRetract])
    :- Exchange(distribution=[hash[a1]], updateAsRetraction=[false], accMode=[Acc])
    :  +- Calc(select=[a2, a1], updateAsRetraction=[false], accMode=[Acc])
    :     +- GroupAggregate(groupBy=[a1], select=[a1, SUM(a2) AS a2], updateAsRetraction=[false], accMode=[Acc])
@@ -1038,7 +1014,7 @@ LogicalProject(b=[$1], x=[$3])
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[b, x])
-+- Join(joinType=[RightOuterJoin], where=[AND(=(a, z), $f3)], select=[a, b, x, z, $f3])
++- Join(joinType=[RightOuterJoin], where=[AND(=(a, z), $f3)], select=[a, b, x, z, $f3], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
    :- Exchange(distribution=[hash[a]])
    :  +- Calc(select=[a, b])
    :     +- TableSourceScan(table=[[t, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
@@ -1063,7 +1039,7 @@ LogicalProject(b=[$1], y=[$4])
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[b, y])
-+- Join(joinType=[RightOuterJoin], where=[AND(=(a, z), <(b, x))], select=[a, b, x, y, z])
++- Join(joinType=[RightOuterJoin], where=[AND(=(a, z), <(b, x))], select=[a, b, x, y, z], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
    :- Exchange(distribution=[hash[a]])
    :  +- Calc(select=[a, b])
    :     +- TableSourceScan(table=[[t, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
@@ -1096,7 +1072,7 @@ LogicalProject(key=[$0], v=[$1], key0=[$2], v0=[$3])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Join(joinType=[LeftOuterJoin], where=[=(key, key0)], select=[key, v, key0, v0], updateAsRetraction=[false], accMode=[AccRetract])
+Join(joinType=[LeftOuterJoin], where=[=(key, key0)], select=[key, v, key0, v0], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey], updateAsRetraction=[false], accMode=[AccRetract])
 :- Exchange(distribution=[hash[key]], updateAsRetraction=[true], accMode=[Acc])
 :  +- Calc(select=[CAST(0:BIGINT) AS key, v], where=[=(key, 0:BIGINT)], updateAsRetraction=[true], accMode=[Acc])
 :     +- TableSourceScan(table=[[src, source: [TestTableSource(key, v)]]], fields=[key, v], updateAsRetraction=[true], accMode=[Acc])

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stream/sql/join/JoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stream/sql/join/JoinTest.scala
@@ -38,13 +38,6 @@ class JoinTest extends TableTestBase {
   }
 
   @Test
-  def testInnerJoinWithMiniBatch(): Unit = {
-    util.tableEnv.getConfig.getConf
-      .setLong(TableConfigOptions.SQL_EXEC_MINIBATCH_ALLOW_LATENCY, 1000L)
-    util.verifyPlanWithTrait( "SELECT a1, b1 FROM A JOIN B ON a1 = b1")
-  }
-
-  @Test
   def testInnerJoinWithEqualPk(): Unit = {
     val query1 = "SELECT SUM(a2) AS a2, a1 FROM A GROUP BY a1"
     val query2 = "SELECT SUM(b2) AS b2, b1 FROM B GROUP BY b1"

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/stream/sql/JoinITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/stream/sql/JoinITCase.scala
@@ -1,0 +1,1109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.stream.sql
+
+import org.apache.flink.api.scala._
+import org.apache.flink.streaming.api.TimeCharacteristic
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.runtime.utils.StreamingWithStateTestBase.StateBackendMode
+import org.apache.flink.table.runtime.utils._
+import org.apache.flink.types.Row
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+import scala.collection.{Seq, mutable}
+
+@RunWith(classOf[Parameterized])
+class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(state) {
+
+  val smallTuple5Data = List(
+    (1, 1L, 0, "Hallo", 1L),
+    (2, 2L, 1, "Hallo Welt", 2L),
+    (2, 3L, 2, "Hallo Welt wie", 1L),
+    (3, 4L, 3, "Hallo Welt wie gehts?", 2L),
+    (3, 5L, 4, "ABC", 2L),
+    (3, 6L, 5, "BCD", 3L)
+  )
+
+  val tuple3Data = List(
+    (1, 1L, "Hi"),
+    (2, 2L, "Hello"),
+    (3, 2L, "Hello world")
+  )
+
+  val dataCannotBeJoin = List(
+    (2, 3L, 2, "Hallo Welt wie", 1L),
+    (3, 4L, 3, "Hallo Welt wie gehts?", 2L),
+    (3, 5L, 4, "ABC", 2L),
+    (3, 6L, 5, "BCD", 3L)
+  )
+
+  override def before(): Unit = {
+    super.before()
+    val tableA = failingDataSource(TestData.smallTupleData3)
+      .toTable(tEnv, 'a1, 'a2, 'a3)
+    val tableB = failingDataSource(TestData.tupleData5)
+      .toTable(tEnv, 'b1, 'b2, 'b3, 'b4, 'b5)
+    tEnv.registerTable("A", tableA)
+    tEnv.registerTable("B", tableB)
+  }
+
+
+
+  // Tests for inner join.
+  override def after(): Unit = {}
+
+
+  /** test non-window inner join **/
+  @Test
+  def testNonWindowInnerJoin(): Unit = {
+    val data1 = new mutable.MutableList[(Int, Long, String)]
+    data1.+=((1, 1L, "Hi1"))
+    data1.+=((1, 2L, "Hi2"))
+    data1.+=((1, 2L, "Hi2"))
+    data1.+=((1, 5L, "Hi3"))
+    data1.+=((2, 7L, "Hi5"))
+    data1.+=((1, 9L, "Hi6"))
+    data1.+=((1, 8L, "Hi8"))
+    data1.+=((3, 8L, "Hi9"))
+
+    val data2 = new mutable.MutableList[(Int, Long, String)]
+    data2.+=((1, 1L, "HiHi"))
+    data2.+=((2, 2L, "HeHe"))
+    data2.+=((3, 2L, "HeHe"))
+
+    val t1 = failingDataSource(data1).toTable(tEnv, 'a, 'b, 'c)
+    val t2 = failingDataSource(data2).toTable(tEnv, 'a, 'b, 'c)
+
+    tEnv.registerTable("T1", t1)
+    tEnv.registerTable("T2", t2)
+
+    val sqlQuery =
+      """
+        |SELECT t2.a, t2.c, t1.c
+        |FROM (
+        | SELECT if(a = 3, cast(null as int), a) as a, b, c FROM T1
+        |) as t1
+        |JOIN (
+        | SELECT if(a = 3, cast(null as int), a) as a, b, c FROM T2
+        |) as t2
+        |ON t1.a = t2.a AND t1.b > t2.b
+        |""".stripMargin
+
+    val sink = new TestingAppendSink
+    tEnv.sqlQuery(sqlQuery).toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected = mutable.MutableList(
+      "1,HiHi,Hi2",
+      "1,HiHi,Hi2",
+      "1,HiHi,Hi3",
+      "1,HiHi,Hi6",
+      "1,HiHi,Hi8",
+      "2,HeHe,Hi5")
+
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
+
+  @Test
+  def testIsNullInnerJoinWithNullCond(): Unit = {
+    val data1 = new mutable.MutableList[(Int, Long, String)]
+    data1.+=((1, 1L, "Hi1"))
+    data1.+=((1, 2L, "Hi2"))
+    data1.+=((1, 2L, "Hi2"))
+    data1.+=((1, 5L, "Hi3"))
+    data1.+=((2, 7L, "Hi5"))
+    data1.+=((1, 9L, "Hi6"))
+    data1.+=((1, 8L, "Hi8"))
+    data1.+=((3, 8L, "Hi9"))
+
+    val data2 = new mutable.MutableList[(Int, Long, String)]
+    data2.+=((1, 1L, "HiHi"))
+    data2.+=((2, 2L, "HeHe"))
+    data2.+=((3, 2L, "HeHe"))
+
+    val t1 = failingDataSource(data1).toTable(tEnv, 'a, 'b, 'c)
+    val t2 = failingDataSource(data2).toTable(tEnv, 'a, 'b, 'c)
+
+    tEnv.registerTable("T1", t1)
+    tEnv.registerTable("T2", t2)
+
+    val sqlQuery =
+      """
+        |SELECT t2.a, t2.c, t1.c
+        |FROM (
+        | SELECT if(a = 3, cast(null as int), a) as a, b, c FROM T1
+        |) as t1
+        |JOIN (
+        | SELECT if(a = 3, cast(null as int), a) as a, b, c FROM T2
+        |) as t2
+        |ON
+        |  ((t1.a is null AND t2.a is null) OR
+        |  (t1.a = t2.a))
+        |  AND t1.b > t2.b
+        |""".stripMargin
+
+    val sink = new TestingAppendSink
+    tEnv.sqlQuery(sqlQuery).toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected = mutable.MutableList(
+      "1,HiHi,Hi2",
+      "1,HiHi,Hi2",
+      "1,HiHi,Hi3",
+      "1,HiHi,Hi6",
+      "1,HiHi,Hi8",
+      "2,HeHe,Hi5",
+      "null,HeHe,Hi9")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
+
+  @Test
+  def testJoin(): Unit = {
+
+    val sqlQuery = "SELECT a3, b4 FROM A, B WHERE a2 = b2"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("Hi,Hallo", "Hello,Hallo Welt", "Hello world,Hallo Welt")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testInnerJoin(): Unit = {
+    val ds1 = failingDataSource(tuple3Data).toTable(tEnv, 'a, 'b, 'c)
+    val ds2 = failingDataSource(smallTuple5Data).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    tEnv.registerTable("ds1", ds1)
+    tEnv.registerTable("ds2", ds2)
+    val query = "SELECT b, c, e, g FROM ds1 JOIN ds2 ON b = e"
+
+    val sink = new TestingAppendSink
+    tEnv.sqlQuery(query).toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected = Seq("1,Hi,1,Hallo", "2,Hello world,2,Hallo Welt", "2,Hello,2,Hallo Welt")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
+
+  @Test
+  def testInnerJoin2(): Unit = {
+    val query = "SELECT a1, b1 FROM A JOIN B ON a1 = b1"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("3,3", "1,1", "3,3", "2,2", "3,3", "2,2")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testJoinWithFilter(): Unit = {
+    val sqlQuery = "SELECT a3, b4 FROM A, B WHERE a2 = b2 AND a2 < 2"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("Hi,Hallo")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testInnerJoinWithNonEquiJoinPredicate(): Unit = {
+    val sqlQuery = "SELECT c, g FROM Table3, Table5 WHERE b = e AND a < 6 AND h < b"
+
+    val ds1 = failingDataSource(TestData.tupleData3).toTable(tEnv, 'a, 'b, 'c)
+    val ds2 = failingDataSource(TestData.tupleData5).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    tEnv.registerTable("Table3", ds1)
+    tEnv.registerTable("Table5", ds2)
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("Hello world, how are you?,Hallo Welt wie", "I am fine.,Hallo Welt wie")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testJoinWithMultipleKeys(): Unit = {
+    val sqlQuery = "SELECT c, g FROM Table3, Table5 WHERE a = d AND b = h"
+
+    val ds1 = failingDataSource(TestData.tupleData3).toTable(tEnv, 'a, 'b, 'c)
+    val ds2 = failingDataSource(TestData.tupleData5).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    tEnv.registerTable("Table3", ds1)
+    tEnv.registerTable("Table5", ds2)
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq(
+      "Hi,Hallo", "Hello,Hallo Welt", "Hello world,Hallo Welt wie gehts?", "Hello world,ABC",
+      "I am fine.,HIJ", "I am fine.,IJK")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testJoinWithAlias(): Unit = {
+    val sqlQuery =
+      "SELECT B.b5, T.`1-_./Ü` FROM (SELECT a1, a2, a3 AS `1-_./Ü` FROM A) AS T, B " +
+        "WHERE a1 = b1 AND a1 < 4"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("1,Hi", "2,Hello", "1,Hello",
+      "2,Hello world", "2,Hello world", "3,Hello world")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testDataStreamJoinWithAggregation(): Unit = {
+    val sqlQuery = "SELECT COUNT(b4), COUNT(a2) FROM A, B WHERE a1 = b1"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("6,6")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testLeftOuterJoin(): Unit = {
+    val ds1 = failingDataSource(tuple3Data).toTable(tEnv, 'a, 'b, 'c)
+    val ds2 = failingDataSource(dataCannotBeJoin).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    tEnv.registerTable("ds1", ds1)
+    tEnv.registerTable("ds2", ds2)
+    val query = "SELECT b, c, e, g FROM ds1 LEFT OUTER JOIN ds2 ON b = e"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("1,Hi,null,null", "2,Hello world,null,null", "2,Hello,null,null")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testLeftOuterJoinWithRetraction(): Unit = {
+    val ds1 = failingDataSource(tuple3Data).toTable(tEnv, 'a, 'b, 'c)
+    val ds2 = failingDataSource(smallTuple5Data).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    tEnv.registerTable("ds1", ds1)
+    tEnv.registerTable("ds2", ds2)
+    val query = "SELECT b, c, e, g FROM ds1 LEFT OUTER JOIN ds2 ON b = e"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("1,Hi,1,Hallo", "2,Hello world,2,Hallo Welt", "2,Hello,2,Hallo Welt")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testStreamJoinWithSameRecord(): Unit = {
+    val data1 = List(
+      (1, 1),
+      (1, 1),
+      (2, 2),
+      (2, 2),
+      (3, 3),
+      (3, 3),
+      (4, 4),
+      (4, 4),
+      (5, 5),
+      (5, 5))
+
+    val data2 = List(
+      (1, 1),
+      (2, 2),
+      (3, 3),
+      (4, 4),
+      (5, 5),
+      (6, 6),
+      (7, 7),
+      (8, 8),
+      (9, 9),
+      (10, 10))
+
+    val table1 = failingDataSource(data1).toTable(tEnv, 'pk, 'a)
+    val table2 = failingDataSource(data2).toTable(tEnv, 'pk, 'a)
+    tEnv.registerTable("ds1", table1)
+    tEnv.registerTable("ds2", table2)
+
+    val sql =
+      """
+        |SELECT
+        |  ds1.pk as leftPk,
+        |  ds1.a as leftA,
+        |  ds2.pk as rightPk,
+        |  ds2.a as rightA
+        |FROM ds1 JOIN ds2 ON ds1.pk = ds2.pk
+      """.stripMargin
+
+    val sink = new TestingAppendSink
+    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected = Seq("1,1,1,1", "1,1,1,1",
+      "2,2,2,2", "2,2,2,2",
+      "3,3,3,3", "3,3,3,3",
+      "4,4,4,4", "4,4,4,4",
+      "5,5,5,5", "5,5,5,5")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
+
+  @Test
+  def testFullOuterJoin(): Unit = {
+    val sqlQuery = "SELECT a3, b4 FROM A FULL OUTER JOIN B ON a2 = b2"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("Hi,Hallo", "Hello,Hallo Welt", "Hello world,Hallo Welt",
+      "null,Hallo Welt wie", "null,Hallo Welt wie gehts?", "null,ABC", "null,BCD",
+      "null,CDE", "null,DEF", "null,EFG", "null,FGH", "null,GHI", "null,HIJ",
+      "null,IJK", "null,JKL", "null,KLM")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testLeftOuterJoin2(): Unit = {
+    val sqlQuery = "SELECT c, g FROM Table5 LEFT OUTER JOIN Table3 ON b = e"
+
+    val ds1 = failingDataSource(TestData.smallTupleData3).toTable(tEnv, 'a, 'b, 'c)
+    val ds2 = failingDataSource(TestData.tupleData5).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    tEnv.registerTable("Table3", ds1)
+    tEnv.registerTable("Table5", ds2)
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("Hi,Hallo", "Hello,Hallo Welt", "Hello world,Hallo Welt",
+      "null,Hallo Welt wie", "null,Hallo Welt wie gehts?", "null,ABC", "null,BCD",
+      "null,CDE", "null,DEF", "null,EFG", "null,FGH", "null,GHI", "null,HIJ",
+      "null,IJK", "null,JKL", "null,KLM")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testRightOuterJoin(): Unit = {
+    val sqlQuery = "SELECT a3, b4 FROM A RIGHT OUTER JOIN B ON a2 = b2"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("Hi,Hallo", "Hello,Hallo Welt", "Hello world,Hallo Welt",
+      "null,Hallo Welt wie", "null,Hallo Welt wie gehts?", "null,ABC", "null,BCD",
+      "null,CDE", "null,DEF", "null,EFG", "null,FGH", "null,GHI", "null,HIJ",
+      "null,IJK", "null,JKL", "null,KLM")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testInnerJoinWithEqualPk(): Unit = {
+    val query1 = "SELECT SUM(a2) AS a2, a1 FROM A group by a1"
+    val query2 = "SELECT SUM(b2) AS b2, b1 FROM B group by b1"
+    val query = s"SELECT a1, b1 FROM ($query1) JOIN ($query2) ON a1 = b1"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("1,1", "2,2", "3,3")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testInnerJoinWithPk(): Unit = {
+    val query1 = "SELECT SUM(a2) AS a2, a1 FROM A group by a1"
+    val query2 = "SELECT SUM(b2) AS b2, b1 FROM B group by b1"
+    val query = s"SELECT a1, a2, b1, b2 FROM ($query1) JOIN ($query2) ON a2 = b2"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("1,1,1,1")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testLeftJoinNonEqui(): Unit = {
+    val query = "SELECT a1, b1 FROM A LEFT JOIN B ON a1 = b1 AND a2 > b2"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("3,null", "1,null", "2,null")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testLeftJoinWithEqualPkNonEqui(): Unit = {
+    val query1 = "SELECT SUM(a2) AS a2, a1 FROM A group by a1"
+    val query2 = "SELECT SUM(b2) AS b2, b1 FROM B group by b1"
+    val query = s"SELECT a1, b1 FROM ($query1) LEFT JOIN ($query2) ON a1 = b1 AND a2 > b2"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("1,null", "3,null", "2,null")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testLeftJoinWithRightNotPkNonEqui(): Unit = {
+    val query1 = "SELECT SUM(a2) AS a2, a1 FROM A group by a1"
+    val query = s"SELECT a1, b1 FROM ($query1) LEFT JOIN B ON a1 = b1 AND a2 > b2"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("1,null", "3,null", "2,null")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testLeftJoinWithPkNonEqui(): Unit = {
+    val query1 = "SELECT SUM(a2) AS a2, a1 FROM A group by a1"
+    val query2 = "SELECT SUM(b2) AS b2, b1 FROM B group by b1"
+    val query = s"SELECT a1, a2, b1, b2 FROM ($query1) LEFT JOIN ($query2) ON a2 = b2 AND a1 > b1"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("1,1,null,null", "3,2,null,null", "2,2,null,null")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testLeftJoin(): Unit = {
+    val query = "SELECT a1, b1 FROM A LEFT JOIN B ON a1 = b1"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("1,1", "2,2", "3,3", "2,2", "3,3", "3,3")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testLeftJoinWithEqualPk(): Unit = {
+    val query1 = "SELECT SUM(a2) AS a2, a1 FROM A group by a1"
+    val query2 = "SELECT SUM(b2) AS b2, b1 FROM B group by b1"
+    val query = s"SELECT a1, b1 FROM ($query1) LEFT JOIN ($query2) ON a1 = b1"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("2,2", "1,1", "3,3")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testLeftJoinWithRightNotPk(): Unit = {
+    val query1 = "SELECT SUM(a2) AS a2, a1 FROM A group by a1"
+    val query = s"SELECT a1, b1 FROM ($query1) LEFT JOIN B ON a1 = b1"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("3,3", "3,3", "3,3", "2,2", "2,2", "1,1")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testLeftJoinWithPk(): Unit = {
+    val query1 = "SELECT SUM(a2) AS a2, a1 FROM A group by a1"
+    val query2 = "SELECT SUM(b2) AS b2, b1 FROM B group by b1"
+    val query = s"SELECT a1, a2, b1, b2 FROM ($query1) LEFT JOIN ($query2) ON a2 = b2"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("1,1,1,1", "3,2,null,null", "2,2,null,null")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testRightJoinNonEqui(): Unit = {
+    val query = "SELECT a1, b1 FROM A RIGHT JOIN B ON a1 = b1 AND a2 > b2"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("null,2", "null,1", "null,3", "null,3", "null,2", "null,5", "null,3",
+      "null,5", "null,4", "null,5", "null,4", "null,5", "null,4", "null,5", "null,4")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testRightJoinWithEqualPkNonEqui(): Unit = {
+    val query1 = "SELECT SUM(a2) AS a2, a1 FROM A group by a1"
+    val query2 = "SELECT SUM(b2) AS b2, b1 FROM B group by b1"
+    val query = s"SELECT a1, b1 FROM ($query1) RIGHT JOIN ($query2) ON a1 = b1 AND a2 > b2"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("null,1", "null,3", "null,2", "null,5", "null,4")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testRightJoinWithRightNotPkNonEqui(): Unit = {
+    val query1 = "SELECT SUM(a2) AS a2, a1 FROM A group by a1"
+    val query = s"SELECT a1, b1 FROM ($query1) RIGHT JOIN B ON a1 = b1 AND a2 > b2"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("null,2", "null,1", "null,3", "null,2", "null,3", "null,5", "null,5",
+      "null,3", "null,5", "null,5", "null,4", "null,5", "null,4", "null,4", "null,4")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testRightJoinWithPkNonEqui(): Unit = {
+    val query1 = "SELECT SUM(a2) AS a2, a1 FROM A group by a1"
+    val query2 = "SELECT SUM(b2) AS b2, b1 FROM B group by b1"
+    val query = s"SELECT a1, a2, b1, b2 FROM ($query1) RIGHT JOIN ($query2) ON a2 = b2 AND a1 > b1"
+
+    env.setParallelism(1)
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("null,null,3,15", "null,null,4,34", "null,null,2,5", "null,null,5,65",
+      "null,null,1,1")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testRightJoin(): Unit = {
+    val query = "SELECT a1, b1 FROM A RIGHT JOIN B ON a1 = b1"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("2,2", "3,3", "3,3", "2,2", "3,3", "null,5", "null,4", "1,1", "null,5",
+      "null,4", "null,5", "null,5", "null,5", "null,4", "null,4")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testRightJoinWithEqualPk(): Unit = {
+    val query1 = "SELECT SUM(a2) AS a2, a1 FROM A group by a1"
+    val query2 = "SELECT SUM(b2) AS b2, b1 FROM B group by b1"
+    val query = s"SELECT a1, b1 FROM ($query1) RIGHT JOIN ($query2) ON a1 = b1"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("1,1", "2,2", "null,5", "3,3", "null,4")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testRightJoinWithRightNotPk(): Unit = {
+    val query1 = "SELECT SUM(a2) AS a2, a1 FROM A group by a1"
+    val query = s"SELECT a1, b1 FROM ($query1) RIGHT JOIN B ON a1 = b1"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("null,4", "null,4", "null,4", "null,4", "null,5", "null,5", "null,5",
+      "null,5", "null,5", "1,1", "2,2", "3,3", "3,3", "3,3", "2,2")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testRightJoinWithPk(): Unit = {
+    val query1 = "SELECT SUM(a2) AS a2, a1 FROM A group by a1"
+    val query2 = "SELECT SUM(b2) AS b2, b1 FROM B group by b1"
+    val query = s"SELECT a1, a2, b1, b2 FROM ($query1) RIGHT JOIN ($query2) ON a2 = b2"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("null,null,3,15", "null,null,4,34", "null,null,5,65",
+      "1,1,1,1", "null,null,2,5")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testFullJoinNonEqui(): Unit = {
+    val query = "SELECT a1, b1 FROM A FULL JOIN B ON a1 = b1 AND a2 > b2"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("1,null", "3,null", "2,null", "null,3", "null,2", "null,2", "null,3",
+      "null,5", "null,3", "null,5", "null,4", "null,5", "null,4", "null,1", "null,5", "null,4",
+      "null,5", "null,4")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testFullJoinWithEqualPkNonEqui(): Unit = {
+    val query1 = "SELECT SUM(a2) AS a2, a1 FROM A group by a1"
+    val query2 = "SELECT SUM(b2) AS b2, b1 FROM B group by b1"
+    val query = s"SELECT a1, b1 FROM ($query1) FULL JOIN ($query2) ON a1 = b1 AND a2 > b2"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("null,2", "null,5", "null,3", "null,4", "3,null", "1,null", "null,1", "2," +
+      "null")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testFullJoinWithFullNotPkNonEqui(): Unit = {
+    val query1 = "SELECT SUM(a2) AS a2, a1 FROM A group by a1"
+    val query = s"SELECT a1, b1 FROM ($query1) FULL JOIN B ON a1 = b1 AND a2 > b2"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("null,2", "null,1", "null,2", "null,5", "null,5", "null,5", "null,5",
+      "null,5", "null,3", "null,3", "null,3", "null,4", "null,4", "null,4", "null,4", "3,null",
+      "1,null", "2,null")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testFullJoinWithPkNonEqui(): Unit = {
+    val query1 = "SELECT SUM(a2) AS a2, a1 FROM A group by a1"
+    val query2 = "SELECT SUM(b2) AS b2, b1 FROM B group by b1"
+    val query = s"SELECT a1, a2, b1, b2 FROM ($query1) FULL JOIN ($query2) ON a2 = b2 AND a1 > b1"
+
+    env.setParallelism(1)
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("1,1,null,null", "null,null,5,65", "null,null,2,5", "2,2,null,null", "3,2," +
+      "null,null", "null,null,3,15", "null,null,4,34", "null,null,1,1")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testFullJoin(): Unit = {
+    val query = "SELECT a1, b1 FROM A FULL JOIN B ON a1 = b1"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("1,1", "null,5", "null,5", "null,5", "null,4", "null,5", "null,4", "null," +
+      "5", "null,4", "null,4", "2,2", "2,2", "3,3", "3,3", "3,3")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testFullJoinWithEqualPk(): Unit = {
+    val query1 = "SELECT SUM(a2) AS a2, a1 FROM A group by a1"
+    val query2 = "SELECT SUM(b2) AS b2, b1 FROM B group by b1"
+    val query = s"SELECT a1, b1 FROM ($query1) FULL JOIN ($query2) ON a1 = b1"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("null,4", "1,1", "3,3", "2,2", "null,5")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testFullJoinWithFullNotPk(): Unit = {
+    val query1 = "SELECT SUM(a2) AS a2, a1 FROM A group by a1"
+    val query = s"SELECT a1, b1 FROM ($query1) FULL JOIN B ON a1 = b1"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("null,4", "null,4", "null,4", "null,4", "null,5", "null,5", "null,5",
+      "null,5", "null,5", "3,3", "3,3", "3,3", "1,1", "2,2", "2,2")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def FullJoinWithPk(): Unit = {
+    val query1 = "SELECT SUM(a2) AS a2, a1 FROM A group by a1"
+    val query2 = "SELECT SUM(b2) AS b2, b1 FROM B group by b1"
+    val query = s"SELECT a1, a2, b1, b2 FROM ($query1) FULL JOIN ($query2) ON a2 = b2"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("null,null,3,15", "null,null,4,34", "null,null,5,65", "3,2,null,null", "2," +
+      "2,null,null", "null,null,2,5", "1,1,1,1")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testNullLeftOuterJoin(): Unit = {
+    val data1 = new mutable.MutableList[(Int, Long)]
+    data1.+=((1, 1L))
+    data1.+=((3, 8L))
+    data1.+=((4, 2L))
+
+    val data2 = new mutable.MutableList[(Int, Long)]
+    data2.+=((1, 1L))
+    data2.+=((2, 2L))
+    data2.+=((3, 2L))
+
+    val t1 = failingDataSource(data1).toTable(tEnv, 'a, 'b)
+    val t2 = failingDataSource(data2).toTable(tEnv, 'a, 'b)
+
+    tEnv.registerTable("T1", t1)
+    tEnv.registerTable("T2", t2)
+
+    val sqlQuery =
+      """
+        |SELECT t1.a, t1.b, t2.a, t2.b
+        |FROM (
+        | SELECT if(a = 3, cast(null as int), a) as a, b FROM T1
+        |) as t1
+        |LEFT OUTER JOIN (
+        | SELECT if(a = 3, cast(null as int), a) as a, b FROM T2
+        |) as t2
+        |ON t1.a = t2.a
+        |""".stripMargin
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = mutable.MutableList(
+      "1,1,1,1",
+      "4,2,null,null",
+      "null,8,null,null"
+    )
+
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testNullLeftOuterJoinWithNullCond(): Unit = {
+    val data1 = new mutable.MutableList[(Int, Long)]
+    data1.+=((1, 1L))
+    data1.+=((3, 8L))
+    data1.+=((4, 2L))
+
+    val data2 = new mutable.MutableList[(Int, Long)]
+    data2.+=((1, 1L))
+    data2.+=((2, 2L))
+    data2.+=((3, 2L))
+
+    val t1 = failingDataSource(data1).toTable(tEnv, 'a, 'b)
+    val t2 = failingDataSource(data2).toTable(tEnv, 'a, 'b)
+
+    tEnv.registerTable("T1", t1)
+    tEnv.registerTable("T2", t2)
+
+    val sqlQuery =
+      """
+        |SELECT t1.a, t1.b, t2.a, t2.b
+        |FROM (
+        | SELECT if(a = 3, cast(null as int), a) as a, b FROM T1
+        |) as t1
+        |LEFT OUTER JOIN (
+        | SELECT if(a = 3, cast(null as int), a) as a, b FROM T2
+        |) as t2
+        |ON t1.a = t2.a OR (t1.a is null AND t2.a is null)
+        |""".stripMargin
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = mutable.MutableList(
+      "1,1,1,1",
+      "4,2,null,null",
+      "null,8,null,2"
+    )
+
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testNullRightOuterJoin(): Unit = {
+    val data1 = new mutable.MutableList[(Int, Long)]
+    data1.+=((1, 1L))
+    data1.+=((3, 8L))
+    data1.+=((4, 2L))
+
+    val data2 = new mutable.MutableList[(Int, Long)]
+    data2.+=((1, 1L))
+    data2.+=((2, 2L))
+    data2.+=((3, 2L))
+
+    val t1 = failingDataSource(data1).toTable(tEnv, 'a, 'b)
+    val t2 = failingDataSource(data2).toTable(tEnv, 'a, 'b)
+
+    tEnv.registerTable("T1", t1)
+    tEnv.registerTable("T2", t2)
+
+    val sqlQuery =
+      """
+        |SELECT t1.a, t1.b, t2.a, t2.b
+        |FROM (
+        | SELECT if(a = 3, cast(null as int), a) as a, b FROM T1
+        |) as t1
+        |RIGHT OUTER JOIN (
+        | SELECT if(a = 3, cast(null as int), a) as a, b FROM T2
+        |) as t2 ON t1.a = t2.a
+        |""".stripMargin
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = mutable.MutableList(
+      "1,1,1,1",
+      "null,null,2,2",
+      "null,null,null,2"
+    )
+
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testNullRightOuterJoinWithNullCond(): Unit = {
+    val data1 = new mutable.MutableList[(Int, Long)]
+    data1.+=((1, 1L))
+    data1.+=((3, 8L))
+    data1.+=((4, 2L))
+
+    val data2 = new mutable.MutableList[(Int, Long)]
+    data2.+=((1, 1L))
+    data2.+=((2, 2L))
+    data2.+=((3, 2L))
+
+    val t1 = failingDataSource(data1).toTable(tEnv, 'a, 'b)
+    val t2 = failingDataSource(data2).toTable(tEnv, 'a, 'b)
+
+    tEnv.registerTable("T1", t1)
+    tEnv.registerTable("T2", t2)
+
+    val sqlQuery =
+      """
+        |SELECT t1.a, t1.b, t2.a, t2.b
+        |FROM (
+        | SELECT if(a = 3, cast(null as int), a) as a, b FROM T1
+        |) as t1
+        |RIGHT OUTER JOIN (
+        | SELECT if(a = 3, cast(null as int), a) as a, b FROM T2
+        |) as t2
+        |ON t1.a = t2.a OR (t1.a is null AND t2.a is null)
+        |""".stripMargin
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = mutable.MutableList(
+      "1,1,1,1",
+      "null,null,2,2",
+      "null,8,null,2"
+    )
+
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testNullFullOuterJoin(): Unit = {
+    val data1 = new mutable.MutableList[(Int, Long)]
+    data1.+=((1, 1L))
+    data1.+=((3, 8L))
+    data1.+=((4, 2L))
+
+    val data2 = new mutable.MutableList[(Int, Long)]
+    data2.+=((1, 1L))
+    data2.+=((2, 2L))
+    data2.+=((3, 2L))
+
+    val t1 = failingDataSource(data1).toTable(tEnv, 'a, 'b)
+    val t2 = failingDataSource(data2).toTable(tEnv, 'a, 'b)
+
+    tEnv.registerTable("T1", t1)
+    tEnv.registerTable("T2", t2)
+
+    val sqlQuery =
+      """
+        |SELECT t1.a, t1.b, t2.a, t2.b
+        |FROM (
+         SELECT if(a = 3, cast(null as int), a) as a, b FROM T1
+        |) as t1
+        |FULL OUTER JOIN (
+         SELECT if(a = 3, cast(null as int), a) as a, b FROM T2
+        |) as t2
+        |ON t1.a = t2.a
+        |""".stripMargin
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = mutable.MutableList(
+      "1,1,1,1",
+      "null,null,2,2",
+      "4,2,null,null",
+      "null,8,null,null",
+      "null,null,null,2"
+    )
+
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testNullFullOuterJoinWithNullCond(): Unit = {
+    val data1 = new mutable.MutableList[(Int, Long)]
+    data1.+=((1, 1L))
+    data1.+=((3, 8L))
+    data1.+=((4, 2L))
+
+    val data2 = new mutable.MutableList[(Int, Long)]
+    data2.+=((1, 1L))
+    data2.+=((2, 2L))
+    data2.+=((3, 2L))
+
+    val t1 = failingDataSource(data1).toTable(tEnv, 'a, 'b)
+    val t2 = failingDataSource(data2).toTable(tEnv, 'a, 'b)
+
+    tEnv.registerTable("T1", t1)
+    tEnv.registerTable("T2", t2)
+
+    val sqlQuery =
+      """
+        |SELECT t1.a, t1.b, t2.a, t2.b
+        |FROM (
+         SELECT if(a = 3, cast(null as int), a) as a, b FROM T1
+        |) as t1
+        |FULL OUTER JOIN (
+         SELECT if(a = 3, cast(null as int), a) as a, b FROM T2
+        |) as t2
+        |ON t1.a = t2.a
+        |OR (t1.a is null AND t2.a is null)
+        |""".stripMargin
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = mutable.MutableList(
+      "1,1,1,1",
+      "null,null,2,2",
+      "4,2,null,null",
+      "null,8,null,2"
+    )
+
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testJoinWithoutWatermark(): Unit = {
+    // NOTE: Different from AggregateITCase, we do not set stream time characteristic
+    // of environment to event time, so that emitWatermark() actually does nothing.
+    env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime)
+
+    val data1 = new mutable.MutableList[(Int, Long)]
+    data1 .+= ((1, 1L))
+    data1 .+= ((2, 2L))
+    data1 .+= ((3, 3L))
+    val data2 = new mutable.MutableList[(Int, Long)]
+    data2 .+= ((1, -1L))
+    data2 .+= ((2, -2L))
+    data2 .+= ((3, -3L))
+
+    val t1 = failingDataSource(data1).toTable(tEnv, 'a, 'b)
+    tEnv.registerTable("T1", t1)
+    val t2 = failingDataSource(data2).toTable(tEnv, 'a, 'c)
+    tEnv.registerTable("T2", t2)
+
+    val t3 = tEnv.sqlQuery(
+      "select T1.a, b, c from T1, T2 WHERE T1.a = T2.a")
+    val sink = new TestingRetractSink
+    t3.toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+    val expected = List("1,1,-1", "2,2,-2", "3,3,-3")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testBigDataOfJoin(): Unit = {
+    env.setParallelism(1)
+
+    val data = new mutable.MutableList[(Int, Long, String)]
+    for (i <- 0 until 500) {
+      data.+=((i % 10, i, i.toString))
+    }
+
+    val t1 = failingDataSource(data).toTable(tEnv, 'a, 'b, 'c)
+    val t2 = failingDataSource(data).toTable(tEnv, 'd, 'e, 'f)
+    tEnv.registerTable("T1", t1)
+    tEnv.registerTable("T2", t2)
+
+    val sql =
+      """
+        |SELECT COUNT(DISTINCT b) FROM (SELECT b FROM T1, T2 WHERE b = e)
+      """.stripMargin
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = List("500")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/join/stream/StreamingJoinOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/join/stream/StreamingJoinOperator.java
@@ -1,0 +1,465 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.join.stream;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.TimestampedCollector;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.GenericRow;
+import org.apache.flink.table.dataformat.JoinedRow;
+import org.apache.flink.table.dataformat.util.BaseRowUtil;
+import org.apache.flink.table.generated.GeneratedJoinCondition;
+import org.apache.flink.table.generated.JoinCondition;
+import org.apache.flink.table.runtime.join.NullAwareJoinHelper;
+import org.apache.flink.table.runtime.join.stream.state.JoinInputSideSpec;
+import org.apache.flink.table.runtime.join.stream.state.JoinRecordStateView;
+import org.apache.flink.table.runtime.join.stream.state.JoinRecordStateViews;
+import org.apache.flink.table.runtime.join.stream.state.OuterJoinRecordStateView;
+import org.apache.flink.table.runtime.join.stream.state.OuterJoinRecordStateViews;
+import org.apache.flink.table.typeutils.BaseRowTypeInfo;
+import org.apache.flink.util.IterableIterator;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Streaming unbounded Join operator which support INNER/LEFT/RIGHT/FULL JOIN.
+ */
+public class StreamingJoinOperator extends AbstractStreamOperator<BaseRow>
+	implements TwoInputStreamOperator<BaseRow, BaseRow, BaseRow> {
+
+	private static final long serialVersionUID = -376944622236540545L;
+
+	private final BaseRowTypeInfo leftType;
+	private final BaseRowTypeInfo rightType;
+	private final GeneratedJoinCondition generatedJoinCondition;
+
+	private final JoinInputSideSpec leftInputSideSpec;
+	private final JoinInputSideSpec rightInputSideSpec;
+
+	// whether left side is outer side, e.g. left is outer but right is not when LEFT OUTER JOIN
+	private final boolean leftIsOuter;
+	// whether right side is outer side, e.g. right is outer but left is not when RIGHT OUTER JOIN
+	private final boolean rightIsOuter;
+
+	private final int[] nullFilterKeys;
+
+	private final long minRetentionTime;
+	private final boolean stateCleaningEnabled;
+
+	private transient JoinCondition joinCondition;
+	private transient TimestampedCollector<BaseRow> collector;
+
+	private transient JoinedRow outRow;
+	private transient BaseRow leftNullRow;
+	private transient BaseRow rightNullRow;
+
+	// left join state
+	private transient JoinRecordStateView leftRecordStateView;
+	// right join state
+	private transient JoinRecordStateView rightRecordStateView;
+
+	public StreamingJoinOperator(
+		BaseRowTypeInfo leftType,
+		BaseRowTypeInfo rightType,
+		GeneratedJoinCondition generatedJoinCondition,
+		JoinInputSideSpec leftInputSideSpec,
+		JoinInputSideSpec rightInputSideSpec,
+		boolean leftIsOuter,
+		boolean rightIsOuter,
+		boolean[] filterNullKeys,
+		long minRetentionTime) {
+		this.leftType = leftType;
+		this.rightType = rightType;
+		this.generatedJoinCondition = generatedJoinCondition;
+		this.leftInputSideSpec = leftInputSideSpec;
+		this.rightInputSideSpec = rightInputSideSpec;
+		this.minRetentionTime = minRetentionTime;
+		this.stateCleaningEnabled = minRetentionTime > 1;
+		this.leftIsOuter = leftIsOuter;
+		this.rightIsOuter = rightIsOuter;
+		if (filterNullKeys == null || filterNullKeys.length == 0) {
+			this.nullFilterKeys = new int[0];
+		} else {
+			this.nullFilterKeys = NullAwareJoinHelper.getNullFilterKeys(filterNullKeys);
+		}
+	}
+
+	@Override
+	public void open() throws Exception {
+		super.open();
+
+		this.joinCondition = new JoinConditionWithNullFilters(
+			generatedJoinCondition.newInstance(getRuntimeContext().getUserCodeClassLoader()));
+
+		this.collector = new TimestampedCollector<>(output);
+		this.outRow = new JoinedRow();
+		this.leftNullRow = new GenericRow(leftType.getArity());
+		this.rightNullRow = new GenericRow(rightType.getArity());
+
+		// initialize states
+		if (leftIsOuter) {
+			this.leftRecordStateView = OuterJoinRecordStateViews.create(
+				getRuntimeContext(),
+				"left-records",
+				leftInputSideSpec,
+				leftType,
+				minRetentionTime,
+				stateCleaningEnabled);
+		} else {
+			this.leftRecordStateView = JoinRecordStateViews.create(
+				getRuntimeContext(),
+				"left-records",
+				leftInputSideSpec,
+				leftType,
+				minRetentionTime,
+				stateCleaningEnabled);
+		}
+
+		if (rightIsOuter) {
+			this.rightRecordStateView = OuterJoinRecordStateViews.create(
+				getRuntimeContext(),
+				"right-records",
+				rightInputSideSpec,
+				rightType,
+				minRetentionTime,
+				stateCleaningEnabled);
+		} else {
+			this.rightRecordStateView = JoinRecordStateViews.create(
+				getRuntimeContext(),
+				"right-records",
+				rightInputSideSpec,
+				rightType,
+				minRetentionTime,
+				stateCleaningEnabled);
+		}
+	}
+
+	@Override
+	public void processElement1(StreamRecord<BaseRow> element) throws Exception {
+		processElement(element.getValue(), leftRecordStateView, rightRecordStateView, true);
+	}
+
+	@Override
+	public void processElement2(StreamRecord<BaseRow> element) throws Exception {
+		processElement(element.getValue(), rightRecordStateView, leftRecordStateView, false);
+	}
+
+	/**
+	 * Process an input element and output incremental joined records, retraction messages will
+	 * be sent in some scenarios.
+	 *
+	 * <p>Following is the pseudocode to describe the core logic of this method. The logic of this
+	 * method is too complex, so we provide the pseudocode to help understand the logic. We should
+	 * keep sync the following pseudocode with the real logic of the method.
+	 *
+	 * <pre>
+	 * if input record is accumulate
+	 * |  if input side is outer
+	 * |  |  if there is no matched rows on the other side, send +[record+null], state.add(record, 0)
+	 * |  |  if there are matched rows on the other side
+	 * |  |  | if other side is outer
+	 * |  |  | |  if the matched num in the matched rows == 0, send -[null+other]
+	 * |  |  | |  if the matched num in the matched rows > 0, skip
+	 * |  |  | |  otherState.update(other, old + 1)
+	 * |  |  | endif
+	 * |  |  | send +[record+other]s, state.add(record, other.size)
+	 * |  |  endif
+	 * |  endif
+	 * |  if input side not outer
+	 * |  |  state.add(record)
+	 * |  |  if there is no matched rows on the other side, skip
+	 * |  |  if there are matched rows on the other side
+	 * |  |  |  if other side is outer
+	 * |  |  |  |  if the matched num in the matched rows == 0, send -[null+other]
+	 * |  |  |  |  if the matched num in the matched rows > 0, skip
+	 * |  |  |  |  otherState.update(other, old + 1)
+	 * |  |  |  endif
+	 * |  |  |  send +[record+other]s
+	 * |  |  endif
+	 * |  endif
+	 * endif
+	 *
+	 * if input record is retract
+	 * |  state.retract(record)
+	 * |  if there is no matched rows on the other side
+	 * |  | if input side is outer, send -[record+null]
+	 * |  endif
+	 * |  if there are matched rows on the other side, send -[record+other]s
+	 * |  |  if other side is outer
+	 * |  |  |  if the matched num in the matched rows == 0, this should never happen!
+	 * |  |  |  if the matched num in the matched rows == 1, send +[null+other]
+	 * |  |  |  if the matched num in the matched rows > 1, skip
+	 * |  |  |  otherState.update(other, old - 1)
+	 * |  |  endif
+	 * |  endif
+	 * endif
+	 * </pre>
+	 *
+	 * @param input the input element
+	 * @param inputSideStateView state of input side
+	 * @param otherSideStateView state of other side
+	 * @param inputIsLeft whether input side is left side
+	 */
+	private void processElement(
+		BaseRow input,
+		JoinRecordStateView inputSideStateView,
+		JoinRecordStateView otherSideStateView,
+		boolean inputIsLeft) throws Exception {
+
+		boolean inputIsOuter = inputIsLeft ? leftIsOuter : rightIsOuter;
+		boolean otherIsOuter = inputIsLeft ? rightIsOuter : leftIsOuter;
+
+		AssociatedRecords associatedRecords = AssociatedRecords.of(input, inputIsLeft, otherSideStateView, joinCondition);
+		if (BaseRowUtil.isAccumulateMsg(input)) { // record is accumulate
+			if (inputIsOuter) { // input side is outer
+				OuterJoinRecordStateView inputSideOuterStateView = (OuterJoinRecordStateView) inputSideStateView;
+				if (associatedRecords.isEmpty()) { // there is no matched rows on the other side
+					// send +[record+null]
+					outRow.setHeader(BaseRowUtil.ACCUMULATE_MSG);
+					outputNullPadding(input, inputIsLeft);
+					// state.add(record, 0)
+					inputSideOuterStateView.addRecord(input, 0);
+				} else { // there are matched rows on the other side
+					if (otherIsOuter) { // other side is outer
+						OuterJoinRecordStateView otherSideOuterStateView = (OuterJoinRecordStateView) otherSideStateView;
+						for (OuterRecord outerRecord : associatedRecords.getOuterRecords()) {
+							BaseRow other = outerRecord.record;
+							// if the matched num in the matched rows == 0
+							if (outerRecord.numOfAssociations == 0) {
+								// send -[null+other]
+								outRow.setHeader(BaseRowUtil.RETRACT_MSG);
+								outputNullPadding(other, !inputIsLeft);
+							} // ignore matched number > 0
+							// otherState.update(other, old + 1)
+							otherSideOuterStateView.updateNumOfAssociations(other, outerRecord.numOfAssociations + 1);
+						}
+					}
+					// send +[record+other]s
+					outRow.setHeader(BaseRowUtil.ACCUMULATE_MSG);
+					for (BaseRow other : associatedRecords.getRecords()) {
+						output(input, other, inputIsLeft);
+					}
+					// state.add(record, other.size)
+					inputSideOuterStateView.addRecord(input, associatedRecords.size());
+				}
+			} else { // input side not outer
+				// state.add(record)
+				inputSideStateView.addRecord(input);
+				if (!associatedRecords.isEmpty()) { // if there are matched rows on the other side
+					if (otherIsOuter) { // if other side is outer
+						OuterJoinRecordStateView otherSideOuterStateView = (OuterJoinRecordStateView) otherSideStateView;
+						for (OuterRecord outerRecord : associatedRecords.getOuterRecords()) {
+							if (outerRecord.numOfAssociations == 0) { // if the matched num in the matched rows == 0
+								// send -[null+other]
+								outRow.setHeader(BaseRowUtil.RETRACT_MSG);
+								outputNullPadding(outerRecord.record, !inputIsLeft);
+							}
+							// otherState.update(other, old + 1)
+							otherSideOuterStateView.updateNumOfAssociations(outerRecord.record, outerRecord.numOfAssociations + 1);
+						}
+					}
+					// send +[record+other]s
+					outRow.setHeader(BaseRowUtil.ACCUMULATE_MSG);
+					for (BaseRow other : associatedRecords.getRecords()) {
+						output(input, other, inputIsLeft);
+					}
+				}
+				// skip when there is no matched rows on the other side
+			}
+		} else { // input record is retract
+			// state.retract(record)
+			inputSideStateView.retractRecord(input);
+			if (associatedRecords.isEmpty()) { // there is no matched rows on the other side
+				if (inputIsOuter) { // input side is outer
+					// send -[record+null]
+					outRow.setHeader(BaseRowUtil.RETRACT_MSG);
+					outputNullPadding(input, inputIsLeft);
+				}
+				// nothing to do when input side is not outer
+			} else { // there are matched rows on the other side
+				// send -[record+other]s
+				outRow.setHeader(BaseRowUtil.RETRACT_MSG);
+				for (BaseRow other : associatedRecords.getRecords()) {
+					output(input, other, inputIsLeft);
+				}
+				// if other side is outer
+				if (otherIsOuter) {
+					OuterJoinRecordStateView otherSideOuterStateView = (OuterJoinRecordStateView) otherSideStateView;
+					for (OuterRecord outerRecord : associatedRecords.getOuterRecords()) {
+						if (outerRecord.numOfAssociations == 1) {
+							// send +[null+other]
+							outRow.setHeader(BaseRowUtil.ACCUMULATE_MSG);
+							outputNullPadding(outerRecord.record, !inputIsLeft);
+						} // nothing else to do when number of associations > 1
+						// otherState.update(other, old - 1)
+						otherSideOuterStateView.updateNumOfAssociations(outerRecord.record, outerRecord.numOfAssociations - 1);
+					}
+				}
+			}
+		}
+	}
+
+	// -------------------------------------------------------------------------------------
+
+	private void output(BaseRow inputRow, BaseRow otherRow, boolean inputIsLeft) {
+		if (inputIsLeft) {
+			outRow.replace(inputRow, otherRow);
+		} else {
+			outRow.replace(otherRow, inputRow);
+		}
+		collector.collect(outRow);
+	}
+
+	private void outputNullPadding(BaseRow row, boolean isLeft) {
+		if (isLeft) {
+			outRow.replace(row, rightNullRow);
+		} else {
+			outRow.replace(leftNullRow, row);
+		}
+		collector.collect(outRow);
+	}
+
+	// ----------------------------------------------------------------------------------------
+	// Utility Classes
+	// ----------------------------------------------------------------------------------------
+
+	private class JoinConditionWithNullFilters implements JoinCondition {
+
+		final JoinCondition backingJoinCondition;
+
+		private JoinConditionWithNullFilters(JoinCondition backingJoinCondition) {
+			this.backingJoinCondition = backingJoinCondition;
+		}
+
+		@Override
+		public boolean apply(BaseRow left, BaseRow right) {
+			if (nullFilterKeys.length != 0) { // is not null safe, return false if any null exists
+				BaseRow joinKey = (BaseRow) getCurrentKey();
+				for (int idx : nullFilterKeys) {
+					if (joinKey.isNullAt(idx)) {
+						// find null present, return false directly
+						return false;
+					}
+				}
+			}
+			// test condition
+			return backingJoinCondition.apply(left, right);
+		}
+	}
+
+	private static final class AssociatedRecords {
+		private final List<OuterRecord> records;
+
+		private AssociatedRecords(List<OuterRecord> records) {
+			checkNotNull(records);
+			this.records = records;
+		}
+
+		public boolean isEmpty() {
+			return records.isEmpty();
+		}
+
+		public int size() {
+			return records.size();
+		}
+
+		public Iterable<BaseRow> getRecords() {
+			return new RecordsIterable(records);
+		}
+
+		public Iterable<OuterRecord> getOuterRecords() {
+			return records;
+		}
+
+		public static AssociatedRecords of(
+			BaseRow input,
+			boolean inputIsLeft,
+			JoinRecordStateView otherSideStateView,
+			JoinCondition condition) throws Exception {
+
+			List<OuterRecord> associations = new ArrayList<>();
+			if (otherSideStateView instanceof OuterJoinRecordStateView) {
+				OuterJoinRecordStateView outerStateView = (OuterJoinRecordStateView) otherSideStateView;
+				Iterable<Tuple2<BaseRow, Integer>> records = outerStateView.getRecordsAndNumOfAssociations();
+				for (Tuple2<BaseRow, Integer> record : records) {
+					boolean matched = inputIsLeft ? condition.apply(input, record.f0) : condition.apply(record.f0, input);
+					if (matched) {
+						associations.add(new OuterRecord(record.f0, record.f1));
+					}
+				}
+			} else {
+				Iterable<BaseRow> records = otherSideStateView.getRecords();
+				for (BaseRow record : records) {
+					boolean matched = inputIsLeft ? condition.apply(input, record) : condition.apply(record, input);
+					if (matched) {
+						// use -1 as the default number of associations
+						associations.add(new OuterRecord(record, -1));
+					}
+				}
+			}
+			return new AssociatedRecords(associations);
+		}
+
+	}
+
+	private static final class RecordsIterable implements IterableIterator<BaseRow> {
+		private final List<OuterRecord> records;
+		private int index = 0;
+
+		private RecordsIterable(List<OuterRecord> records) {
+			this.records = records;
+		}
+
+		@Override
+		public Iterator<BaseRow> iterator() {
+			index = 0;
+			return this;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return index < records.size();
+		}
+
+		@Override
+		public BaseRow next() {
+			BaseRow row = records.get(index).record;
+			index++;
+			return row;
+		}
+	}
+
+	private static final class OuterRecord {
+		private final BaseRow record;
+		private final int numOfAssociations;
+
+		private OuterRecord(BaseRow record, int numOfAssociations) {
+			this.record = record;
+			this.numOfAssociations = numOfAssociations;
+		}
+	}
+
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/join/stream/state/JoinInputSideSpec.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/join/stream/state/JoinInputSideSpec.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.join.stream.state;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.typeutils.BaseRowTypeInfo;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The {@link JoinInputSideSpec} is ap specification which describes input side information of
+ * a Join.
+ */
+public class JoinInputSideSpec implements Serializable {
+	private static final long serialVersionUID = 3178408082297179959L;
+
+	private final boolean inputSideHasUniqueKey;
+	private final boolean joinKeyContainsUniqueKey;
+	@Nullable private final BaseRowTypeInfo uniqueKeyType;
+	@Nullable private final KeySelector<BaseRow, BaseRow> uniqueKeySelector;
+
+	private JoinInputSideSpec(
+			boolean joinKeyContainsUniqueKey,
+			@Nullable BaseRowTypeInfo uniqueKeyType,
+			@Nullable KeySelector<BaseRow, BaseRow> uniqueKeySelector) {
+		this.inputSideHasUniqueKey = uniqueKeyType != null && uniqueKeySelector != null;
+		this.joinKeyContainsUniqueKey = joinKeyContainsUniqueKey;
+		this.uniqueKeyType = uniqueKeyType;
+		this.uniqueKeySelector = uniqueKeySelector;
+	}
+
+	/**
+	 * Returns true if the input has unique key, otherwise false.
+	 */
+	public boolean hasUniqueKey() {
+		return inputSideHasUniqueKey;
+	}
+
+	/**
+	 * Returns true if the join key contains the unique key of the input.
+	 */
+	public boolean joinKeyContainsUniqueKey() {
+		return joinKeyContainsUniqueKey;
+	}
+
+	/**
+	 * Returns the {@link TypeInformation} of the unique key.
+	 * Returns null if the input hasn't unique key.
+	 */
+	@Nullable
+	public BaseRowTypeInfo getUniqueKeyType() {
+		return uniqueKeyType;
+	}
+
+	/**
+	 * Returns the {@link KeySelector} to extract unique key from the input row.
+	 * Returns null if the input hasn't unique key.
+	 */
+	@Nullable
+	public KeySelector<BaseRow, BaseRow> getUniqueKeySelector() {
+		return uniqueKeySelector;
+	}
+
+	/**
+	 * Creates a {@link JoinInputSideSpec} that the input has an unique key.
+	 * @param uniqueKeyType type information of the unique key
+	 * @param uniqueKeySelector key selector to extract unique key from the input row
+	 */
+	public static JoinInputSideSpec withUniqueKey(BaseRowTypeInfo uniqueKeyType, KeySelector<BaseRow, BaseRow> uniqueKeySelector) {
+		checkNotNull(uniqueKeyType);
+		checkNotNull(uniqueKeySelector);
+		return new JoinInputSideSpec(false, uniqueKeyType, uniqueKeySelector);
+	}
+
+	/**
+	 * Creates a {@link JoinInputSideSpec} that input has an unique key and the unique key is
+	 * contained by the join key.
+	 * @param uniqueKeyType type information of the unique key
+	 * @param uniqueKeySelector key selector to extract unique key from the input row
+	 */
+	public static JoinInputSideSpec withUniqueKeyContainedByJoinKey(BaseRowTypeInfo uniqueKeyType, KeySelector<BaseRow, BaseRow> uniqueKeySelector) {
+		checkNotNull(uniqueKeyType);
+		checkNotNull(uniqueKeySelector);
+		return new JoinInputSideSpec(true, uniqueKeyType, uniqueKeySelector);
+	}
+
+	/**
+	 * Creates a {@link JoinInputSideSpec} that input hasn't any unique keys.
+	 */
+	public static JoinInputSideSpec withoutUniqueKey() {
+		return new JoinInputSideSpec(false, null,  null);
+	}
+
+	@Override
+	public String toString() {
+		if (inputSideHasUniqueKey) {
+			if (joinKeyContainsUniqueKey) {
+				return "JoinKeyContainsUniqueKey";
+			} else {
+				return "HasUniqueKey";
+			}
+		} else {
+			return "NoUniqueKey";
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/join/stream/state/JoinRecordStateView.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/join/stream/state/JoinRecordStateView.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.join.stream.state;
+
+import org.apache.flink.table.dataformat.BaseRow;
+
+/**
+ * A {@link JoinRecordStateView} is a view to the join state. It encapsulates the join state and
+ * provides some APIs facing the input records. The join state is used to store
+ * input records. The structure of the join state is vary depending on the {@link JoinInputSideSpec}.
+ *
+ * <p>For example: when the {@link JoinInputSideSpec} is JoinKeyContainsUniqueKey, we will use
+ * {@link org.apache.flink.api.common.state.ValueState} to store records which has better performance.
+ */
+public interface JoinRecordStateView {
+
+	/**
+	 * Add a new record to the state view.
+	 */
+	void addRecord(BaseRow record) throws Exception;
+
+	/**
+	 * Retract the record from the state view.
+	 */
+	void retractRecord(BaseRow record) throws Exception;
+
+	/**
+	 * Gets all the records under the current context (i.e. join key).
+	 */
+	Iterable<BaseRow> getRecords() throws Exception;
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/join/stream/state/JoinRecordStateViews.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/join/stream/state/JoinRecordStateViews.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.join.stream.state;
+
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.StateTtlConfig;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.typeutils.BaseRowTypeInfo;
+import org.apache.flink.util.IterableIterator;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Utility to create a {@link JoinRecordStateView} depends on {@link JoinInputSideSpec}.
+ */
+public final class JoinRecordStateViews {
+
+	/**
+	 * Creates a {@link JoinRecordStateView} depends on {@link JoinInputSideSpec}.
+	 */
+	public static JoinRecordStateView create(
+			RuntimeContext ctx,
+			String stateName,
+			JoinInputSideSpec inputSideSpec,
+			BaseRowTypeInfo recordType,
+			long retentionTime,
+			boolean stateCleaningEnabled) {
+		StateTtlConfig ttlConfig = createTtlConfig(retentionTime, stateCleaningEnabled);
+		if (inputSideSpec.hasUniqueKey()) {
+			if (inputSideSpec.joinKeyContainsUniqueKey()) {
+				return new JoinKeyContainsUniqueKey(ctx, stateName, recordType, ttlConfig);
+			} else {
+				return new InputSideHasUniqueKey(
+					ctx,
+					stateName,
+					recordType,
+					inputSideSpec.getUniqueKeyType(),
+					inputSideSpec.getUniqueKeySelector(),
+					ttlConfig);
+			}
+		} else {
+			return new InputSideHasNoUniqueKey(ctx, stateName, recordType, ttlConfig);
+		}
+	}
+
+	static StateTtlConfig createTtlConfig(long retentionTime, boolean stateCleaningEnabled) {
+		if (stateCleaningEnabled) {
+			checkArgument(retentionTime > 0);
+			return StateTtlConfig
+				.newBuilder(Time.milliseconds(retentionTime))
+				.setUpdateType(StateTtlConfig.UpdateType.OnCreateAndWrite)
+				.setStateVisibility(StateTtlConfig.StateVisibility.ReturnExpiredIfNotCleanedUp)
+				.build();
+		} else {
+			return StateTtlConfig.DISABLED;
+		}
+	}
+
+	// ------------------------------------------------------------------------------------
+
+	private static final class JoinKeyContainsUniqueKey implements JoinRecordStateView {
+
+		private final ValueState<BaseRow> recordState;
+		private final List<BaseRow> reusedList;
+
+		private JoinKeyContainsUniqueKey(
+			RuntimeContext ctx,
+			String stateName,
+			BaseRowTypeInfo recordType,
+			StateTtlConfig ttlConfig) {
+			ValueStateDescriptor<BaseRow> recordStateDesc = new ValueStateDescriptor<>(
+				stateName,
+				recordType);
+			if (!ttlConfig.equals(StateTtlConfig.DISABLED)) {
+				recordStateDesc.enableTimeToLive(ttlConfig);
+			}
+			this.recordState = ctx.getState(recordStateDesc);
+			// the result records always not more than 1
+			this.reusedList = new ArrayList<>(1);
+		}
+
+		@Override
+		public void addRecord(BaseRow record) throws Exception {
+			recordState.update(record);
+		}
+
+		@Override
+		public void retractRecord(BaseRow record) throws Exception {
+			recordState.clear();
+		}
+
+		@Override
+		public Iterable<BaseRow> getRecords() throws Exception {
+			BaseRow record = recordState.value();
+			if (record == null) {
+				reusedList.clear();
+			} else {
+				reusedList.add(record);
+			}
+			return reusedList;
+		}
+	}
+
+	private static final class InputSideHasUniqueKey implements JoinRecordStateView {
+
+		// stores record in the mapping <UK, Record>
+		private final MapState<BaseRow, BaseRow> recordState;
+		private final KeySelector<BaseRow, BaseRow> uniqueKeySelector;
+
+		private InputSideHasUniqueKey(
+			RuntimeContext ctx,
+			String stateName,
+			BaseRowTypeInfo recordType,
+			BaseRowTypeInfo uniqueKeyType,
+			KeySelector<BaseRow, BaseRow> uniqueKeySelector,
+			StateTtlConfig ttlConfig) {
+
+			checkNotNull(uniqueKeyType);
+			checkNotNull(uniqueKeySelector);
+			MapStateDescriptor<BaseRow, BaseRow> recordStateDesc = new MapStateDescriptor<>(
+				stateName,
+				uniqueKeyType,
+				recordType);
+			if (!ttlConfig.equals(StateTtlConfig.DISABLED)) {
+				recordStateDesc.enableTimeToLive(ttlConfig);
+			}
+			this.recordState = ctx.getMapState(recordStateDesc);
+			this.uniqueKeySelector = uniqueKeySelector;
+		}
+
+		@Override
+		public void addRecord(BaseRow record) throws Exception {
+			BaseRow uniqueKey = uniqueKeySelector.getKey(record);
+			recordState.put(uniqueKey, record);
+		}
+
+		@Override
+		public void retractRecord(BaseRow record) throws Exception {
+			BaseRow uniqueKey = uniqueKeySelector.getKey(record);
+			recordState.remove(uniqueKey);
+		}
+
+		@Override
+		public Iterable<BaseRow> getRecords() throws Exception {
+			return recordState.values();
+		}
+	}
+
+	private static final class InputSideHasNoUniqueKey implements JoinRecordStateView {
+
+		private final MapState<BaseRow, Integer> recordState;
+
+		private InputSideHasNoUniqueKey(
+				RuntimeContext ctx,
+				String stateName,
+				BaseRowTypeInfo recordType,
+				StateTtlConfig ttlConfig) {
+			MapStateDescriptor<BaseRow, Integer> recordStateDesc = new MapStateDescriptor<>(
+				stateName,
+				recordType,
+				Types.INT);
+			if (!ttlConfig.equals(StateTtlConfig.DISABLED)) {
+				recordStateDesc.enableTimeToLive(ttlConfig);
+			}
+			this.recordState = ctx.getMapState(recordStateDesc);
+		}
+
+		@Override
+		public void addRecord(BaseRow record) throws Exception {
+			Integer cnt = recordState.get(record);
+			if (cnt != null) {
+				cnt += 1;
+			} else {
+				cnt = 1;
+			}
+			recordState.put(record, cnt);
+		}
+
+		@Override
+		public void retractRecord(BaseRow record) throws Exception {
+			Integer cnt = recordState.get(record);
+			if (cnt != null) {
+				if (cnt > 1) {
+					recordState.put(record, cnt - 1);
+				} else {
+					recordState.remove(record);
+				}
+			}
+			// ignore cnt == null, which means state may be expired
+		}
+
+		@Override
+		public Iterable<BaseRow> getRecords() throws Exception {
+			return new IterableIterator<BaseRow>() {
+
+				private final Iterator<Map.Entry<BaseRow, Integer>> backingIterable = recordState.entries().iterator();
+				private BaseRow record;
+				private int remainingTimes = 0;
+
+				@Override
+				public boolean hasNext() {
+					return backingIterable.hasNext() || remainingTimes > 0;
+				}
+
+				@Override
+				public BaseRow next() {
+					if (remainingTimes > 0) {
+						checkNotNull(record);
+						remainingTimes--;
+						return record;
+					} else {
+						Map.Entry<BaseRow, Integer> entry = backingIterable.next();
+						record = entry.getKey();
+						remainingTimes = entry.getValue() - 1;
+						return record;
+					}
+				}
+
+				@Override
+				public Iterator<BaseRow> iterator() {
+					return this;
+				}
+			};
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/join/stream/state/OuterJoinRecordStateView.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/join/stream/state/OuterJoinRecordStateView.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.join.stream.state;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.table.dataformat.BaseRow;
+
+/**
+ * A {@link OuterJoinRecordStateView} is an extension to {@link JoinRecordStateView}.
+ * The {@link OuterJoinRecordStateView} is used to store records for the outer input
+ * side of the Join, e.g. the left side of left join, the both side of full join.
+ *
+ * <p>The additional information we should store with the record is the number of associations
+ * which is the number of records associated this record with other side. This is an
+ * important information when to send/retract a null padding row, to avoid recompute the
+ * associated numbers every time.
+ *
+ * @see JoinRecordStateView
+ */
+public interface OuterJoinRecordStateView extends JoinRecordStateView {
+
+	/**
+	 * Adds a new record with the number of associations to the state view.
+	 * @param record the added record
+	 * @param numOfAssociations the number of records associated with other side
+	 */
+	void addRecord(BaseRow record, int numOfAssociations) throws Exception;
+
+	/**
+	 * Updates the number of associations belongs to the record.
+	 * @param record the record to update
+	 * @param numOfAssociations the new number of records associated with other side
+	 */
+	void updateNumOfAssociations(BaseRow record, int numOfAssociations) throws Exception;
+
+	/**
+	 * Gets all the records and number of associations under the current context (i.e. join key).
+	 */
+	Iterable<Tuple2<BaseRow, Integer>> getRecordsAndNumOfAssociations() throws Exception;
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/join/stream/state/OuterJoinRecordStateViews.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/join/stream/state/OuterJoinRecordStateViews.java
@@ -1,0 +1,331 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.join.stream.state;
+
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.StateTtlConfig;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.typeutils.BaseRowTypeInfo;
+import org.apache.flink.util.IterableIterator;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.table.runtime.join.stream.state.JoinRecordStateViews.createTtlConfig;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Utility to create a {@link OuterJoinRecordStateViews} depends on {@link JoinInputSideSpec}.
+ */
+public final class OuterJoinRecordStateViews {
+
+	/**
+	 * Creates a {@link OuterJoinRecordStateView} depends on {@link JoinInputSideSpec}.
+	 */
+	public static OuterJoinRecordStateView create(
+		RuntimeContext ctx,
+		String stateName,
+		JoinInputSideSpec inputSideSpec,
+		BaseRowTypeInfo recordType,
+		long retentionTime,
+		boolean stateCleaningEnabled) {
+		StateTtlConfig ttlConfig = createTtlConfig(retentionTime, stateCleaningEnabled);
+		if (inputSideSpec.hasUniqueKey()) {
+			if (inputSideSpec.joinKeyContainsUniqueKey()) {
+				return new OuterJoinRecordStateViews.JoinKeyContainsUniqueKey(ctx, stateName, recordType, ttlConfig);
+			} else {
+				return new OuterJoinRecordStateViews.InputSideHasUniqueKey(
+					ctx,
+					stateName,
+					recordType,
+					inputSideSpec.getUniqueKeyType(),
+					inputSideSpec.getUniqueKeySelector(),
+					ttlConfig);
+			}
+		} else {
+			return new OuterJoinRecordStateViews.InputSideHasNoUniqueKey(ctx, stateName, recordType, ttlConfig);
+		}
+	}
+
+	// ------------------------------------------------------------------------------------------
+
+	private static final class JoinKeyContainsUniqueKey implements OuterJoinRecordStateView {
+
+		private final ValueState<Tuple2<BaseRow, Integer>> recordState;
+		private final List<BaseRow> reusedRecordList;
+		private final List<Tuple2<BaseRow, Integer>> reusedTupleList;
+
+		private JoinKeyContainsUniqueKey(RuntimeContext ctx, String stateName, BaseRowTypeInfo recordType, StateTtlConfig ttlConfig) {
+			TupleTypeInfo<Tuple2<BaseRow, Integer>> valueTypeInfo = new TupleTypeInfo<>(recordType, Types.INT);
+			ValueStateDescriptor<Tuple2<BaseRow, Integer>> recordStateDesc = new ValueStateDescriptor<>(
+				stateName,
+				valueTypeInfo);
+			if (!ttlConfig.equals(StateTtlConfig.DISABLED)) {
+				recordStateDesc.enableTimeToLive(ttlConfig);
+			}
+			this.recordState = ctx.getState(recordStateDesc);
+			// the result records always not more than 1
+			this.reusedRecordList = new ArrayList<>(1);
+			this.reusedTupleList = new ArrayList<>(1);
+		}
+
+		@Override
+		public void addRecord(BaseRow record) throws Exception {
+			addRecord(record, -1);
+		}
+
+		@Override
+		public void addRecord(BaseRow record, int numOfAssociations) throws Exception {
+			recordState.update(Tuple2.of(record, numOfAssociations));
+		}
+
+		@Override
+		public void updateNumOfAssociations(BaseRow record, int numOfAssociations) throws Exception {
+			recordState.update(Tuple2.of(record, numOfAssociations));
+		}
+
+		@Override
+		public void retractRecord(BaseRow record) throws Exception {
+			recordState.clear();
+		}
+
+		@Override
+		public Iterable<BaseRow> getRecords() throws Exception {
+			Tuple2<BaseRow, Integer> tuple = recordState.value();
+			if (tuple == null) {
+				reusedRecordList.clear();
+			} else {
+				reusedRecordList.add(tuple.f0);
+			}
+			return reusedRecordList;
+		}
+
+		@Override
+		public Iterable<Tuple2<BaseRow, Integer>> getRecordsAndNumOfAssociations() throws Exception {
+			Tuple2<BaseRow, Integer> tuple = recordState.value();
+			if (tuple == null) {
+				reusedTupleList.clear();
+			} else {
+				reusedTupleList.add(tuple);
+			}
+			return reusedTupleList;
+		}
+	}
+
+	private static final class InputSideHasUniqueKey implements OuterJoinRecordStateView {
+
+		// stores record in the mapping <UK, <Record, associated-num>>
+		private final MapState<BaseRow, Tuple2<BaseRow, Integer>> recordState;
+		private final KeySelector<BaseRow, BaseRow> uniqueKeySelector;
+
+		private InputSideHasUniqueKey(
+			RuntimeContext ctx,
+			String stateName,
+			BaseRowTypeInfo recordType,
+			BaseRowTypeInfo uniqueKeyType,
+			KeySelector<BaseRow, BaseRow> uniqueKeySelector,
+			StateTtlConfig ttlConfig) {
+
+			checkNotNull(uniqueKeyType);
+			checkNotNull(uniqueKeySelector);
+			TupleTypeInfo<Tuple2<BaseRow, Integer>> valueTypeInfo = new TupleTypeInfo<>(recordType, Types.INT);
+			MapStateDescriptor<BaseRow, Tuple2<BaseRow, Integer>> recordStateDesc = new MapStateDescriptor<>(
+				stateName,
+				uniqueKeyType,
+				valueTypeInfo);
+			if (!ttlConfig.equals(StateTtlConfig.DISABLED)) {
+				recordStateDesc.enableTimeToLive(ttlConfig);
+			}
+			this.recordState = ctx.getMapState(recordStateDesc);
+			this.uniqueKeySelector = uniqueKeySelector;
+		}
+
+		@Override
+		public void addRecord(BaseRow record) throws Exception {
+			addRecord(record, -1);
+		}
+
+		@Override
+		public void addRecord(BaseRow record, int numOfAssociations) throws Exception {
+			BaseRow uniqueKey = uniqueKeySelector.getKey(record);
+			recordState.put(uniqueKey, Tuple2.of(record, numOfAssociations));
+		}
+
+		@Override
+		public void updateNumOfAssociations(BaseRow record, int numOfAssociations) throws Exception {
+			BaseRow uniqueKey = uniqueKeySelector.getKey(record);
+			recordState.put(uniqueKey, Tuple2.of(record, numOfAssociations));
+		}
+
+		@Override
+		public void retractRecord(BaseRow record) throws Exception {
+			BaseRow uniqueKey = uniqueKeySelector.getKey(record);
+			recordState.remove(uniqueKey);
+		}
+
+		@Override
+		public Iterable<BaseRow> getRecords() throws Exception {
+			return new RecordsIterable(getRecordsAndNumOfAssociations());
+		}
+
+		@Override
+		public Iterable<Tuple2<BaseRow, Integer>> getRecordsAndNumOfAssociations() throws Exception {
+			return recordState.values();
+		}
+	}
+
+	private static final class InputSideHasNoUniqueKey implements OuterJoinRecordStateView {
+
+		// stores record in the mapping <Record, <appear-times, associated-num>>
+		private final MapState<BaseRow, Tuple2<Integer, Integer>> recordState;
+
+		private InputSideHasNoUniqueKey(
+			RuntimeContext ctx,
+			String stateName,
+			BaseRowTypeInfo recordType,
+			StateTtlConfig ttlConfig) {
+			TupleTypeInfo<Tuple2<Integer, Integer>> tupleTypeInfo = new TupleTypeInfo<>(Types.INT, Types.INT);
+			MapStateDescriptor<BaseRow, Tuple2<Integer, Integer>> recordStateDesc = new MapStateDescriptor<>(
+				stateName,
+				recordType,
+				tupleTypeInfo);
+			if (!ttlConfig.equals(StateTtlConfig.DISABLED)) {
+				recordStateDesc.enableTimeToLive(ttlConfig);
+			}
+			this.recordState = ctx.getMapState(recordStateDesc);
+		}
+
+		@Override
+		public void addRecord(BaseRow record) throws Exception {
+			addRecord(record, -1);
+		}
+
+		@Override
+		public void addRecord(BaseRow record, int numOfAssociations) throws Exception {
+			Tuple2<Integer, Integer> tuple = recordState.get(record);
+			if (tuple != null) {
+				tuple.f0 = tuple.f0 + 1;
+				tuple.f1 = numOfAssociations;
+			} else {
+				tuple = Tuple2.of(1, numOfAssociations);
+			}
+			recordState.put(record, tuple);
+		}
+
+		@Override
+		public void updateNumOfAssociations(BaseRow record, int numOfAssociations) throws Exception {
+			Tuple2<Integer, Integer> tuple = recordState.get(record);
+			if (tuple != null) {
+				tuple.f1 = numOfAssociations;
+			} else {
+				// compatible for state ttl
+				tuple = Tuple2.of(1, numOfAssociations);
+			}
+			recordState.put(record, tuple);
+		}
+
+		@Override
+		public void retractRecord(BaseRow record) throws Exception {
+			Tuple2<Integer, Integer> tuple = recordState.get(record);
+			if (tuple != null) {
+				if (tuple.f0 > 1) {
+					tuple.f0 = tuple.f0 - 1;
+					recordState.put(record, tuple);
+				} else {
+					recordState.remove(record);
+				}
+			}
+		}
+
+		@Override
+		public Iterable<BaseRow> getRecords() throws Exception {
+			return new RecordsIterable(getRecordsAndNumOfAssociations());
+		}
+
+		@Override
+		public Iterable<Tuple2<BaseRow, Integer>> getRecordsAndNumOfAssociations() throws Exception {
+			return new IterableIterator<Tuple2<BaseRow, Integer>>() {
+
+				private final Iterator<Map.Entry<BaseRow, Tuple2<Integer, Integer>>> backingIterable = recordState.entries().iterator();
+				private Tuple2<BaseRow, Integer> tuple;
+				private int remainingTimes = 0;
+
+				@Override
+				public boolean hasNext() {
+					return backingIterable.hasNext() || remainingTimes > 0;
+				}
+
+				@Override
+				public Tuple2<BaseRow, Integer> next() {
+					if (remainingTimes > 0) {
+						checkNotNull(tuple);
+						remainingTimes--;
+						return tuple;
+					} else {
+						Map.Entry<BaseRow, Tuple2<Integer, Integer>> entry = backingIterable.next();
+						tuple = Tuple2.of(entry.getKey(), entry.getValue().f1);
+						remainingTimes = entry.getValue().f0 - 1;
+						return tuple;
+					}
+				}
+
+				@Override
+				public Iterator<Tuple2<BaseRow, Integer>> iterator() {
+					return this;
+				}
+			};
+		}
+	}
+
+	// ----------------------------------------------------------------------------------------
+
+	private static final class RecordsIterable implements IterableIterator<BaseRow> {
+		private final Iterator<Tuple2<BaseRow, Integer>> tupleIterator;
+
+		private RecordsIterable(Iterable<Tuple2<BaseRow, Integer>> tuples) {
+			checkNotNull(tuples);
+			this.tupleIterator = tuples.iterator();
+		}
+
+		@Override
+		public Iterator<BaseRow> iterator() {
+			return this;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return tupleIterator.hasNext();
+		}
+
+		@Override
+		public BaseRow next() {
+			return tupleIterator.next().f0;
+		}
+	}
+}


### PR DESCRIPTION
Mirror of apache flink#8629

## What is the purpose of the change

Introduce unbounded streaming inner/left/right/full join operator. We will support SEMI/ANTI in another pull request.

## Brief change log

  - Introduce `JoinInputSideSpec` describes input information, for example: has/not unique key.
  - Introduce `JoinRecordStateView` to encapsulates the join state and provides some APIs facing the input records. Because we will have different state structure depends on the input information.
  - Introduce `StreamingJoinOperator` to support INNER/LEFT/RIGHT/FULL together.

## Verifying this change

Adds `JoinITCase` to test join end-to-end.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

