### PR TITLE
Mirror of apache flink#8695

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sinks/OverwritableTableSink.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sinks/OverwritableTableSink.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sinks;
+
+/**
+ * A {@link TableSink} that supports INSERT OVERWRITE should implement this trait.
+ */
+public interface OverwritableTableSink {
+
+	/**
+	 * Configures whether the insert should overwrite existing data or not.
+	 */
+	void setOverwrite(boolean overwrite);
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sinks/PartitionableTableSink.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sinks/PartitionableTableSink.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sinks;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An abstract class with trait about partitionable table sink. This is mainly used for
+ * static partitions. For sql statement:
+ * <pre>
+ * <code>
+ * INSERT INTO A PARTITION(a='ab', b='cd') select c, d from B
+ * </code>
+ * </pre>
+ * We Assume the A has partition columns as &lt;a&gt;, &lt;b&gt;, &lt;c&gt;.
+ * The columns &lt;a&gt; and &lt;b&gt; are called static partition columns, while c is called
+ * dynamic partition column.
+ *
+ * <p>Note: Current class implementation don't support partition pruning which means constant
+ * partition columns will still be kept in result row.
+ */
+public interface PartitionableTableSink {
+
+	/**
+	 * Get the partition keys of the table. This should be an empty set if the table is not partitioned.
+	 *
+	 * @return partition keys of the table
+	 */
+	List<String> getPartitionKeys();
+
+	/**
+	 * Sets the static partitions into the {@link TableSink}.
+	 * @param partitions mapping from static partition column names to string literal values.
+	 *                      String literals will be quoted using {@code '}, for example,
+	 *                      value {@code abc} will be stored as {@code 'abc'} with quotes around.
+	 */
+	void setStaticPartitions(Map<String, String> partitions);
+
+	/**
+	 * If true, all records would be sort with partition fields before output, for some sinks, this
+	 * can be used to reduce the partition writers, that means the sink will accept data
+	 * one partition at a time.
+	 *
+	 * <p>A sink should consider whether to override this especially when it needs buffer
+	 * data before writing.
+	 *
+	 * <p>Notes:
+	 * 1. If returns true, the output data will be sorted <strong>locally</strong> after partitioning.
+	 * 2. Default returns true, if the table is partitioned.
+	 */
+	default boolean sortLocalPartition() {
+		return !getPartitionKeys().isEmpty();
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/PartitionPrunableTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/PartitionPrunableTableSource.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sources;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Adds support for partition pruning to a [[TableSource]].
+ * A {@link TableSource} extending this interface is a partition table and able to
+ * prune partitions before reading data.
+ *
+ * <p>Partitions is represented as a {@code Map<String, String>} which maps from partition-key
+ * to value. The partition columns and values are NOT of strict order in the Map. The correct
+ * order of partition fields should be provided by {@link #getPartitionKeys()}.
+ */
+public interface PartitionPrunableTableSource {
+
+	/**
+	 * Gets all partitions as key-value map belong to this table.
+	 */
+	List<Map<String, String>> getAllPartitions();
+
+	/**
+	 * Get the partition keys of the table. This should be an empty set if the table
+	 * is not partitioned.
+	 *
+	 * @return partition keys of the table
+	 */
+	List<String> getPartitionKeys();
+
+	/**
+	 * Return the flag to indicate whether partition pruning has been tried. Must return true on
+	 * the returned instance of {@link #applyPartitionPruning(List)}.
+	 */
+	boolean isPartitionPruned();
+
+	/**
+	 * Applies the remaining partitions to the table source. The {@code remainingPartitions} is
+	 * the remaining partitions of {@link #getAllPartitions()} after partition pruning applied.
+	 *
+	 * <p>After trying to apply partition pruning, we should return a new {@link TableSource}
+	 * instance which holds all pruned-partitions. Even if we actually pushed nothing down,
+	 * it is recommended that we still return a new {@link TableSource} instance since we will
+	 * mark the returned instance as partition pruned and will never try again.
+	 *
+	 * @param remainingPartitions Remaining partitions after partition pruning applied.
+	 * @return A new cloned instance of {@link TableSource}.
+	 */
+	TableSource applyPartitionPruning(List<Map<String, String>> remainingPartitions);
+
+	/**
+	 * Whether drop partition predicates after apply partition pruning.
+	 *
+	 * @return true only if the result is correct without partition predicate.
+	 */
+	default boolean supportDropPartitionPredicate() {
+		return false;
+	}
+}


### PR DESCRIPTION
Mirror of apache flink#8695

## What is the purpose of the change

Introduce `PartitionableTableSource` for partition pruning, and introduce `OverwritableTableSink` for supporting insert overwrite, and introduce `PartitionableTableSink` for support writing data into partitions.

All of them are only supported in Blink planner in the first version.

## Brief change log

This pull request only contains the three interface. We didn't include any implementations because: 
 - `OverwritableTableSink` depends on the `INSERT OVERWRITE` syntax. 
 - `PartitionableTableSink` depends on the `INSERT PARTITION` syntax.
 - `PartitionableTableSource` depends on the filter pushdown optimization implementation in Blink planner.

## Verifying this change

N/A


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

