### PR TITLE
Mirror of apache flink#8692

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -28,9 +28,12 @@ import org.apache.flink.util.function.SupplierWithException;
 
 import akka.dispatch.OnComplete;
 
+import javax.annotation.Nonnull;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -994,5 +997,28 @@ public class FutureUtils {
 				uncaughtExceptionHandler.uncaughtException(Thread.currentThread(), throwable);
 			}
 		});
+	}
+
+	/**
+	 * Cancels all instances of {@link java.util.concurrent.Future} in the given list of runnables without interrupting.
+	 * This method will suppress unexpected exceptions until the whole list is processed and then rethrow.
+	 *
+	 * @param runnables list of {@link Runnable} candidates to cancel.
+	 */
+	public static void cancelRunnableFutures(@Nonnull List<Runnable> runnables) {
+		RuntimeException suppressedExceptions = null;
+		for (Runnable runnable : runnables) {
+			if (runnable instanceof java.util.concurrent.Future) {
+				try {
+					((java.util.concurrent.Future<?>) runnable).cancel(false);
+				} catch (RuntimeException ex) {
+					// safety net to ensure all candidates get cancelled before we let the exception bubble up.
+					suppressedExceptions = ExceptionUtils.firstOrSuppressed(ex, suppressedExceptions);
+				}
+			}
+		}
+		if (suppressedExceptions != null) {
+			throw suppressedExceptions;
+		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -25,6 +25,8 @@ import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.streaming.api.checkpoint.ExternallyInducedSource;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.operators.StreamSource;
+import org.apache.flink.streaming.runtime.tasks.mailbox.Mailbox;
+import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxStateException;
 import org.apache.flink.util.FlinkException;
 
 /**
@@ -44,8 +46,6 @@ import org.apache.flink.util.FlinkException;
 @Internal
 public class SourceStreamTask<OUT, SRC extends SourceFunction<OUT>, OP extends StreamSource<OUT, SRC>>
 	extends StreamTask<OUT, OP> {
-
-	private static final Runnable SOURCE_POISON_LETTER = () -> {};
 
 	private volatile boolean externallyInducedCheckpoints;
 
@@ -114,6 +114,7 @@ public class SourceStreamTask<OUT, SRC extends SourceFunction<OUT>, OP extends S
 			if (!isCanceled()) {
 				cancelTask();
 			}
+			sourceThread.interrupt();
 			throw mailboxEx;
 		}
 
@@ -123,14 +124,12 @@ public class SourceStreamTask<OUT, SRC extends SourceFunction<OUT>, OP extends S
 		context.allActionsCompleted();
 	}
 
-	private void runAlternativeMailboxLoop() throws InterruptedException {
+	private void runAlternativeMailboxLoop() throws InterruptedException, MailboxStateException {
 
-		while (true) {
+		final Mailbox mailbox = taskMailboxExecutor.getMailbox();
+		while (isMailboxLoopRunning()) {
 
 			Runnable letter = mailbox.takeMail();
-			if (letter == SOURCE_POISON_LETTER) {
-				break;
-			}
 
 			synchronized (getCheckpointLock()) {
 				letter.run();
@@ -184,8 +183,15 @@ public class SourceStreamTask<OUT, SRC extends SourceFunction<OUT>, OP extends S
 				headOperator.run(getCheckpointLock(), getStreamStatusMaintainer());
 			} catch (Throwable t) {
 				sourceExecutionThrowable = t;
-			} finally {
-				mailbox.clearAndPut(SOURCE_POISON_LETTER);
+				LOG.info("LegacySourceFunctionThread emitted throwable.", t);
+			}
+
+			try {
+				taskMailboxExecutor.getMailbox().putFirst(mailboxPoisonLetter);
+			} catch (InterruptedException ie) {
+				Thread.currentThread().interrupt();
+			} catch (MailboxStateException me) {
+				LOG.debug("Could not submit poison letter to mailbox.", me);
 			}
 		}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxImpl.java
@@ -24,6 +24,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
@@ -77,6 +79,12 @@ public class MailboxImpl implements Mailbox {
 	private volatile int count;
 
 	/**
+	 * The state of the mailbox in the lifecycle of open, quiesced, and closed.
+	 */
+	@GuardedBy("lock")
+	private volatile State state;
+
+	/**
 	 * A mask to wrap around the indexes of the ring buffer. We use this to avoid ifs or modulo ops.
 	 */
 	private final int moduloMask;
@@ -93,6 +101,7 @@ public class MailboxImpl implements Mailbox {
 		this.lock = new ReentrantLock();
 		this.notEmpty = lock.newCondition();
 		this.notFull = lock.newCondition();
+		this.state = State.CLOSED;
 	}
 
 	@Override
@@ -101,11 +110,16 @@ public class MailboxImpl implements Mailbox {
 	}
 
 	@Override
-	public Optional<Runnable> tryTakeMail() {
+	public Optional<Runnable> tryTakeMail() throws MailboxStateException {
 		final ReentrantLock lock = this.lock;
 		lock.lock();
 		try {
-			return isEmpty() ? Optional.empty() : Optional.of(takeInternal());
+			if (isEmpty()) {
+				checkTakeStateConditions();
+				return Optional.empty();
+			} else {
+				return Optional.of(takeInternal());
+			}
 		} finally {
 			lock.unlock();
 		}
@@ -113,11 +127,12 @@ public class MailboxImpl implements Mailbox {
 
 	@Nonnull
 	@Override
-	public Runnable takeMail() throws InterruptedException {
+	public Runnable takeMail() throws InterruptedException, MailboxStateException {
 		final ReentrantLock lock = this.lock;
 		lock.lockInterruptibly();
 		try {
 			while (isEmpty()) {
+				checkTakeStateConditions();
 				notEmpty.await();
 			}
 			return takeInternal();
@@ -131,7 +146,7 @@ public class MailboxImpl implements Mailbox {
 		final ReentrantLock lock = this.lock;
 		lock.lockInterruptibly();
 		try {
-			while (isEmpty()) {
+			while (isEmpty() && isTakeAbleState()) {
 				notEmpty.await();
 			}
 		} finally {
@@ -142,14 +157,15 @@ public class MailboxImpl implements Mailbox {
 	//------------------------------------------------------------------------------------------------------------------
 
 	@Override
-	public boolean tryPutMail(@Nonnull Runnable letter) {
+	public boolean tryPutMail(@Nonnull Runnable letter) throws MailboxStateException {
 		final ReentrantLock lock = this.lock;
 		lock.lock();
 		try {
 			if (isFull()) {
+				checkPutStateConditions();
 				return false;
 			} else {
-				putInternal(letter);
+				putTailInternal(letter);
 				return true;
 			}
 		} finally {
@@ -158,14 +174,15 @@ public class MailboxImpl implements Mailbox {
 	}
 
 	@Override
-	public void putMail(@Nonnull Runnable letter) throws InterruptedException {
+	public void putMail(@Nonnull Runnable letter) throws InterruptedException, MailboxStateException {
 		final ReentrantLock lock = this.lock;
 		lock.lockInterruptibly();
 		try {
 			while (isFull()) {
+				checkPutStateConditions();
 				notFull.await();
 			}
-			putInternal(letter);
+			putTailInternal(letter);
 		} finally {
 			lock.unlock();
 		}
@@ -176,7 +193,7 @@ public class MailboxImpl implements Mailbox {
 		final ReentrantLock lock = this.lock;
 		lock.lockInterruptibly();
 		try {
-			while (isFull()) {
+			while (isFull() && isPutAbleState()) {
 				notFull.await();
 			}
 		} finally {
@@ -186,16 +203,79 @@ public class MailboxImpl implements Mailbox {
 
 	//------------------------------------------------------------------------------------------------------------------
 
-	private void putInternal(Runnable letter) {
+	@Nonnull
+	@Override
+	public List<Runnable> clearAndPut(@Nonnull Runnable priorityLetter) throws MailboxStateException {
+		ArrayList<Runnable> droppedLetters = new ArrayList<>(capacity());
+
+		lock.lock();
+		try {
+			// check state first to avoid loosing any letters forever through exception
+			checkPutStateConditions();
+			dropAllLetters(droppedLetters);
+			putTailInternal(priorityLetter);
+		} finally {
+			lock.unlock();
+		}
+
+		return droppedLetters;
+	}
+
+	@Override
+	public void putFirst(@Nonnull Runnable priorityLetter) throws InterruptedException, MailboxStateException {
+		final ReentrantLock lock = this.lock;
+		lock.lockInterruptibly();
+		try {
+			while (isFull()) {
+				checkPutStateConditions();
+				notFull.await();
+			}
+			putHeadInternal(priorityLetter);
+		} finally {
+			lock.unlock();
+		}
+	}
+
+	@Override
+	public boolean tryPutFirst(@Nonnull Runnable priorityLetter) throws MailboxStateException {
+		final ReentrantLock lock = this.lock;
+		lock.lock();
+		try {
+			if (isFull()) {
+				checkPutStateConditions();
+				return false;
+			} else {
+				putHeadInternal(priorityLetter);
+				return true;
+			}
+		} finally {
+			lock.unlock();
+		}
+	}
+
+	//------------------------------------------------------------------------------------------------------------------
+
+	private void putHeadInternal(Runnable letter) throws MailboxStateException {
 		assert lock.isHeldByCurrentThread();
+		checkPutStateConditions();
+		headIndex = decreaseIndexWithWrapAround(headIndex);
+		this.ringBuffer[headIndex] = letter;
+		++count;
+		notEmpty.signal();
+	}
+
+	private void putTailInternal(Runnable letter) throws MailboxStateException {
+		assert lock.isHeldByCurrentThread();
+		checkPutStateConditions();
 		this.ringBuffer[tailIndex] = letter;
 		tailIndex = increaseIndexWithWrapAround(tailIndex);
 		++count;
 		notEmpty.signal();
 	}
 
-	private Runnable takeInternal() {
+	private Runnable takeInternal() throws MailboxStateException {
 		assert lock.isHeldByCurrentThread();
+		checkTakeStateConditions();
 		final Runnable[] buffer = this.ringBuffer;
 		Runnable letter = buffer[headIndex];
 		buffer[headIndex] = null;
@@ -205,32 +285,111 @@ public class MailboxImpl implements Mailbox {
 		return letter;
 	}
 
+	private void dropAllLetters(List<Runnable> dropInto) {
+		assert lock.isHeldByCurrentThread();
+		int localCount = count;
+		while (localCount > 0) {
+			dropInto.add(ringBuffer[headIndex]);
+			ringBuffer[headIndex] = null;
+			headIndex = increaseIndexWithWrapAround(headIndex);
+			--localCount;
+			notFull.signal();
+		}
+		count = 0;
+	}
+
 	private int increaseIndexWithWrapAround(int old) {
 		return (old + 1) & moduloMask;
 	}
 
+	private int decreaseIndexWithWrapAround(int old) {
+		return (old - 1) & moduloMask;
+	}
+
 	private boolean isFull() {
-		return count >= ringBuffer.length;
+		return count >= capacity();
 	}
 
 	private boolean isEmpty() {
 		return count == 0;
 	}
 
+	private boolean isPutAbleState() {
+		return state == State.OPEN;
+	}
+
+	private boolean isTakeAbleState() {
+		return state != State.CLOSED;
+	}
+
+	private void checkPutStateConditions() throws MailboxStateException {
+		final State state = this.state;
+		if (!isPutAbleState()) {
+			throw new MailboxStateException("Mailbox is in state " + state + ", but is required to be in state " +
+				State.OPEN + " for put operations.");
+		}
+	}
+
+	private void checkTakeStateConditions() throws MailboxStateException {
+		final State state = this.state;
+		if (!isTakeAbleState()) {
+			throw new MailboxStateException("Mailbox is in state " + state + ", but is required to be in state " +
+				State.OPEN + " or " + State.QUIESCED + " for take operations.");
+		}
+	}
+
 	@Override
-	public void clearAndPut(@Nonnull Runnable shutdownAction) {
+	public void open() {
 		lock.lock();
 		try {
-			int localCount = count;
-			while (localCount > 0) {
-				ringBuffer[headIndex] = null;
-				headIndex = increaseIndexWithWrapAround(headIndex);
-				--localCount;
+			if (state == State.CLOSED) {
+				state = State.OPEN;
 			}
-			count = 0;
-			putInternal(shutdownAction);
 		} finally {
 			lock.unlock();
 		}
+	}
+
+	@Override
+	public void quiesce() {
+		lock.lock();
+		try {
+			if (state == State.OPEN) {
+				state = State.QUIESCED;
+			}
+			notFull.signalAll();
+		} finally {
+			lock.unlock();
+		}
+	}
+
+	@Nonnull
+	@Override
+	public List<Runnable> close() {
+		final ArrayList<Runnable> droppedLetters = new ArrayList<>(capacity());
+
+		lock.lock();
+		try {
+			dropAllLetters(droppedLetters);
+			state = State.CLOSED;
+			// to unblock all
+			notFull.signalAll();
+			notEmpty.signalAll();
+		} finally {
+			lock.unlock();
+		}
+
+		return droppedLetters;
+	}
+
+	@Nonnull
+	@Override
+	public State getState() {
+		return state;
+	}
+
+	@Override
+	public int capacity() {
+		return ringBuffer.length;
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxReceiver.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxReceiver.java
@@ -39,17 +39,19 @@ public interface MailboxReceiver {
 	 *
 	 * @return an optional with either the oldest letter from the mailbox (head of queue) if the mailbox is not empty or
 	 * an empty optional otherwise.
+	 * @throws  MailboxStateException if mailbox is already closed.
 	 */
-	Optional<Runnable> tryTakeMail();
+	Optional<Runnable> tryTakeMail() throws MailboxStateException;
 
 	/**
 	 * This method returns the oldest letter from the mailbox (head of queue) or blocks until a letter is available.
 	 *
 	 * @return the oldest letter from the mailbox (head of queue).
 	 * @throws InterruptedException on interruption.
+	 * @throws  MailboxStateException if mailbox is already closed.
 	 */
 	@Nonnull
-	Runnable takeMail() throws InterruptedException;
+	Runnable takeMail() throws InterruptedException, MailboxStateException;
 
 	/**
 	 * This method blocks if the mailbox is empty until mail becomes available.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxSender.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxSender.java
@@ -32,16 +32,18 @@ public interface MailboxSender {
 	 *
 	 * @param letter the letter to enqueue.
 	 * @return <code>true</code> iff successful.
+	 * @throws MailboxStateException if the mailbox is quiesced or closed.
 	 */
-	boolean tryPutMail(@Nonnull Runnable letter);
+	boolean tryPutMail(@Nonnull Runnable letter) throws MailboxStateException;
 
 	/**
 	 * Enqueues the given letter to the mailbox and blocks until there is capacity for a successful put.
 	 *
 	 * @param letter the letter to enqueue.
 	 * @throws InterruptedException on interruption.
+	 * @throws MailboxStateException if the mailbox is quiesced or closed.
 	 */
-	void putMail(@Nonnull Runnable letter) throws InterruptedException;
+	void putMail(@Nonnull Runnable letter) throws InterruptedException,  MailboxStateException;
 
 	/**
 	 * This method blocks until the mailbox has again capacity to enqueue new letters.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxStateException.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxStateException.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks.mailbox;
+
+/**
+ * This exception signals that a method of the mailbox was invoked in a state that does not support the invocation,
+ * e.g. on the attempt to put a letter into a closed mailbox.
+ */
+public class MailboxStateException extends Exception {
+
+	MailboxStateException() {
+	}
+
+	MailboxStateException(String message) {
+		super(message);
+	}
+
+	MailboxStateException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	MailboxStateException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxExecutor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxExecutor.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks.mailbox;
+
+import javax.annotation.Nonnull;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+
+/**
+ * Interface for an {@link Executor} build around a {@link Mailbox}-based execution model.
+ */
+public interface TaskMailboxExecutor extends Executor {
+
+	/**
+	 * Executes the given command at some time in the future in the mailbox thread. This call can block when the
+	 * mailbox is currently full. Therefore, this method must not be called from the mailbox thread itself as this
+	 * can cause a deadlock. Instead, if the caller is already in the mailbox thread, the command should just be
+	 * executed directly or use the non-blocking {@link #tryExecute(Runnable)}.
+	 *
+	 * @param command the runnable task to add to the mailbox for execution.
+	 * @throws RejectedExecutionException if this task cannot be accepted for execution, e.g. because the mailbox is
+	 *                                    quiesced or closed.
+	 */
+	@Override
+	void execute(@Nonnull Runnable command) throws RejectedExecutionException;
+
+	/**
+	 * Attempts to enqueue the given command in the mailbox for execution. On success, the method returns true. If
+	 * the mailbox is full, this method returns immediately without adding the command and returns false.
+	 *
+	 * @param command the runnable task to add to the mailbox for execution.
+	 * @return true if the command was added to the mailbox. False if the command could not be added because the mailbox
+	 * was full.
+	 * @throws RejectedExecutionException if this task cannot be accepted for execution, e.g. because the mailbox is
+	 *                                    quiesced or closed.
+	 */
+	boolean tryExecute(Runnable command) throws RejectedExecutionException;
+
+	/**
+	 * This method blocks until the mailbox potentially has again capacity to add another command. This method must not
+	 * be called from the mailbox thread itself as this can cause a deadlock.
+	 *
+	 * @throws InterruptedException on interruption.
+	 */
+	void waitUntilCanExecute() throws InterruptedException;
+
+	/**
+	 * This methods starts running the command at the head of the mailbox and is intended to be used by the mailbox
+	 * thread to yield from a currently ongoing action to another command. The method blocks until another command to
+	 * run is available in the mailbox and must only be called from the mailbox thread. Must only be called from the
+	 * mailbox thread to not violate the single-threaded execution model.
+	 *
+	 * @throws InterruptedException on interruption.
+	 * @throws IllegalStateException if the mailbox is closed and can no longer supply runnables for yielding.
+	 */
+	void yield() throws InterruptedException, IllegalStateException;
+
+	/**
+	 * This methods attempts to run the command at the head of the mailbox. This is intended to be used by the mailbox
+	 * thread to yield from a currently ongoing action to another command. The method returns true if a command was
+	 * found and executed or false if the mailbox was empty. Must only be called from the
+	 * mailbox thread to not violate the single-threaded execution model.
+	 *
+	 * @return true on successful yielding to another command, false if there was no command to yield to.
+	 * @throws IllegalStateException if the mailbox is closed and can no longer supply runnables for yielding.
+	 */
+	boolean tryYield() throws IllegalStateException;
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxExecutorService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxExecutorService.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks.mailbox;
+
+import javax.annotation.Nonnull;
+
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Interface for an {@link ExecutorService} build around a {@link Mailbox}-based execution model.
+ */
+public interface TaskMailboxExecutorService extends TaskMailboxExecutor, ExecutorService {
+
+	/**
+	 * Returns the mailbox that manages the execution order.
+	 *
+	 * @return the mailbox.
+	 */
+	@Nonnull
+	Mailbox getMailbox();
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxExecutorServiceImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxExecutorServiceImpl.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks.mailbox;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Implementation of an executor service build around a mailbox-based execution model.
+ */
+public class TaskMailboxExecutorServiceImpl extends AbstractExecutorService implements TaskMailboxExecutorService {
+
+	/** Optional reference to the thread that executes the mailbox letters. For debugging. */
+	@Nullable
+	private final Thread taskMainThread;
+
+	/** The mailbox that manages the submitted runnable objects. */
+	@Nonnull
+	private final Mailbox mailbox;
+
+	public TaskMailboxExecutorServiceImpl(@Nonnull Mailbox mailbox) {
+		this(mailbox, null);
+	}
+
+	private TaskMailboxExecutorServiceImpl(@Nonnull Mailbox mailbox, @Nullable Thread taskMainThread) {
+		this.mailbox = mailbox;
+		this.taskMainThread = taskMainThread;
+	}
+
+	@Override
+	public void execute(@Nonnull Runnable command) {
+		assertIsNotMailboxThread();
+		try {
+			mailbox.putMail(command);
+		} catch (InterruptedException irex) {
+			Thread.currentThread().interrupt();
+			throw new RejectedExecutionException("Sender thread was interrupted while blocking on mailbox.", irex);
+		} catch (MailboxStateException mbex) {
+			throw new RejectedExecutionException(mbex);
+		}
+	}
+
+	@Override
+	public boolean tryExecute(Runnable command) {
+		try {
+			return mailbox.tryPutMail(command);
+		} catch (MailboxStateException e) {
+			throw new RejectedExecutionException(e);
+		}
+	}
+
+	@Override
+	public void waitUntilCanExecute() throws InterruptedException {
+		assertIsNotMailboxThread();
+		mailbox.waitUntilHasCapacity();
+	}
+
+	@Override
+	public void yield() throws InterruptedException, IllegalStateException {
+		assertIsMailboxThread();
+		try {
+			Runnable runnable = mailbox.takeMail();
+			runnable.run();
+		} catch (MailboxStateException e) {
+			throw new IllegalStateException("Mailbox can no longer supply runnables for yielding.", e);
+		}
+	}
+
+	@Override
+	public boolean tryYield() throws IllegalStateException {
+		assertIsMailboxThread();
+		try {
+			Optional<Runnable> runnableOptional = mailbox.tryTakeMail();
+			if (runnableOptional.isPresent()) {
+				runnableOptional.get().run();
+				return true;
+			} else {
+				return false;
+			}
+		} catch (MailboxStateException e) {
+			throw new IllegalStateException("Mailbox can no longer supply runnables for yielding.", e);
+		}
+	}
+
+	@Override
+	public void shutdown() {
+		mailbox.quiesce();
+	}
+
+	@Nonnull
+	@Override
+	public List<Runnable> shutdownNow() {
+		return mailbox.close();
+	}
+
+	@Override
+	public boolean isShutdown() {
+		return mailbox.getState() != Mailbox.State.OPEN;
+	}
+
+	@Override
+	public boolean isTerminated() {
+		return mailbox.getState() == Mailbox.State.CLOSED;
+	}
+
+	@Override
+	public boolean awaitTermination(long timeout, @Nonnull TimeUnit unit) {
+		return isTerminated();
+	}
+
+	@Nonnull
+	public Mailbox getMailbox() {
+		return mailbox;
+	}
+
+	private void assertIsMailboxThread() {
+		assert (taskMainThread == null || taskMainThread == Thread.currentThread());
+	}
+
+	private void assertIsNotMailboxThread() {
+		assert (taskMainThread == null || taskMainThread != Thread.currentThread());
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxImplTest.java
@@ -18,16 +18,22 @@
 
 package org.apache.flink.streaming.runtime.tasks.mailbox;
 
+import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.util.function.BiConsumerWithException;
 import org.apache.flink.util.function.FunctionWithException;
+import org.apache.flink.util.function.RunnableWithException;
 import org.apache.flink.util.function.ThrowingRunnable;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Queue;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Consumer;
 
 /**
  * Unit tests for {@link MailboxImpl}.
@@ -35,7 +41,7 @@ import java.util.Queue;
 public class MailboxImplTest {
 
 	private static final Runnable POISON_LETTER = () -> {};
-	private static final int CAPACITY_POW_2 = 1;
+	private static final int CAPACITY_POW_2 = 2;
 	private static final int CAPACITY = 1 << CAPACITY_POW_2;
 
 	/**
@@ -44,24 +50,77 @@ public class MailboxImplTest {
 	private Mailbox mailbox;
 
 	@Before
-	public void setUp() throws Exception {
+	public void setUp() {
 		mailbox = new MailboxImpl(CAPACITY_POW_2);
+		mailbox.open();
+	}
+
+	@After
+	public void tearDown() {
+		mailbox.close();
 	}
 
 	/**
 	 * Test for #clearAndPut should remove other pending events and enqueue directly to the head of the mailbox queue.
 	 */
 	@Test
-	public void testClearAndPut() {
+	public void testClearAndPut() throws Exception {
+
+		Runnable letterInstance = () -> {};
+
 		for (int i = 0; i < CAPACITY; ++i) {
-			Assert.assertTrue(mailbox.tryPutMail(() -> {}));
+			Assert.assertTrue(mailbox.tryPutMail(letterInstance));
 		}
 
-		mailbox.clearAndPut(POISON_LETTER);
+		List<Runnable> droppedLetters = mailbox.clearAndPut(POISON_LETTER);
 
 		Assert.assertTrue(mailbox.hasMail());
 		Assert.assertEquals(POISON_LETTER, mailbox.tryTakeMail().get());
 		Assert.assertFalse(mailbox.hasMail());
+		Assert.assertEquals(CAPACITY, droppedLetters.size());
+	}
+
+	@Test
+	public void testPutAsHead() throws Exception {
+
+		Runnable instanceA = () -> {};
+		Runnable instanceB = () -> {};
+		Runnable instanceC = () -> {};
+		Runnable instanceD = () -> {};
+		Runnable instanceE = () -> {};
+
+		mailbox.putMail(instanceD);
+		mailbox.tryPutFirst(instanceC);
+		mailbox.putMail(instanceE);
+		mailbox.putFirst(instanceA);
+
+		OneShotLatch latch = new OneShotLatch();
+		Thread blockingPut = new Thread(() -> {
+			// ensure we are full
+			try {
+				if (!mailbox.tryPutFirst(() -> { })) {
+					latch.trigger();
+
+					mailbox.putFirst(instanceB);
+
+				}
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			} catch (MailboxStateException ignore) {
+			}
+		});
+
+		blockingPut.start();
+		latch.await();
+
+		Assert.assertSame(instanceA, mailbox.takeMail());
+		blockingPut.join();
+		Assert.assertSame(instanceB, mailbox.takeMail());
+		Assert.assertSame(instanceC, mailbox.takeMail());
+		Assert.assertSame(instanceD, mailbox.takeMail());
+		Assert.assertSame(instanceE, mailbox.takeMail());
+
+		Assert.assertFalse(mailbox.tryTakeMail().isPresent());
 	}
 
 	@Test
@@ -126,6 +185,140 @@ public class MailboxImplTest {
 	}
 
 	/**
+	 * Test that closing the mailbox unblocks pending accesses with correct exceptions.
+	 */
+	@Test
+	public void testCloseUnblocks() throws InterruptedException {
+		testAllPuttingUnblocksInternal(Mailbox::close);
+		setUp();
+		testUnblocksInternal(() -> mailbox.takeMail(), Mailbox::close, MailboxStateException.class);
+		setUp();
+		testUnblocksInternal(() -> {
+			mailbox.waitUntilHasMail();
+			throw new UnblockedException();
+		}, Mailbox::close, UnblockedException.class);
+	}
+
+	/**
+	 * Test that silencing the mailbox unblocks pending accesses with correct exceptions.
+	 */
+	@Test
+	public void testQuiesceUnblocks() throws Exception {
+		testAllPuttingUnblocksInternal(Mailbox::quiesce);
+	}
+
+	@Test
+	public void testLifeCycleQuiesce() throws Exception {
+		mailbox.putMail(() -> {});
+		mailbox.putMail(() -> {});
+		mailbox.quiesce();
+		testLifecyclePuttingInternal();
+		mailbox.takeMail();
+		Assert.assertTrue(mailbox.tryTakeMail().isPresent());
+		Assert.assertFalse(mailbox.tryTakeMail().isPresent());
+	}
+
+	@Test
+	public void testLifeCycleClose() throws Exception {
+		mailbox.close();
+		testLifecyclePuttingInternal();
+
+		try {
+			mailbox.takeMail();
+			Assert.fail();
+		} catch (MailboxStateException ignore) {
+		}
+
+		try {
+			mailbox.tryTakeMail();
+			Assert.fail();
+		} catch (MailboxStateException ignore) {
+		}
+	}
+
+	private void testLifecyclePuttingInternal() throws Exception {
+		try {
+			mailbox.tryPutMail(() -> {});
+			Assert.fail();
+		} catch (MailboxStateException ignore) {
+		}
+		try {
+			mailbox.tryPutFirst(() -> {});
+			Assert.fail();
+		} catch (MailboxStateException ignore) {
+		}
+		try {
+			mailbox.putMail(() -> {});
+			Assert.fail();
+		} catch (MailboxStateException ignore) {
+		}
+		try {
+			mailbox.putFirst(() -> {});
+			Assert.fail();
+		} catch (MailboxStateException ignore) {
+		}
+	}
+
+	private void testAllPuttingUnblocksInternal(Consumer<Mailbox> unblockMethod) throws InterruptedException {
+		testUnblocksInternal(() -> mailbox.putMail(() -> {}), unblockMethod, MailboxStateException.class);
+		setUp();
+		testUnblocksInternal(() -> mailbox.putFirst(() -> {}), unblockMethod, MailboxStateException.class);
+		setUp();
+		testUnblocksInternal(() -> mailbox.clearAndPut(() -> {}), unblockMethod, MailboxStateException.class);
+		setUp();
+		testUnblocksInternal(() -> {
+			boolean putOk;
+			try {
+				putOk = mailbox.tryPutMail(() -> {});
+			} catch (MailboxStateException ignore) {
+				putOk = false;
+			}
+			if (!putOk) {
+				mailbox.waitUntilHasCapacity();
+				throw new UnblockedException();
+			}
+		}, unblockMethod, UnblockedException.class);
+	}
+
+	private void testUnblocksInternal(
+		RunnableWithException testMethod,
+		Consumer<Mailbox> unblockMethod,
+		Class<?> expectedExceptionClass) throws InterruptedException {
+		final Thread[] blockedThreads = new Thread[CAPACITY * 2];
+		final Exception[] exceptions = new Exception[blockedThreads.length];
+
+		CountDownLatch countDownLatch = new CountDownLatch(blockedThreads.length);
+
+		for (int i = 0; i < blockedThreads.length; ++i) {
+			final int id = i;
+			Thread blocked = new Thread(() -> {
+				try {
+					countDownLatch.countDown();
+					while (true) {
+						testMethod.run();
+					}
+				} catch (Exception ex) {
+					exceptions[id] = ex;
+				}
+			});
+			blockedThreads[i] = blocked;
+			blocked.start();
+		}
+
+		countDownLatch.await();
+		unblockMethod.accept(mailbox);
+
+		for (Thread blockedThread : blockedThreads) {
+			blockedThread.join();
+		}
+
+		for (Exception exception : exceptions) {
+			Assert.assertEquals(expectedExceptionClass, exception.getClass());
+		}
+
+	}
+
+	/**
 	 * Test producer-consumer pattern through the mailbox in a concurrent setting (n-writer / 1-reader).
 	 */
 	private void testPutTake(
@@ -167,4 +360,6 @@ public class MailboxImplTest {
 			Assert.assertEquals(numLettersPerThread, perThreadResult);
 		}
 	}
+
+	private static final class UnblockedException extends Exception {}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxExecutorServiceImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxExecutorServiceImplTest.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks.mailbox;
+
+import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.util.Preconditions;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Tests for {@link TaskMailboxExecutorServiceImpl}.
+ */
+public class TaskMailboxExecutorServiceImplTest {
+
+	private TaskMailboxExecutorServiceImpl mailboxExecutorService;
+	private MailboxImpl mailbox;
+
+	@Before
+	public void setUp() throws Exception {
+		this.mailbox = new MailboxImpl();
+		this.mailbox.open();
+		this.mailboxExecutorService = new TaskMailboxExecutorServiceImpl(mailbox);
+	}
+
+	@Test
+	public void testOpsAndLifecycle() throws Exception {
+		Assert.assertFalse(mailboxExecutorService.isShutdown());
+		Assert.assertFalse(mailboxExecutorService.isTerminated());
+		final TestRunnable testRunnable = new TestRunnable();
+		Assert.assertTrue(mailboxExecutorService.tryExecute(testRunnable));
+		Assert.assertEquals(testRunnable, mailbox.tryTakeMail().get());
+		mailboxExecutorService.execute(testRunnable);
+		Assert.assertEquals(testRunnable, mailbox.takeMail());
+		final TestRunnable yieldRun = new TestRunnable();
+		final TestRunnable leftoverRun = new TestRunnable();
+		Assert.assertTrue(mailboxExecutorService.tryExecute(yieldRun));
+		Future<?> leftoverFuture = mailboxExecutorService.submit(leftoverRun);
+		mailboxExecutorService.shutdown();
+		Assert.assertTrue(mailboxExecutorService.isShutdown());
+		Assert.assertFalse(mailboxExecutorService.isTerminated());
+
+		try {
+			mailboxExecutorService.execute(testRunnable);
+			Assert.fail("execution should not work after shutdown().");
+		} catch (RejectedExecutionException expected) {
+		}
+
+		try {
+			mailboxExecutorService.tryExecute(testRunnable);
+			Assert.fail("execution should not work after shutdown().");
+		} catch (RejectedExecutionException expected) {
+		}
+
+		Assert.assertTrue(mailboxExecutorService.tryYield());
+		Assert.assertEquals(Thread.currentThread(), yieldRun.wasExecutedBy());
+
+		Assert.assertFalse(mailboxExecutorService.awaitTermination(1L, TimeUnit.SECONDS));
+		Assert.assertFalse(leftoverFuture.isDone());
+
+		List<Runnable> leftoverTasks = mailboxExecutorService.shutdownNow();
+		Assert.assertEquals(1, leftoverTasks.size());
+		Assert.assertFalse(leftoverFuture.isCancelled());
+		FutureUtils.cancelRunnableFutures(leftoverTasks);
+		Assert.assertTrue(leftoverFuture.isCancelled());
+
+		try {
+			mailboxExecutorService.tryYield();
+			Assert.fail("yielding should not work after shutdown().");
+		} catch (IllegalStateException expected) {
+		}
+
+		try {
+			mailboxExecutorService.yield();
+			Assert.fail("yielding should not work after shutdown().");
+		} catch (IllegalStateException expected) {
+		}
+	}
+
+	@Test
+	public void testWaitUntilCanExecute() throws Exception {
+		while (mailboxExecutorService.tryExecute(() -> {})) {}
+
+		// basic blocking
+		final AtomicReference<Exception> exceptionReference = new AtomicReference<>();
+		final OneShotLatch runLatch = new OneShotLatch();
+		final Runnable waiterRunnable = () -> {
+			runLatch.trigger();
+			try {
+				mailboxExecutorService.waitUntilCanExecute();
+			} catch (InterruptedException e) {
+				exceptionReference.set(e);
+			}
+		};
+		Thread waiterThread = new Thread(waiterRunnable);
+		waiterThread.start();
+		runLatch.await();
+		Thread.sleep(1L);
+		Assert.assertTrue(waiterThread.isAlive());
+
+		mailboxExecutorService.yield();
+		waiterThread.join();
+		Assert.assertNull(exceptionReference.get());
+
+		// interruption
+		runLatch.reset();
+		waiterThread = new Thread(waiterRunnable);
+		waiterThread.start();
+		waiterThread.interrupt();
+		waiterThread.join();
+		Assert.assertEquals(InterruptedException.class, exceptionReference.get().getClass());
+	}
+
+	@Test
+	public void testTryYield() throws Exception {
+		final TestRunnable testRunnable = new TestRunnable();
+		mailboxExecutorService.execute(testRunnable);
+		Assert.assertTrue(mailboxExecutorService.tryYield());
+		Assert.assertFalse(mailbox.tryTakeMail().isPresent());
+		Assert.assertEquals(Thread.currentThread(), testRunnable.wasExecutedBy());
+	}
+
+	@Test
+	public void testYield() throws Exception {
+		AtomicReference<Exception> exceptionReference = new AtomicReference<>();
+		OneShotLatch isRunningLatch = new OneShotLatch();
+
+		Thread mbRunner = new Thread(() -> {
+			isRunningLatch.trigger();
+			try {
+				mailboxExecutorService.yield();
+			} catch (Exception e) {
+				exceptionReference.set(e);
+			}
+		});
+
+		mbRunner.start();
+		isRunningLatch.await();
+		Thread.sleep(1L);
+		Assert.assertTrue(mbRunner.isAlive());
+
+		final TestRunnable testRunnable = new TestRunnable();
+		mailboxExecutorService.execute(testRunnable);
+
+		mbRunner.join();
+		Assert.assertEquals(mbRunner, testRunnable.wasExecutedBy());
+		Assert.assertNull(exceptionReference.get());
+	}
+
+	/**
+	 * Test {@link Runnable} that tracks execution.
+	 */
+	static class TestRunnable implements Runnable {
+
+		private Thread executedByThread = null;
+
+		@Override
+		public void run() {
+			Preconditions.checkState(!isExecuted(), "Runnable was already executed before by " + executedByThread);
+			executedByThread = Thread.currentThread();
+		}
+
+		boolean isExecuted() {
+			return executedByThread != null;
+		}
+
+		Thread wasExecutedBy() {
+			return executedByThread;
+		}
+	}
+}


### PR DESCRIPTION
Mirror of apache flink#8692
## What is the purpose of the change
This PR introduced an ``ExecutorService`` frontend to the mailbox that can be used by client code. For this purpose, the mailbox was also extended with open->quiesce -> close lifecycle methods.


## Brief change log

- Intoduce ``TaskMailboxExecutorService``, an ``ExecutorService`` with additional  non-blocking alternative to ``execute`` and a ``yield()`` functionality.

- Enhanced ``Mailbox`` with lifecycle methods.

- Improvements to the mailbox usage in ``StreamTask``

## Verifying this change

Introduced ``TaskMailboxExecutorServiceImplTest`` and extended ``MailboxImplTest``.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

