### PR TITLE
Mirror of apache flink#8681

### DIFF
--- a/flink-python/pyflink/batch/__init__.py
+++ b/flink-python/pyflink/batch/__init__.py
@@ -15,25 +15,6 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+from pyflink.batch.execution_environment import ExecutionEnvironment
 
-from pyflink.java_gateway import get_gateway
-
-
-def to_jarray(j_type, arr):
-    """
-    Convert python list to java type array
-
-    :param j_type: java type of element in array
-    :param arr: python type list
-    """
-    gateway = get_gateway()
-    j_arr = gateway.new_array(j_type, len(arr))
-    for i in range(0, len(arr)):
-        j_arr[i] = arr[i]
-    return j_arr
-
-
-def load_java_class(class_name):
-    gateway = get_gateway()
-    context_classloader = gateway.jvm.Thread.currentThread().getContextClassLoader()
-    return context_classloader.loadClass(class_name)
+__all__ = ['ExecutionEnvironment']

--- a/flink-python/pyflink/batch/execution_environment.py
+++ b/flink-python/pyflink/batch/execution_environment.py
@@ -1,0 +1,164 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from pyflink.java_gateway import get_gateway
+from pyflink.util.utils import load_java_class
+
+
+class ExecutionEnvironment(object):
+    """
+    The ExecutionEnvironment is the context in which a program is executed.
+
+    The environment provides methods to control the job execution (such as setting the parallelism)
+    and to interact with the outside world (data access).
+    """
+
+    def __init__(self, j_execution_environment):
+        self._j_execution_environment = j_execution_environment
+
+    def get_parallelism(self):
+        """
+        Gets the parallelism with which operation are executed by default.
+
+        :return: The parallelism.
+        """
+        return self._j_execution_environment.getParallelism()
+
+    def set_parallelism(self, parallelism):
+        """
+        Sets the parallelism for operations executed through this environment.
+        Setting a parallelism of x here will cause all operators to run with
+        x parallel instances.
+
+        :param parallelism: The parallelism.
+        """
+        self._j_execution_environment.setParallelism(parallelism)
+
+    def set_session_timeout(self, timeout):
+        """
+        Sets the session timeout to hold the intermediate results of a job. This only
+        applies the updated timeout in future executions.
+
+        :param timeout: The timeout value, in seconds.
+        """
+        self._j_execution_environment.setSessionTimeout(timeout)
+
+    def get_session_timeout(self):
+        """
+        Gets the session timeout for this environment. The session timeout defines for how long
+        after an execution, the job and its intermediate results will be kept for future
+        interactions.
+
+        :return: The session timeout value, in seconds.
+        """
+        return self._j_execution_environment.getSessionTimeout()
+
+    def get_default_local_parallelism(self):
+        """
+        Gets the default parallelism that will be used for the local execution environment.
+
+        :return: The parallelism.
+        """
+        return self._j_execution_environment.getDefaultLocalParallelism()
+
+    def set_default_local_parallelism(self, parallelism):
+        """
+        Sets the default parallelism that will be used for the local execution environment.
+
+        :param parallelism: The parallelism.
+        """
+        self._j_execution_environment.setDefaultLocalParallelism(parallelism)
+
+    def add_default_kryo_serializer(self, type_class_name, serializer_class_name):
+        """
+        Adds a new Kryo default serializer to the Runtime.
+
+        :param type_class_name: The full-qualified java class name of the types serialized with the
+                                given serializer.
+        :param serializer_class_name: The full-qualified java class name of the serializer to use.
+        """
+        type_clz = load_java_class(type_class_name)
+        j_serializer_clz = load_java_class(serializer_class_name)
+        self._j_execution_environment.addDefaultKryoSerializer(type_clz, j_serializer_clz)
+
+    def register_type_with_kryo_serializer(self, type_class_name, serializer_class_name):
+        """
+        Registers the given Serializer via its class as a serializer for the given type at the
+        KryoSerializer.
+
+        :param type_class_name: The full-qualified java class name of the types serialized with
+                                the given serializer.
+        :param serializer_class_name: The full-qualified java class name of the serializer to use.
+        """
+        type_clz = load_java_class(type_class_name)
+        j_serializer_clz = load_java_class(serializer_class_name)
+        self._j_execution_environment.registerTypeWithKryoSerializer(type_clz, j_serializer_clz)
+
+    def register_type(self, type_class_name):
+        """
+        Registers the given type with the serialization stack. If the type is eventually
+        serialized as a POJO, then the type is registered with the POJO serializer. If the
+        type ends up being serialized with Kryo, then it will be registered at Kryo to make
+        sure that only tags are written.
+
+        :param type_class_name: The full-qualified java class name of the type to register.
+        """
+        type_clz = load_java_class(type_class_name)
+        self._j_execution_environment.registerType(type_clz)
+
+    def execute(self, job_name=None):
+        """
+        Triggers the program execution. The environment will execute all parts of the program that
+        have resulted in a "sink" operation.
+
+        The program execution will be logged and displayed with the given job name.
+
+        :param job_name: Desired name of the job, optional.
+        """
+        if job_name is None:
+            self._j_execution_environment.execute()
+        else:
+            self._j_execution_environment.execute(job_name)
+
+    def get_execution_plan(self):
+        """
+        Creates the plan with which the system will execute the program, and returns it as
+        a String using a JSON representation of the execution data flow graph.
+        Note that this needs to be called, before the plan is executed.
+
+        If the compiler could not be instantiated, or the master could not
+        be contacted to retrieve information relevant to the execution planning,
+        an exception will be thrown.
+
+        :return: The execution plan of the program, as a JSON String.
+        """
+        return self._j_execution_environment.getExecutionPlan()
+
+    @classmethod
+    def get_execution_environment(cls):
+        """
+        Creates an execution environment that represents the context in which the program is
+        currently executed. If the program is invoked standalone, this method returns a local
+        execution environment. If the program is invoked from within the command line client to be
+        submitted to a cluster, this method returns the execution environment of this cluster.
+
+        :return: The execution environment of the context in which the program is executed.
+        """
+        gateway = get_gateway()
+        j_execution_environment = gateway.jvm.org.apache.flink.api.java.ExecutionEnvironment\
+            .getExecutionEnvironment()
+        return ExecutionEnvironment(j_execution_environment)

--- a/flink-python/pyflink/batch/execution_environment.py
+++ b/flink-python/pyflink/batch/execution_environment.py
@@ -15,6 +15,8 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+from pyflink.common.execution_config import ExecutionConfig
+from pyflink.common.restart_strategy import RestartStrategies
 from pyflink.java_gateway import get_gateway
 from pyflink.util.utils import load_java_class
 
@@ -82,6 +84,33 @@ class ExecutionEnvironment(object):
         :param parallelism: The parallelism.
         """
         self._j_execution_environment.setDefaultLocalParallelism(parallelism)
+
+    def get_config(self):
+        """
+        Gets the config object that defines execution parameters.
+
+        :return: The environment's execution configuration.
+        """
+        return ExecutionConfig(self._j_execution_environment.getConfig())
+
+    def set_restart_strategy(self, restart_strategy_configuration):
+        """
+        Sets the restart strategy configuration. The configuration specifies which restart strategy
+        will be used for the execution graph in case of a restart.
+
+        :param restart_strategy_configuration: Restart strategy configuration to be set.
+        """
+        self._j_execution_environment.setRestartStrategy(
+            restart_strategy_configuration._j_restart_strategy_configuration)
+
+    def get_restart_strategy(self):
+        """
+        Returns the specified restart strategy configuration.
+
+        :return: The restart strategy configuration to be used.
+        """
+        return RestartStrategies._from_j_restart_strategy(
+            self._j_execution_environment.getRestartStrategy())
 
     def add_default_kryo_serializer(self, type_class_name, serializer_class_name):
         """

--- a/flink-python/pyflink/batch/tests/__init__.py
+++ b/flink-python/pyflink/batch/tests/__init__.py
@@ -15,25 +15,3 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-
-from pyflink.java_gateway import get_gateway
-
-
-def to_jarray(j_type, arr):
-    """
-    Convert python list to java type array
-
-    :param j_type: java type of element in array
-    :param arr: python type list
-    """
-    gateway = get_gateway()
-    j_arr = gateway.new_array(j_type, len(arr))
-    for i in range(0, len(arr)):
-        j_arr[i] = arr[i]
-    return j_arr
-
-
-def load_java_class(class_name):
-    gateway = get_gateway()
-    context_classloader = gateway.jvm.Thread.currentThread().getContextClassLoader()
-    return context_classloader.loadClass(class_name)

--- a/flink-python/pyflink/batch/tests/test_execution_environment.py
+++ b/flink-python/pyflink/batch/tests/test_execution_environment.py
@@ -1,0 +1,96 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import json
+import os
+import tempfile
+
+from py4j.protocol import Py4JJavaError
+
+from pyflink.batch import ExecutionEnvironment
+from pyflink.table import DataTypes, BatchTableEnvironment, CsvTableSource, CsvTableSink
+from pyflink.testing.test_case_utils import PyFlinkTestCase
+
+
+class ExecutionEnvironmentTests(PyFlinkTestCase):
+
+    def setUp(self):
+        self.env = ExecutionEnvironment.get_execution_environment()
+
+    def test_get_set_parallelism(self):
+
+        self.env.set_parallelism(10)
+
+        parallelism = self.env.get_parallelism()
+
+        assert parallelism == 10
+
+    def test_get_session_timeout(self):
+
+        timeout = self.env.get_session_timeout()
+
+        assert timeout == 0
+
+    def test_set_session_timeout(self):
+
+        self.assertRaisesRegexp(Py4JJavaError,
+                                "Support for sessions is currently disabled\\. "
+                                "It will be enabled in future Flink versions\\.",
+                                self.env.set_session_timeout, 1000)
+
+    def test_get_set_default_local_parallelism(self):
+
+        self.env.set_default_local_parallelism(8)
+
+        parallelism = self.env.get_default_local_parallelism()
+
+        assert parallelism == 8
+
+    def test_add_default_kryo_serializer(self):
+
+        self.env.add_default_kryo_serializer(
+            "org.apache.flink.runtime.state.StateBackendTestBase$TestPojo",
+            "org.apache.flink.runtime.state.StateBackendTestBase$CustomKryoTestSerializer")
+
+    def test_register_type_with_kryo_serializer(self):
+
+        self.env.register_type_with_kryo_serializer(
+            "org.apache.flink.runtime.state.StateBackendTestBase$TestPojo",
+            "org.apache.flink.runtime.state.StateBackendTestBase$CustomKryoTestSerializer")
+
+    def test_register_type(self):
+
+        self.env.register_type("org.apache.flink.runtime.state.StateBackendTestBase$TestPojo")
+
+    def test_get_execution_plan(self):
+        tmp_dir = tempfile.gettempdir()
+        source_path = os.path.join(tmp_dir + '/streaming.csv')
+        tmp_csv = os.path.join(tmp_dir + '/streaming2.csv')
+        field_names = ["a", "b", "c"]
+        field_types = [DataTypes.INT(), DataTypes.STRING(), DataTypes.STRING()]
+
+        t_env = BatchTableEnvironment.create(self.env)
+        csv_source = CsvTableSource(source_path, field_names, field_types)
+        t_env.register_table_source("Orders", csv_source)
+        t_env.register_table_sink(
+            "Results",
+            field_names, field_types, CsvTableSink(tmp_csv))
+        t_env.scan("Orders").insert_into("Results")
+
+        plan = t_env.exec_env().get_execution_plan()
+
+        json.loads(plan)

--- a/flink-python/pyflink/batch/tests/test_execution_environment.py
+++ b/flink-python/pyflink/batch/tests/test_execution_environment.py
@@ -22,6 +22,7 @@ import tempfile
 from py4j.protocol import Py4JJavaError
 
 from pyflink.batch import ExecutionEnvironment
+from pyflink.common import ExecutionConfig, RestartStrategies
 from pyflink.table import DataTypes, BatchTableEnvironment, CsvTableSource, CsvTableSink
 from pyflink.testing.test_case_utils import PyFlinkTestCase
 
@@ -60,11 +61,31 @@ class ExecutionEnvironmentTests(PyFlinkTestCase):
 
         assert parallelism == 8
 
+    def test_get_config(self):
+
+        execution_config = self.env.get_config()
+
+        assert isinstance(execution_config, ExecutionConfig)
+
+    def test_set_get_restart_strategy(self):
+
+        self.env.set_restart_strategy(RestartStrategies.no_restart())
+
+        restart_strategy = self.env.get_restart_strategy()
+
+        assert restart_strategy == RestartStrategies.no_restart()
+
     def test_add_default_kryo_serializer(self):
 
         self.env.add_default_kryo_serializer(
             "org.apache.flink.runtime.state.StateBackendTestBase$TestPojo",
             "org.apache.flink.runtime.state.StateBackendTestBase$CustomKryoTestSerializer")
+
+        dict = self.env.get_config().get_default_kryo_serializer_classes()
+
+        assert dict == {'org.apache.flink.runtime.state.StateBackendTestBase$TestPojo':
+                        'org.apache.flink.runtime.state'
+                        '.StateBackendTestBase$CustomKryoTestSerializer'}
 
     def test_register_type_with_kryo_serializer(self):
 
@@ -72,9 +93,19 @@ class ExecutionEnvironmentTests(PyFlinkTestCase):
             "org.apache.flink.runtime.state.StateBackendTestBase$TestPojo",
             "org.apache.flink.runtime.state.StateBackendTestBase$CustomKryoTestSerializer")
 
+        dict = self.env.get_config().get_registered_types_with_kryo_serializer_classes()
+
+        assert dict == {'org.apache.flink.runtime.state.StateBackendTestBase$TestPojo':
+                        'org.apache.flink.runtime.state'
+                        '.StateBackendTestBase$CustomKryoTestSerializer'}
+
     def test_register_type(self):
 
         self.env.register_type("org.apache.flink.runtime.state.StateBackendTestBase$TestPojo")
+
+        type_list = self.env.get_config().get_registered_pojo_types()
+
+        assert type_list == ["org.apache.flink.runtime.state.StateBackendTestBase$TestPojo"]
 
     def test_get_execution_plan(self):
         tmp_dir = tempfile.gettempdir()

--- a/flink-python/pyflink/common/__init__.py
+++ b/flink-python/pyflink/common/__init__.py
@@ -15,12 +15,17 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+from pyflink.common.checkpoint_config import CheckpointConfig, ExternalizedCheckpointCleanup
+from pyflink.common.checkpointing_mode import CheckpointingMode
 from pyflink.common.execution_config import ExecutionConfig
 from pyflink.common.execution_mode import ExecutionMode
 from pyflink.common.input_dependency_constraint import InputDependencyConstraint
 from pyflink.common.restart_strategy import RestartStrategies
 
 __all__ = [
+    'CheckpointConfig',
+    'ExternalizedCheckpointCleanup',
+    'CheckpointingMode',
     'ExecutionConfig',
     'ExecutionMode',
     'InputDependencyConstraint',

--- a/flink-python/pyflink/common/__init__.py
+++ b/flink-python/pyflink/common/__init__.py
@@ -1,0 +1,28 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from pyflink.common.execution_config import ExecutionConfig
+from pyflink.common.execution_mode import ExecutionMode
+from pyflink.common.input_dependency_constraint import InputDependencyConstraint
+from pyflink.common.restart_strategy import RestartStrategies
+
+__all__ = [
+    'ExecutionConfig',
+    'ExecutionMode',
+    'InputDependencyConstraint',
+    'RestartStrategies'
+]

--- a/flink-python/pyflink/common/__init__.py
+++ b/flink-python/pyflink/common/__init__.py
@@ -21,6 +21,7 @@ from pyflink.common.execution_config import ExecutionConfig
 from pyflink.common.execution_mode import ExecutionMode
 from pyflink.common.input_dependency_constraint import InputDependencyConstraint
 from pyflink.common.restart_strategy import RestartStrategies
+from pyflink.common.time_characteristic import TimeCharacteristic
 
 __all__ = [
     'CheckpointConfig',
@@ -29,5 +30,6 @@ __all__ = [
     'ExecutionConfig',
     'ExecutionMode',
     'InputDependencyConstraint',
-    'RestartStrategies'
+    'RestartStrategies',
+    'TimeCharacteristic'
 ]

--- a/flink-python/pyflink/common/__init__.py
+++ b/flink-python/pyflink/common/__init__.py
@@ -21,6 +21,9 @@ from pyflink.common.execution_config import ExecutionConfig
 from pyflink.common.execution_mode import ExecutionMode
 from pyflink.common.input_dependency_constraint import InputDependencyConstraint
 from pyflink.common.restart_strategy import RestartStrategies
+from pyflink.common.state_backend import (StateBackend, MemoryStateBackend, FsStateBackend,
+                                          RocksDBStateBackend, CustomStateBackend,
+                                          PredefinedOptions)
 from pyflink.common.time_characteristic import TimeCharacteristic
 
 __all__ = [
@@ -31,5 +34,11 @@ __all__ = [
     'ExecutionMode',
     'InputDependencyConstraint',
     'RestartStrategies',
+    'StateBackend',
+    'MemoryStateBackend',
+    'FsStateBackend',
+    'RocksDBStateBackend',
+    'CustomStateBackend',
+    'PredefinedOptions',
     'TimeCharacteristic'
 ]

--- a/flink-python/pyflink/common/checkpoint_config.py
+++ b/flink-python/pyflink/common/checkpoint_config.py
@@ -1,0 +1,307 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from pyflink.common.checkpointing_mode import CheckpointingMode
+from pyflink.java_gateway import get_gateway
+
+__all__ = ['CheckpointConfig', 'ExternalizedCheckpointCleanup']
+
+
+class CheckpointConfig(object):
+    """
+    Configuration that captures all checkpointing related settings.
+
+    :data:`DEFAULT_MODE`:
+
+    The default checkpoint mode: exactly once.
+
+    :data:`DEFAULT_TIMEOUT`:
+
+    The default timeout of a checkpoint attempt: 10 minutes.
+
+    :data:`DEFAULT_MIN_PAUSE_BETWEEN_CHECKPOINTS`:
+
+    The default minimum pause to be made between checkpoints: none.
+
+    :data:`DEFAULT_MAX_CONCURRENT_CHECKPOINTS`:
+
+    The default limit of concurrently happening checkpoints: one.
+    """
+
+    DEFAULT_MODE = CheckpointingMode.EXACTLY_ONCE
+
+    DEFAULT_TIMEOUT = 10 * 60 * 1000
+
+    DEFAULT_MIN_PAUSE_BETWEEN_CHECKPOINTS = 0
+
+    DEFAULT_MAX_CONCURRENT_CHECKPOINTS = 1
+
+    def __init__(self, j_checkpoint_config):
+        self._j_checkpoint_config = j_checkpoint_config
+
+    def is_checkpointing_enabled(self):
+        """
+        Checks whether checkpointing is enabled.
+
+        :return: True if checkpointing is enables, false otherwise.
+        """
+        return self._j_checkpoint_config.isCheckpointingEnabled()
+
+    def get_checkpointing_mode(self):
+        """
+        Gets the checkpointing mode (exactly-once vs. at-least-once).
+
+        :return: The :class:`CheckpointingMode`.
+        """
+        return CheckpointingMode._from_j_checkpointing_mode(
+            self._j_checkpoint_config.getCheckpointingMode())
+
+    def set_checkpointing_mode(self, checkpointing_mode):
+        """
+        Sets the checkpointing mode (exactly-once vs. at-least-once).
+
+        :param checkpointing_mode: The :class:`CheckpointingMode`.
+        """
+        self._j_checkpoint_config.setCheckpointingMode(
+            CheckpointingMode._to_j_checkpointing_mode(checkpointing_mode))
+
+    def get_checkpoint_interval(self):
+        """
+        Gets the interval in which checkpoints are periodically scheduled.
+
+        This setting defines the base interval. Checkpoint triggering may be delayed by the settings
+        :func:`get_max_concurrent_checkpoints` and :func:`get_min_pause_between_checkpoints`.
+
+        :return: The checkpoint interval, in milliseconds.
+        """
+        return self._j_checkpoint_config.getCheckpointInterval()
+
+    def set_checkpoint_interval(self, checkpoint_interval):
+        """
+        Sets the interval in which checkpoints are periodically scheduled.
+
+        This setting defines the base interval. Checkpoint triggering may be delayed by the settings
+        :func:`set_max_concurrent_checkpoints` and :func:`set_min_pause_between_checkpoints`.
+
+        :param checkpoint_interval: The checkpoint interval, in milliseconds.
+        """
+        self._j_checkpoint_config.setCheckpointInterval(checkpoint_interval)
+
+    def get_checkpoint_timeout(self):
+        """
+        Gets the maximum time that a checkpoint may take before being discarded.
+
+        :return: The checkpoint timeout, in milliseconds.
+        """
+        return self._j_checkpoint_config.getCheckpointTimeout()
+
+    def set_checkpoint_timeout(self, checkpoint_timeout):
+        """
+        Sets the maximum time that a checkpoint may take before being discarded.
+
+        :param checkpoint_timeout: The checkpoint timeout, in milliseconds.
+        """
+        self._j_checkpoint_config.setCheckpointTimeout(checkpoint_timeout)
+
+    def get_min_pause_between_checkpoints(self):
+        """
+        Gets the minimal pause between checkpointing attempts. This setting defines how soon the
+        checkpoint coordinator may trigger another checkpoint after it becomes possible to trigger
+        another checkpoint with respect to the maximum number of concurrent checkpoints
+        (see :func:`get_max_concurrent_checkpoints`).
+
+        :return: The minimal pause before the next checkpoint is triggered.
+        """
+        return self._j_checkpoint_config.getMinPauseBetweenCheckpoints()
+
+    def set_min_pause_between_checkpoints(self, min_pause_between_checkpoints):
+        """
+        Sets the minimal pause between checkpointing attempts. This setting defines how soon the
+        checkpoint coordinator may trigger another checkpoint after it becomes possible to trigger
+        another checkpoint with respect to the maximum number of concurrent checkpoints
+        (see :func:`set_max_concurrent_checkpoints`).
+
+        If the maximum number of concurrent checkpoints is set to one, this setting makes
+        effectively sure that a minimum amount of time passes where no checkpoint is in progress
+        at all.
+
+        :param min_pause_between_checkpoints: The minimal pause before the next checkpoint is
+                                              triggered.
+        """
+        self._j_checkpoint_config.setMinPauseBetweenCheckpoints(min_pause_between_checkpoints)
+
+    def get_max_concurrent_checkpoints(self):
+        """
+        Gets the maximum number of checkpoint attempts that may be in progress at the same time.
+        If this value is *n*, then no checkpoints will be triggered while *n* checkpoint attempts
+        are currently in flight. For the next checkpoint to be triggered, one checkpoint attempt
+        would need to finish or expire.
+
+        :return: The maximum number of concurrent checkpoint attempts.
+        """
+        return self._j_checkpoint_config.getMaxConcurrentCheckpoints()
+
+    def set_max_concurrent_checkpoints(self, max_concurrent_checkpoints):
+        """
+        Sets the maximum number of checkpoint attempts that may be in progress at the same time.
+        If this value is *n*, then no checkpoints will be triggered while *n* checkpoint attempts
+        are currently in flight. For the next checkpoint to be triggered, one checkpoint attempt
+        would need to finish or expire.
+
+        :param max_concurrent_checkpoints: The maximum number of concurrent checkpoint attempts.
+        """
+        self._j_checkpoint_config.setMaxConcurrentCheckpoints(max_concurrent_checkpoints)
+
+    def is_fail_on_checkpointing_errors(self):
+        """
+        This determines the behaviour of tasks if there is an error in their local checkpointing.
+        If this returns true, tasks will fail as a reaction. If this returns false, task will only
+        decline the failed checkpoint.
+
+        :return: True if failing on checkpointing errors, false otherwise.
+        """
+        return self._j_checkpoint_config.isFailOnCheckpointingErrors()
+
+    def set_fail_on_checkpointing_errors(self, fail_on_checkpointing_errors):
+        """
+        Sets the expected behaviour for tasks in case that they encounter an error in their
+        checkpointing procedure. If this is set to true, the task will fail on checkpointing error.
+        If this is set to false, the task will only decline a the checkpoint and continue running.
+        The default is true.
+
+        :param fail_on_checkpointing_errors: True if failing on checkpointing errors,
+                                             false otherwise.
+        """
+        self._j_checkpoint_config.setFailOnCheckpointingErrors(fail_on_checkpointing_errors)
+
+    def enable_externalized_checkpoints(self, cleanup_mode):
+        """
+        Enables checkpoints to be persisted externally.
+
+        Externalized checkpoints write their meta data out to persistent storage and are **not**
+        automatically cleaned up when the owning job fails or is suspended (terminating with job
+        status ``FAILED`` or ``SUSPENDED``). In this case, you have to manually clean up the
+        checkpoint state, both the meta data and actual program state.
+
+        The :class:`ExternalizedCheckpointCleanup` mode defines how an externalized checkpoint
+        should be cleaned up on job cancellation. If you choose to retain externalized checkpoints
+        on cancellation you have you handle checkpoint clean up manually when you cancel the job as
+        well (terminating with job status ``CANCELED``).
+
+        The target directory for externalized checkpoints is configured via
+        ``org.apache.flink.configuration.CheckpointingOptions#CHECKPOINTS_DIRECTORY``.
+
+        :param cleanup_mode: Externalized checkpoint cleanup behaviour, the mode could be
+                             :data:`ExternalizedCheckpointCleanup.DELETE_ON_CANCELLATION` or
+                             :data:`ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION`
+        """
+        gateway = get_gateway()
+        JExternalizedCheckpointCleanup = \
+            gateway.jvm.org.apache.flink.streaming.api.environment.CheckpointConfig\
+            .ExternalizedCheckpointCleanup
+        if cleanup_mode == ExternalizedCheckpointCleanup.DELETE_ON_CANCELLATION:
+            self._j_checkpoint_config.enableExternalizedCheckpoints(JExternalizedCheckpointCleanup
+                                                                    .DELETE_ON_CANCELLATION)
+        elif cleanup_mode == ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION:
+            self._j_checkpoint_config.enableExternalizedCheckpoints(JExternalizedCheckpointCleanup
+                                                                    .RETAIN_ON_CANCELLATION)
+        else:
+            raise TypeError("Unsupported cleanup mode: %s, supported cleanup modes are: "
+                            "ExternalizedCheckpointCleanup.DELETE_ON_CANCELLATION and"
+                            "ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION." % cleanup_mode)
+
+    def is_externalized_checkpoints_enabled(self):
+        """
+        Returns whether checkpoints should be persisted externally.
+
+        :return: ``True`` if checkpoints should be externalized.
+        """
+        return self._j_checkpoint_config.isExternalizedCheckpointsEnabled()
+
+    def is_prefer_checkpoint_for_recovery(self):
+        """
+        Returns whether a job recovery should fallback to checkpoint when there is a more recent
+        savepoint.
+
+        :return: ``True`` if a job recovery should fallback to checkpoint.
+        """
+        return self._j_checkpoint_config.isPreferCheckpointForRecovery()
+
+    def set_prefer_checkpoint_for_recovery(self, prefer_checkpoint_for_recovery):
+        """
+        Sets whether a job recovery should fallback to checkpoint when there is a more recent
+        savepoint.
+
+        :param prefer_checkpoint_for_recovery: ``True`` if a job recovery should fallback to
+                                                checkpoint, false otherwise.
+        """
+        self._j_checkpoint_config.setPreferCheckpointForRecovery(prefer_checkpoint_for_recovery)
+
+    def get_externalized_checkpoint_cleanup(self):
+        """
+        Returns the cleanup behaviour for externalized checkpoints.
+
+        :return: The cleanup behaviour for externalized checkpoints or ``None`` if none is
+                 configured.
+        """
+        cleanup_mode = self._j_checkpoint_config.getExternalizedCheckpointCleanup()
+        gateway = get_gateway()
+        JExternalizedCheckpointCleanup = \
+            gateway.jvm.org.apache.flink.streaming.api.environment.CheckpointConfig\
+            .ExternalizedCheckpointCleanup
+        if cleanup_mode == JExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION:
+            return ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION
+        elif cleanup_mode == JExternalizedCheckpointCleanup.DELETE_ON_CANCELLATION:
+            return ExternalizedCheckpointCleanup.DELETE_ON_CANCELLATION
+        elif cleanup_mode is None:
+            return None
+        else:
+            raise Exception("Unsupported java externalized checkpoint cleanup mode: %s"
+                            % cleanup_mode)
+
+
+class ExternalizedCheckpointCleanup(object):
+    """
+    Cleanup behaviour for externalized checkpoints when the job is cancelled.
+
+    :data:`DELETE_ON_CANCELLATION`:
+
+    Delete externalized checkpoints on job cancellation.
+
+    All checkpoint state will be deleted when you cancel the owning
+    job, both the meta data and actual program state. Therefore, you
+    cannot resume from externalized checkpoints after the job has been
+    cancelled.
+
+    Note that checkpoint state is always kept if the job terminates
+    with state ``FAILED``.
+
+    :data:`RETAIN_ON_CANCELLATION`:
+
+    Retain externalized checkpoints on job cancellation.
+
+    All checkpoint state is kept when you cancel the owning job. You
+    have to manually delete both the checkpoint meta data and actual
+    program state after cancelling the job.
+
+    Note that checkpoint state is always kept if the job terminates
+    with state ``FAILED``.
+    """
+
+    DELETE_ON_CANCELLATION = 0
+
+    RETAIN_ON_CANCELLATION = 1

--- a/flink-python/pyflink/common/checkpointing_mode.py
+++ b/flink-python/pyflink/common/checkpointing_mode.py
@@ -1,0 +1,105 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from pyflink.java_gateway import get_gateway
+
+__all__ = ['CheckpointingMode']
+
+
+class CheckpointingMode(object):
+    """
+    The checkpointing mode defines what consistency guarantees the system gives in the presence of
+    failures.
+
+    When checkpointing is activated, the data streams are replayed such that lost parts of the
+    processing are repeated. For stateful operations and functions, the checkpointing mode defines
+    whether the system draws checkpoints such that a recovery behaves as if the operators/functions
+    see each record "exactly once" (:data:`CheckpointingMode.EXACTLY_ONCE`), or whether the
+    checkpoints are drawn in a simpler fashion that typically encounters some duplicates upon
+    recovery (:data:`CheckpointingMode.AT_LEAST_ONCE`)
+
+    :data:`EXACTLY_ONCE`:
+
+    Sets the checkpointing mode to "exactly once". This mode means that the system will
+    checkpoint the operator and user function state in such a way that, upon recovery,
+    every record will be reflected exactly once in the operator state.
+
+    For example, if a user function counts the number of elements in a stream,
+    this number will consistently be equal to the number of actual elements in the stream,
+    regardless of failures and recovery.
+
+    Note that this does not mean that each record flows through the streaming data flow
+    only once. It means that upon recovery, the state of operators/functions is restored such
+    that the resumed data streams pick up exactly at after the last modification to the state.
+
+    Note that this mode does not guarantee exactly-once behavior in the interaction with
+    external systems (only state in Flink's operators and user functions). The reason for that
+    is that a certain level of "collaboration" is required between two systems to achieve
+    exactly-once guarantees. However, for certain systems, connectors can be written that
+    facilitate this collaboration.
+
+    This mode sustains high throughput. Depending on the data flow graph and operations,
+    this mode may increase the record latency, because operators need to align their input
+    streams, in order to create a consistent snapshot point. The latency increase for simple
+    dataflows (no repartitioning) is negligible. For simple dataflows with repartitioning, the
+    average latency remains small, but the slowest records typically have an increased latency.
+
+    :data:`AT_LEAST_ONCE`:
+
+    Sets the checkpointing mode to "at least once". This mode means that the system will
+    checkpoint the operator and user function state in a simpler way. Upon failure and recovery,
+    some records may be reflected multiple times in the operator state.
+
+    For example, if a user function counts the number of elements in a stream,
+    this number will equal to, or larger, than the actual number of elements in the stream,
+    in the presence of failure and recovery.
+
+    This mode has minimal impact on latency and may be preferable in very-low latency
+    scenarios, where a sustained very-low latency (such as few milliseconds) is needed,
+    and where occasional duplicate messages (on recovery) do not matter.
+    """
+
+    EXACTLY_ONCE = 0
+    AT_LEAST_ONCE = 1
+
+    @classmethod
+    def _from_j_checkpointing_mode(cls, j_checkpointing_mode):
+        gateway = get_gateway()
+        JCheckpointingMode = \
+            gateway.jvm.org.apache.flink.streaming.api.CheckpointingMode
+        if j_checkpointing_mode == JCheckpointingMode.EXACTLY_ONCE:
+            return CheckpointingMode.EXACTLY_ONCE
+        elif j_checkpointing_mode == JCheckpointingMode.AT_LEAST_ONCE:
+            return CheckpointingMode.AT_LEAST_ONCE
+        elif j_checkpointing_mode is None:
+            return None
+        else:
+            raise Exception("Unsupported java checkpointing mode: %s" % j_checkpointing_mode)
+
+    @classmethod
+    def _to_j_checkpointing_mode(cls, checkpointing_mode):
+        gateway = get_gateway()
+        JCheckpointingMode = \
+            gateway.jvm.org.apache.flink.streaming.api.CheckpointingMode
+        if checkpointing_mode == CheckpointingMode.AT_LEAST_ONCE:
+            return JCheckpointingMode.AT_LEAST_ONCE
+        elif checkpointing_mode == CheckpointingMode.EXACTLY_ONCE:
+            return JCheckpointingMode.EXACTLY_ONCE
+        else:
+            raise TypeError("Unsupported checkpointing mode: %s, supported checkpointing modes are:"
+                            "CheckpointingMode.AT_LEAST_ONCE and "
+                            "CheckpointingMode.EXACTLY_ONCE." % checkpointing_mode)

--- a/flink-python/pyflink/common/execution_config.py
+++ b/flink-python/pyflink/common/execution_config.py
@@ -1,0 +1,720 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import sys
+
+from pyflink.common.execution_mode import ExecutionMode
+from pyflink.common.input_dependency_constraint import InputDependencyConstraint
+from pyflink.common.restart_strategy import RestartStrategies
+from pyflink.java_gateway import get_gateway
+from pyflink.util.utils import load_java_class
+
+if sys.version >= '3':
+    unicode = str
+
+__all__ = ['ExecutionConfig']
+
+
+class ExecutionConfig(object):
+    """
+    A config to define the behavior of the program execution. It allows to define (among other
+    options) the following settings:
+
+    - The default parallelism of the program, i.e., how many parallel tasks to use for
+      all functions that do not define a specific value directly.
+
+    - The number of retries in the case of failed executions.
+
+    - The delay between execution retries.
+
+    - The :class:`ExecutionMode` of the program: Batch or Pipelined.
+      The default execution mode is :data:`ExecutionMode.PIPELINED`
+
+    - Enabling or disabling the "closure cleaner". The closure cleaner pre-processes
+      the implementations of functions. In case they are (anonymous) inner classes,
+      it removes unused references to the enclosing class to fix certain serialization-related
+      problems and to reduce the size of the closure.
+
+    - The config allows to register types and serializers to increase the efficiency of
+      handling *generic types* and *POJOs*. This is usually only needed
+      when the functions return not only the types declared in their signature, but
+      also subclasses of those types.
+
+    :data:`PARALLELISM_DEFAULT`:
+
+    The flag value indicating use of the default parallelism. This value can
+    be used to reset the parallelism back to the default state.
+
+    :data:`PARALLELISM_UNKNOWN`:
+
+    The flag value indicating an unknown or unset parallelism. This value is
+    not a valid parallelism and indicates that the parallelism should remain
+    unchanged.
+    """
+
+    PARALLELISM_DEFAULT = -1
+
+    PARALLELISM_UNKNOWN = -2
+
+    def __init__(self, j_execution_config):
+        self._j_execution_config = j_execution_config
+
+    def enable_closure_cleaner(self):
+        """
+        Enables the ClosureCleaner. This analyzes user code functions and sets fields to null
+        that are not used. This will in most cases make closures or anonymous inner classes
+        serializable that where not serializable due to some Scala or Java implementation artifact.
+        User code must be serializable because it needs to be sent to worker nodes.
+
+        :return: This object.
+        """
+        self._j_execution_config = self._j_execution_config.enableClosureCleaner()
+        return self
+
+    def disable_closure_cleaner(self):
+        """
+        Disables the ClosureCleaner.
+
+        see :func:`enable_closure_cleaner`
+
+        :return: This object.
+        """
+        self._j_execution_config = self._j_execution_config.disableClosureCleaner()
+        return self
+
+    def is_closure_cleaner_enabled(self):
+        """
+        Returns whether the ClosureCleaner is enabled.
+
+        see :func:`enable_closure_cleaner`
+
+        :return: ``True`` means enable and ``False`` means disable.
+        """
+        return self._j_execution_config.isClosureCleanerEnabled()
+
+    def set_auto_watermark_interval(self, interval):
+        """
+        Sets the interval of the automatic watermark emission. Watermarks are used throughout
+        the streaming system to keep track of the progress of time. They are used, for example,
+        for time based windowing.
+
+        :param interval: The integer value interval between watermarks in milliseconds.
+        :return: This object.
+        """
+        self._j_execution_config = self._j_execution_config.setAutoWatermarkInterval(interval)
+        return self
+
+    def get_auto_watermark_interval(self):
+        """
+        Returns the interval of the automatic watermark emission.
+
+        see :func:`set_auto_watermark_interval`
+
+        :return: The integer value interval in milliseconds of the automatic watermark emission.
+        """
+        return self._j_execution_config.getAutoWatermarkInterval()
+
+    def set_latency_tracking_interval(self, interval):
+        """
+        Interval for sending latency tracking marks from the sources to the sinks.
+
+        Flink will send latency tracking marks from the sources at the specified interval.
+        Setting a tracking interval <= 0 disables the latency tracking.
+
+        :param interval: Integer value interval in milliseconds.
+        :return: This object.
+        """
+        self._j_execution_config = self._j_execution_config.setLatencyTrackingInterval(interval)
+        return self
+
+    def get_latency_tracking_interval(self):
+        """
+        Returns the latency tracking interval.
+
+        :return: The latency tracking interval in milliseconds.
+        """
+        return self._j_execution_config.getLatencyTrackingInterval()
+
+    def is_latency_tracking_configured(self):
+        """
+        Returns whether the latency tracking is configured.
+
+        :return: ``True`` means configured and ``False`` means not configured.
+        """
+        return self._j_execution_config.isLatencyTrackingConfigured()
+
+    def get_parallelism(self):
+        """
+        Gets the parallelism with which operation are executed by default. Operations can
+        individually override this value to use a specific parallelism.
+
+        Other operations may need to run with a different parallelism - for example calling
+        a reduce operation over the entire data set will involve an operation that runs
+        with a parallelism of one (the final reduce to the single result value).
+
+        :return: The parallelism used by operations, unless they override that value. This method
+                 returns :data:`ExecutionConfig.PARALLELISM_DEFAULT` if the environment's default
+                 parallelism should be used.
+        """
+        return self._j_execution_config.getParallelism()
+
+    def set_parallelism(self, parallelism):
+        """
+        Sets the parallelism for operations executed through this environment.
+        Setting a parallelism of x here will cause all operators (such as join, map, reduce) to run
+        with x parallel instances.
+
+        This method overrides the default parallelism for this environment.
+        The local execution environment uses by default a value equal to the number of hardware
+        contexts (CPU cores / threads). When executing the program via the command line client
+        from a JAR/Python file, the default parallelism is the one configured for that setup.
+
+        :param parallelism: The parallelism to use.
+        :return: This object.
+        """
+        self._j_execution_config = self._j_execution_config.setParallelism(parallelism)
+        return self
+
+    def get_max_parallelism(self):
+        """
+        Gets the maximum degree of parallelism defined for the program.
+
+        The maximum degree of parallelism specifies the upper limit for dynamic scaling. It also
+        defines the number of key groups used for partitioned state.
+
+        :return: Maximum degree of parallelism.
+        """
+        return self._j_execution_config.getMaxParallelism()
+
+    def set_max_parallelism(self, max_parallelism):
+        """
+        Sets the maximum degree of parallelism defined for the program.
+
+        The maximum degree of parallelism specifies the upper limit for dynamic scaling. It also
+        defines the number of key groups used for partitioned state.
+
+        :param max_parallelism: Maximum degree of parallelism to be used for the program.
+        """
+        self._j_execution_config.setMaxParallelism(max_parallelism)
+
+    def get_task_cancellation_interval(self):
+        """
+        Gets the interval (in milliseconds) between consecutive attempts to cancel a running task.
+
+        :return: The integer value interval in milliseconds.
+        """
+        return self._j_execution_config.getTaskCancellationInterval()
+
+    def set_task_cancellation_interval(self, interval):
+        """
+        Sets the configuration parameter specifying the interval (in milliseconds)
+        between consecutive attempts to cancel a running task.
+
+        :param interval: The integer value interval in milliseconds.
+        :return: This object.
+        """
+        self._j_execution_config = self._j_execution_config.setTaskCancellationInterval(interval)
+        return self
+
+    def get_task_cancellation_timeout(self):
+        """
+        Returns the timeout (in milliseconds) after which an ongoing task
+        cancellation leads to a fatal TaskManager error.
+
+        The value ``0`` means that the timeout is disabled. In
+        this case a stuck cancellation will not lead to a fatal error.
+
+        :return: The timeout in milliseconds.
+        """
+        return self._j_execution_config.getTaskCancellationTimeout()
+
+    def set_task_cancellation_timeout(self, timeout):
+        """
+        Sets the timeout (in milliseconds) after which an ongoing task cancellation
+        is considered failed, leading to a fatal TaskManager error.
+
+        The cluster default is configured via ``TaskManagerOptions#TASK_CANCELLATION_TIMEOUT``.
+
+        The value ``0`` disables the timeout. In this case a stuck
+        cancellation will not lead to a fatal error.
+
+        :param timeout: The task cancellation timeout (in milliseconds).
+        :return: This object.
+        """
+        self._j_execution_config = self._j_execution_config.setTaskCancellationTimeout(timeout)
+        return self
+
+    def set_restart_strategy(self, restart_strategy_configuration):
+        """
+        Sets the restart strategy to be used for recovery.
+        ::
+            >>> config = env.getConfig()
+            >>> config.set_restart_strategy(RestartStrategies.fixed_delay_restart(10, 1000))
+
+        :param restart_strategy_configuration: Configuration defining the restart strategy to use.
+        """
+        self._j_execution_config.setRestartStrategy(
+            restart_strategy_configuration._j_restart_strategy_configuration)
+
+    def get_restart_strategy(self):
+        """
+        Returns the restart strategy which has been set for the current job.
+
+        :return: The specified restart configuration.
+        """
+        return RestartStrategies._from_j_restart_strategy(
+            self._j_execution_config.getRestartStrategy())
+
+    def set_execution_mode(self, execution_mode):
+        """
+        Sets the execution mode to execute the program. The execution mode defines whether
+        data exchanges are performed in a batch or on a pipelined manner.
+
+        The default execution mode is :data:`ExecutionMode.PIPELINED`.
+
+        :param execution_mode: The execution mode to use.
+        """
+        gateway = get_gateway()
+        JExecutionMode = gateway.jvm.org.apache.flink.api.common.ExecutionMode
+        if execution_mode == ExecutionMode.PIPELINED:
+            self._j_execution_config.setExecutionMode(JExecutionMode.PIPELINED)
+        elif execution_mode == ExecutionMode.PIPELINED_FORCED:
+            self._j_execution_config.setExecutionMode(JExecutionMode.PIPELINED_FORCED)
+        elif execution_mode == ExecutionMode.BATCH:
+            self._j_execution_config.setExecutionMode(JExecutionMode.BATCH)
+        elif execution_mode == ExecutionMode.BATCH_FORCED:
+            self._j_execution_config.setExecutionMode(JExecutionMode.BATCH_FORCED)
+        else:
+            raise TypeError("Unsupported execution mode: %s, supported execution modes are: "
+                            "ExecutionMode.PIPELINED, ExecutionMode.PIPELINED_FORCED, "
+                            "ExecutionMode.BATCH and ExecutionMode.BATCH_FORCED." % execution_mode)
+
+    def get_execution_mode(self):
+        """
+        Gets the execution mode used to execute the program. The execution mode defines whether
+        data exchanges are performed in a batch or on a pipelined manner.
+
+        The default execution mode is :data:`ExecutionMode.PIPELINED`.
+
+        :return: The execution mode for the program.
+        """
+        gateway = get_gateway()
+        JExecutionMode = gateway.jvm.org.apache.flink.api.common.ExecutionMode
+        j_execution_mode = self._j_execution_config.getExecutionMode()
+        if j_execution_mode == JExecutionMode.PIPELINED:
+            return ExecutionMode.PIPELINED
+        elif j_execution_mode == JExecutionMode.PIPELINED_FORCED:
+            return ExecutionMode.PIPELINED_FORCED
+        elif j_execution_mode == JExecutionMode.BATCH:
+            return ExecutionMode.BATCH
+        elif j_execution_mode == JExecutionMode.BATCH_FORCED:
+            return ExecutionMode.BATCH_FORCED
+        elif j_execution_mode is None:
+            return None
+        else:
+            raise Exception("Unsupported java exection mode: %s" % j_execution_mode)
+
+    def set_default_input_dependency_constraint(self, input_dependency_constraint):
+        """
+        Sets the default input dependency constraint for vertex scheduling. It indicates when a
+        task should be scheduled considering its inputs status.
+
+        The default constraint is :data:`InputDependencyConstraint.ANY`.
+
+        :param input_dependency_constraint: The input dependency constraint.
+        """
+        gateway = get_gateway()
+        JInputDependencyConstraint = gateway.jvm.org.apache.flink.api.common\
+            .InputDependencyConstraint
+        if input_dependency_constraint == InputDependencyConstraint.ANY:
+            self._j_execution_config.setDefaultInputDependencyConstraint(
+                JInputDependencyConstraint.ANY)
+        elif input_dependency_constraint == InputDependencyConstraint.ALL:
+            self._j_execution_config.setDefaultInputDependencyConstraint(
+                JInputDependencyConstraint.ALL)
+        else:
+            raise TypeError("Unsupported input dependency constraint: %s, supported input "
+                            "dependency constraints are: InputDependencyConstraint.ANY and "
+                            "InputDependencyConstraint.ALL." % input_dependency_constraint)
+
+    def get_default_input_dependency_constraint(self):
+        """
+        Gets the default input dependency constraint for vertex scheduling. It indicates when a
+        task should be scheduled considering its inputs status.
+
+        The default constraint is :data:`InputDependencyConstraint.ANY`.
+
+        :return: The input dependency constraint of this job.
+        """
+        gateway = get_gateway()
+        JInputDependencyConstraint = gateway.jvm.org.apache.flink.api.common \
+            .InputDependencyConstraint
+        j_input_dependency_constraint = self._j_execution_config\
+            .getDefaultInputDependencyConstraint()
+        if j_input_dependency_constraint == JInputDependencyConstraint.ANY:
+            return InputDependencyConstraint.ANY
+        elif j_input_dependency_constraint == JInputDependencyConstraint.ALL:
+            return InputDependencyConstraint.ALL
+        elif j_input_dependency_constraint is None:
+            return None
+        else:
+            raise Exception("Unsupported java input dependency constraint: %s"
+                            % j_input_dependency_constraint)
+
+    def enable_force_kryo(self):
+        """
+        Force TypeExtractor to use Kryo serializer for POJOS even though we could analyze as POJO.
+        In some cases this might be preferable. For example, when using interfaces
+        with subclasses that cannot be analyzed as POJO.
+        """
+        self._j_execution_config.enableForceKryo()
+
+    def disable_force_kryo(self):
+        """
+        Disable use of Kryo serializer for all POJOs.
+        """
+        self._j_execution_config.disableForceKryo()
+
+    def is_force_kryo_enabled(self):
+        """
+        :return: Boolean value that represent whether the usage of Kryo serializer for all POJOs
+                 is enabled.
+        """
+        return self._j_execution_config.isForceKryoEnabled()
+
+    def enable_generic_types(self):
+        """
+        Enables the use generic types which are serialized via Kryo.
+
+        Generic types are enabled by default.
+
+        see :func:`disable_generic_types`
+        """
+        self._j_execution_config.enableGenericTypes()
+
+    def disable_generic_types(self):
+        """
+        Disables the use of generic types (types that would be serialized via Kryo). If this option
+        is used, Flink will throw an ``UnsupportedOperationException`` whenever it encounters
+        a data type that would go through Kryo for serialization.
+
+        Disabling generic types can be helpful to eagerly find and eliminate the use of types
+        that would go through Kryo serialization during runtime. Rather than checking types
+        individually, using this option will throw exceptions eagerly in the places where generic
+        types are used.
+
+        **Important:** We recommend to use this option only during development and pre-production
+        phases, not during actual production use. The application program and/or the input data may
+        be such that new, previously unseen, types occur at some point. In that case, setting this
+        option would cause the program to fail.
+
+        see :func:`enable_generic_types`
+        """
+        self._j_execution_config.disableGenericTypes()
+
+    def has_generic_types_disabled(self):
+        """
+        Checks whether generic types are supported. Generic types are types that go through Kryo
+        during serialization.
+
+        Generic types are enabled by default.
+
+        see :func:`enable_generic_types`
+
+        see :func:`disable_generic_types`
+
+        :return: Boolean value that represent whether the generic types are supported.
+        """
+        return self._j_execution_config.hasGenericTypesDisabled()
+
+    def enable_auto_generated_uids(self):
+        """
+        Enables the Flink runtime to auto-generate UID's for operators.
+
+        see :func:`disable_auto_generated_uids`
+        """
+        self._j_execution_config.enableAutoGeneratedUIDs()
+
+    def disable_auto_generated_uids(self):
+        """
+        Disables auto-generated UIDs. Forces users to manually specify UIDs
+        on DataStream applications.
+
+        It is highly recommended that users specify UIDs before deploying to
+        production since they are used to match state in savepoints to operators
+        in a job. Because auto-generated ID's are likely to change when modifying
+        a job, specifying custom IDs allow an application to evolve overtime
+        without discarding state.
+        """
+        self._j_execution_config.disableAutoGeneratedUIDs()
+
+    def has_auto_generated_uids_enabled(self):
+        """
+        Checks whether auto generated UIDs are supported.
+
+        Auto generated UIDs are enabled by default.
+
+        see :func:`enable_auto_generated_uids`
+
+        see :func:`disable_auto_generated_uids`
+
+        :return: Boolean value that represent whether auto generated UIDs are supported.
+        """
+        return self._j_execution_config.hasAutoGeneratedUIDsEnabled()
+
+    def enable_force_avro(self):
+        """
+        Forces Flink to use the Apache Avro serializer for POJOs.
+
+        **Important:** Make sure to include the *flink-avro* module.
+        """
+        self._j_execution_config.enableForceAvro()
+
+    def disable_force_avro(self):
+        """
+        Disables the Apache Avro serializer as the forced serializer for POJOs.
+        """
+        self._j_execution_config.disableForceAvro()
+
+    def is_force_avro_enabled(self):
+        """
+        Returns whether the Apache Avro is the default serializer for POJOs.
+
+        :return: Boolean value that represent whether the Apache Avro is the default serializer
+                 for POJOs.
+        """
+        return self._j_execution_config.isForceAvroEnabled()
+
+    def enable_object_reuse(self):
+        """
+        Enables reusing objects that Flink internally uses for deserialization and passing
+        data to user-code functions. Keep in mind that this can lead to bugs when the
+        user-code function of an operation is not aware of this behaviour.
+
+        :return: This object.
+        """
+        self._j_execution_config = self._j_execution_config.enableObjectReuse()
+        return self
+
+    def disable_object_reuse(self):
+        """
+        Disables reusing objects that Flink internally uses for deserialization and passing
+        data to user-code functions.
+
+        see :func:`enable_object_reuse`
+
+        :return: This object.
+        """
+        self._j_execution_config = self._j_execution_config.disableObjectReuse()
+        return self
+
+    def is_object_reuse_enabled(self):
+        """
+        Returns whether object reuse has been enabled or disabled.
+
+        see :func:`enable_object_reuse`
+
+        :return: Boolean value that represent whether object reuse has been enabled or disabled.
+        """
+        return self._j_execution_config.isObjectReuseEnabled()
+
+    def enable_sysout_logging(self):
+        """
+        Enables the printing of progress update messages to stdout.
+
+        :return: This object.
+        """
+        self._j_execution_config = self._j_execution_config.enableSysoutLogging()
+        return self
+
+    def disable_sysout_logging(self):
+        """
+        Disables the printing of progress update messages to stdout.
+
+        :return: This object.
+        """
+        self._j_execution_config = self._j_execution_config.disableSysoutLogging()
+        return self
+
+    def is_sysout_logging_enabled(self):
+        """
+        Gets whether progress update messages should be printed to stdout.
+
+        :return: True, if progress update messages should be printed, false otherwise.
+        """
+        return self._j_execution_config.isSysoutLoggingEnabled()
+
+    def get_global_job_parameters(self):
+        """
+        Gets current configuration dict.
+
+        :return: The configuration dict.
+        """
+        return dict(self._j_execution_config.getGlobalJobParameters().toMap())
+
+    def set_global_job_parameters(self, global_job_parameters_dict):
+        """
+        Register a custom, serializable user configuration dict.
+
+        :param global_job_parameters_dict: Custom user configuration dict.
+        """
+        gateway = get_gateway()
+        Configuration = gateway.jvm.org.apache.flink.configuration.Configuration
+        j_global_job_parameters = Configuration()
+        for key in global_job_parameters_dict:
+            if not isinstance(global_job_parameters_dict[key], (str, unicode)):
+                value = str(global_job_parameters_dict[key])
+            else:
+                value = global_job_parameters_dict[key]
+            j_global_job_parameters.setString(key, value)
+        self._j_execution_config.setGlobalJobParameters(j_global_job_parameters)
+
+    def add_default_kryo_serializer(self, type_class_name, serializer_class_name):
+        """
+        Adds a new Kryo default serializer to the Runtime.
+
+        :param type_class_name: The full-qualified java class name of the types serialized with the
+                                given serializer.
+        :param serializer_class_name: The full-qualified java class name of the serializer to use.
+        """
+        type_clz = load_java_class(type_class_name)
+        j_serializer_clz = load_java_class(serializer_class_name)
+        self._j_execution_config.addDefaultKryoSerializer(type_clz, j_serializer_clz)
+
+    def register_type_with_kryo_serializer(self, type_class_name, serializer_class_name):
+        """
+        Registers the given Serializer via its class as a serializer for the given type at the
+        KryoSerializer.
+
+        :param type_class_name: The full-qualified java class name of the types serialized with
+                                the given serializer.
+        :param serializer_class_name: The full-qualified java class name of the serializer to use.
+        """
+        type_clz = load_java_class(type_class_name)
+        j_serializer_clz = load_java_class(serializer_class_name)
+        self._j_execution_config.registerTypeWithKryoSerializer(type_clz, j_serializer_clz)
+
+    def register_pojo_type(self, type_class_name):
+        """
+        Registers the given type with the serialization stack. If the type is eventually
+        serialized as a POJO, then the type is registered with the POJO serializer. If the
+        type ends up being serialized with Kryo, then it will be registered at Kryo to make
+        sure that only tags are written.
+
+        :param type_class_name: The full-qualified java class name of the type to register.
+        """
+        type_clz = load_java_class(type_class_name)
+        self._j_execution_config.registerPojoType(type_clz)
+
+    def register_kryo_type(self, type_class_name):
+        """
+        Registers the given type with the serialization stack. If the type is eventually
+        serialized as a POJO, then the type is registered with the POJO serializer. If the
+        type ends up being serialized with Kryo, then it will be registered at Kryo to make
+        sure that only tags are written.
+
+        :param type_class_name: The full-qualified java class name of the type to register.
+        """
+        type_clz = load_java_class(type_class_name)
+        self._j_execution_config.registerKryoType(type_clz)
+
+    def get_registered_types_with_kryo_serializer_classes(self):
+        """
+        Returns the registered types with their Kryo Serializer classes.
+
+        :return: The dict which the keys are full-qualified java class names of the registered
+                 types and the values are full-qualified java class names of the Kryo Serializer
+                 classes.
+        """
+        j_clz_map = self._j_execution_config.getRegisteredTypesWithKryoSerializerClasses()
+        registered_serializers = {}
+        for key in j_clz_map:
+            registered_serializers[key.getName()] = j_clz_map[key].getName()
+        return registered_serializers
+
+    def get_default_kryo_serializer_classes(self):
+        """
+        Returns the registered default Kryo Serializer classes.
+
+        :return: The dict which the keys are full-qualified java class names of the registered
+                 types and the values are full-qualified java class names of the Kryo default
+                 Serializer classes.
+        """
+        j_clz_map = self._j_execution_config.getDefaultKryoSerializerClasses()
+        default_kryo_serializers = {}
+        for key in j_clz_map:
+            default_kryo_serializers[key.getName()] = j_clz_map[key].getName()
+        return default_kryo_serializers
+
+    def get_registered_kryo_types(self):
+        """
+        Returns the registered Kryo types.
+
+        :return: The list of full-qualified java class names of the registered Kryo types.
+        """
+        j_clz_set = self._j_execution_config.getRegisteredKryoTypes()
+        return [value.getName() for value in j_clz_set]
+
+    def get_registered_pojo_types(self):
+        """
+        Returns the registered POJO types.
+
+        :return: The list of full-qualified java class names of the registered POJO types.
+        """
+        j_clz_set = self._j_execution_config.getRegisteredPojoTypes()
+        return [value.getName() for value in j_clz_set]
+
+    def is_auto_type_registration_disabled(self):
+        """
+        Returns whether Flink is automatically registering all types in the user programs with
+        Kryo.
+
+        :return: ``True`` means auto type registration is disabled and ``False`` means enabled.
+        """
+        return self._j_execution_config.isAutoTypeRegistrationDisabled()
+
+    def disable_auto_type_registration(self):
+        """
+        Control whether Flink is automatically registering all types in the user programs with
+        Kryo.
+        """
+        self._j_execution_config.disableAutoTypeRegistration()
+
+    def is_use_snapshot_compression(self):
+        """
+        Returns whether he compression (snappy) for keyed state in full checkpoints and savepoints
+        is enabled.
+
+        :return: ``True`` means enabled and ``False`` means disabled.
+        """
+        return self._j_execution_config.isUseSnapshotCompression()
+
+    def set_use_snapshot_compression(self, use_snapshot_compression):
+        """
+        Control whether the compression (snappy) for keyed state in full checkpoints and savepoints
+        is enabled.
+
+        :param use_snapshot_compression: ``True`` means enabled and ``False`` means disabled.
+        """
+        self._j_execution_config.setUseSnapshotCompression(use_snapshot_compression)
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and \
+            self._j_execution_config == other._j_execution_config
+
+    def __hash__(self):
+        return self._j_execution_config.hashCode()

--- a/flink-python/pyflink/common/execution_mode.py
+++ b/flink-python/pyflink/common/execution_mode.py
@@ -1,0 +1,70 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+__all__ = ['ExecutionMode']
+
+
+class ExecutionMode(object):
+    """
+    The execution mode specifies how a batch program is executed in terms
+    of data exchange: pipelining or batched.
+
+    :data:`PIPELINED`:
+
+    Executes the program in a pipelined fashion (including shuffles and broadcasts),
+    except for data exchanges that are susceptible to deadlocks when pipelining.
+    These data exchanges are performed in a batch manner.
+
+    An example of situations that are susceptible to deadlocks (when executed in a
+    pipelined manner) are data flows that branch (one data set consumed by multiple
+    operations) and re-join later.
+
+
+    :data:`PIPELINED_FORCED`:
+
+    Executes the program in a pipelined fashion (including shuffles and broadcasts),
+    **including** data exchanges that are susceptible to deadlocks when
+    executed via pipelining.
+
+    Usually, PIPELINED is the preferable option, which pipelines most
+    data exchanges and only uses batch data exchanges in situations that are
+    susceptible to deadlocks.
+
+    This option should only be used with care and only in situations where the
+    programmer is sure that the program is safe for full pipelining and that
+    Flink was too conservative when choosing the batch exchange at a certain
+    point.
+
+    :data:`BATCH`:
+
+    This mode executes all shuffles and broadcasts in a batch fashion, while
+    pipelining data between operations that exchange data only locally
+    between one producer and one consumer.
+
+    :data:`BATCH_FORCED`:
+
+    This mode executes the program in a strict batch way, including all points
+    where data is forwarded locally from one producer to one consumer. This mode
+    is typically more expensive to execute than the BATCH mode. It does
+    guarantee that no successive operations are ever executed concurrently.
+    """
+
+    PIPELINED = 0
+    PIPELINED_FORCED = 1
+    BATCH = 2
+    BATCH_FORCED = 3

--- a/flink-python/pyflink/common/input_dependency_constraint.py
+++ b/flink-python/pyflink/common/input_dependency_constraint.py
@@ -1,0 +1,36 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+__all__ = ['InputDependencyConstraint']
+
+
+class InputDependencyConstraint(object):
+    """
+    This constraint indicates when a task should be scheduled considering its inputs status.
+
+    :data:`ANY`:
+
+    Schedule the task if any input is consumable.
+
+    :data:`ALL`:
+
+    Schedule the task if all the inputs are consumable.
+    """
+
+    ANY = 0
+    ALL = 1

--- a/flink-python/pyflink/common/restart_strategy.py
+++ b/flink-python/pyflink/common/restart_strategy.py
@@ -1,0 +1,244 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import sys
+from abc import ABCMeta
+from datetime import timedelta
+
+from py4j.java_gateway import get_java_class
+
+from pyflink.java_gateway import get_gateway
+from pyflink.util.utils import to_j_flink_time, from_j_flink_time
+
+__all__ = ['RestartStrategies']
+
+if sys.version >= '3':
+    long = int
+
+
+class RestartStrategyConfiguration(object):
+    """
+    Abstract configuration for restart strategies.
+    """
+
+    __metaclass__ = ABCMeta
+
+    def __init__(self, j_restart_strategy_configuration):
+        self._j_restart_strategy_configuration = j_restart_strategy_configuration
+
+    def get_description(self):
+        """
+        Returns a description which is shown in the web interface.
+
+        :return: Description of the restart strategy.
+        """
+        return self._j_restart_strategy_configuration.getDescription()
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and \
+            self._j_restart_strategy_configuration == \
+            other._j_restart_strategy_configuration
+
+    def __hash__(self):
+        return self._j_restart_strategy_configuration.hashCode()
+
+
+class RestartStrategies(object):
+    """
+    This class defines methods to generate RestartStrategyConfigurations. These configurations are
+    used to create RestartStrategies at runtime.
+
+    The RestartStrategyConfigurations are used to decouple the core module from the runtime module.
+    """
+
+    class NoRestartStrategyConfiguration(RestartStrategyConfiguration):
+        """
+        Configuration representing no restart strategy.
+        """
+
+        def __init__(self, j_restart_strategy=None):
+            if j_restart_strategy is None:
+                gateway = get_gateway()
+                self._j_restart_strategy_configuration = \
+                    gateway.jvm.RestartStrategies.NoRestartStrategyConfiguration()
+                super(RestartStrategies.NoRestartStrategyConfiguration, self)\
+                    .__init__(self._j_restart_strategy_configuration)
+            else:
+                super(RestartStrategies.NoRestartStrategyConfiguration, self) \
+                    .__init__(j_restart_strategy)
+
+    class FixedDelayRestartStrategyConfiguration(RestartStrategyConfiguration):
+        """
+        Configuration representing a fixed delay restart strategy.
+        """
+
+        def __init__(self, restart_attempts=None, delay_between_attempts_interval=None,
+                     j_restart_strategy=None):
+            if j_restart_strategy is None:
+                if not isinstance(delay_between_attempts_interval, (timedelta, int, long)):
+                    raise TypeError("The delay_between_attempts_interval 'failure_interval' "
+                                    "only supports integer and datetime.timedelta, current input "
+                                    "type is %s." % type(delay_between_attempts_interval))
+                gateway = get_gateway()
+                self._j_restart_strategy_configuration = \
+                    gateway.jvm.RestartStrategies\
+                    .fixedDelayRestart(
+                        restart_attempts, to_j_flink_time(delay_between_attempts_interval))
+                super(RestartStrategies.FixedDelayRestartStrategyConfiguration, self)\
+                    .__init__(self._j_restart_strategy_configuration)
+            else:
+                super(RestartStrategies.FixedDelayRestartStrategyConfiguration, self) \
+                    .__init__(j_restart_strategy)
+
+        def get_restart_attempts(self):
+            return self._j_restart_strategy_configuration.getRestartAttempts()
+
+        def get_delay_between_attempts_interval(self):
+            return from_j_flink_time(
+                self._j_restart_strategy_configuration.getDelayBetweenAttemptsInterval())
+
+    class FailureRateRestartStrategyConfiguration(RestartStrategyConfiguration):
+        """
+        Configuration representing a failure rate restart strategy.
+        """
+
+        def __init__(self,
+                     max_failure_rate=None,
+                     failure_interval=None,
+                     delay_between_attempts_interval=None,
+                     j_restart_strategy=None):
+            if j_restart_strategy is None:
+                if not isinstance(failure_interval, (timedelta, int, long)):
+                    raise TypeError("The parameter 'failure_interval' "
+                                    "only supports integer and datetime.timedelta, current input "
+                                    "type is %s." % type(failure_interval))
+                if not isinstance(delay_between_attempts_interval, (timedelta, int, long)):
+                    raise TypeError("The delay_between_attempts_interval 'failure_interval' "
+                                    "only supports integer and datetime.timedelta, current input "
+                                    "type is %s." % type(delay_between_attempts_interval))
+                gateway = get_gateway()
+                self._j_restart_strategy_configuration = \
+                    gateway.jvm.RestartStrategies\
+                    .FailureRateRestartStrategyConfiguration(max_failure_rate,
+                                                             to_j_flink_time(failure_interval),
+                                                             to_j_flink_time(
+                                                                 delay_between_attempts_interval))
+                super(RestartStrategies.FailureRateRestartStrategyConfiguration, self)\
+                    .__init__(self._j_restart_strategy_configuration)
+            else:
+                super(RestartStrategies.FailureRateRestartStrategyConfiguration, self)\
+                    .__init__(j_restart_strategy)
+
+        def get_max_failure_rate(self):
+            return self._j_restart_strategy_configuration.getMaxFailureRate()
+
+        def get_failure_interval(self):
+            return from_j_flink_time(self._j_restart_strategy_configuration.getFailureInterval())
+
+        def get_delay_between_attempts_interval(self):
+            return from_j_flink_time(self._j_restart_strategy_configuration
+                                     .getDelayBetweenAttemptsInterval())
+
+    class FallbackRestartStrategyConfiguration(RestartStrategyConfiguration):
+        """
+        Restart strategy configuration that could be used by jobs to use cluster level restart
+        strategy. Useful especially when one has a custom implementation of restart strategy set via
+        flink-conf.yaml.
+        """
+
+        def __init__(self, j_restart_strategy=None):
+            if j_restart_strategy is None:
+                gateway = get_gateway()
+                self._j_restart_strategy_configuration = \
+                    gateway.jvm.RestartStrategies.FallbackRestartStrategyConfiguration()
+                super(RestartStrategies.FallbackRestartStrategyConfiguration, self)\
+                    .__init__(self._j_restart_strategy_configuration)
+            else:
+                super(RestartStrategies.FallbackRestartStrategyConfiguration, self)\
+                    .__init__(j_restart_strategy)
+
+    @classmethod
+    def _from_j_restart_strategy(cls, j_restart_strategy):
+        if j_restart_strategy is None:
+            return None
+        gateway = get_gateway()
+        NoRestartStrategyConfiguration = gateway.jvm.RestartStrategies\
+            .NoRestartStrategyConfiguration
+        FixedDelayRestartStrategyConfiguration = gateway.jvm.RestartStrategies\
+            .FixedDelayRestartStrategyConfiguration
+        FailureRateRestartStrategyConfiguration = gateway.jvm.RestartStrategies\
+            .FailureRateRestartStrategyConfiguration
+        FallbackRestartStrategyConfiguration = gateway.jvm.RestartStrategies\
+            .FallbackRestartStrategyConfiguration
+        clz = j_restart_strategy.getClass()
+        if clz.getName() == get_java_class(NoRestartStrategyConfiguration).getName():
+            return RestartStrategies.NoRestartStrategyConfiguration(
+                j_restart_strategy=j_restart_strategy)
+        elif clz.getName() == get_java_class(FixedDelayRestartStrategyConfiguration).getName():
+            return RestartStrategies.FixedDelayRestartStrategyConfiguration(
+                j_restart_strategy=j_restart_strategy)
+        elif clz.getName() == get_java_class(FailureRateRestartStrategyConfiguration).getName():
+            return RestartStrategies.FailureRateRestartStrategyConfiguration(
+                j_restart_strategy=j_restart_strategy)
+        elif clz.getName() == get_java_class(FallbackRestartStrategyConfiguration).getName():
+            return RestartStrategies.FallbackRestartStrategyConfiguration(
+                j_restart_strategy=j_restart_strategy)
+        else:
+            raise Exception("Unsupported java RestartStrategyConfiguration: %s" % clz.getName())
+
+    @classmethod
+    def no_restart(cls):
+        """
+        Generates NoRestartStrategyConfiguration.
+
+        :return: The :class:`NoRestartStrategyConfiguration`.
+        """
+        return RestartStrategies.NoRestartStrategyConfiguration()
+
+    @classmethod
+    def fall_back_restart(cls):
+        return RestartStrategies.FallbackRestartStrategyConfiguration()
+
+    @classmethod
+    def fixed_delay_restart(cls, restart_attempts, delay_between_attempts):
+        """
+        Generates a FixedDelayRestartStrategyConfiguration.
+
+        :param restart_attempts: Number of restart attempts for the FixedDelayRestartStrategy.
+        :param delay_between_attempts: Delay in-between restart attempts for the
+                                       FixedDelayRestartStrategy, the input could be integer value
+                                       in milliseconds or datetime.timedelta object.
+        :return: The :class:`FixedDelayRestartStrategyConfiguration`.
+        """
+        return RestartStrategies.FixedDelayRestartStrategyConfiguration(restart_attempts,
+                                                                        delay_between_attempts)
+
+    @classmethod
+    def failure_rate_restart(cls, failure_rate, failure_interval, delay_interval):
+        """
+        Generates a FailureRateRestartStrategyConfiguration.
+
+        :param failure_rate: Maximum number of restarts in given interval ``failure_interval``
+                             before failing a job.
+        :param failure_interval: Time interval for failures, the input could be integer value
+                                 in milliseconds or datetime.timedelta object.
+        :param delay_interval: Delay in-between restart attempts, the input could be integer value
+                               in milliseconds or datetime.timedelta object.
+        """
+        return RestartStrategies.FailureRateRestartStrategyConfiguration(failure_rate,
+                                                                         failure_interval,
+                                                                         delay_interval)

--- a/flink-python/pyflink/common/state_backend.py
+++ b/flink-python/pyflink/common/state_backend.py
@@ -1,0 +1,797 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import sys
+from abc import ABCMeta
+
+from py4j.java_gateway import get_java_class
+
+from pyflink.java_gateway import get_gateway
+from pyflink.util.utils import to_j_config, load_java_class
+
+__all__ = [
+    'StateBackend',
+    'MemoryStateBackend',
+    'FsStateBackend',
+    'RocksDBStateBackend',
+    'CustomStateBackend',
+    'PredefinedOptions']
+
+if sys.version > '3':
+    xrange = range
+
+
+def _configure(configurable_state_backend, config):
+    gateway = get_gateway()
+    j_config = to_j_config(config)
+    context_class_loader = gateway.jvm.Thread.currentThread().getContextClassLoader()
+    return configurable_state_backend._j_state_backend.configure(j_config, context_class_loader)
+
+
+def _from_j_state_backend(j_state_backend):
+    if j_state_backend is None:
+        return None
+    gateway = get_gateway()
+    JStateBackend = gateway.jvm.org.apache.flink.runtime.state.StateBackend
+    JMemoryStateBackend = gateway.jvm.org.apache.flink.runtime.state.memory \
+        .MemoryStateBackend
+    JFsStateBackend = gateway.jvm.org.apache.flink.runtime.state.filesystem \
+        .FsStateBackend
+    JRocksDBStateBackend = gateway.jvm.org.apache.flink.contrib.streaming.state \
+        .RocksDBStateBackend
+    j_clz = j_state_backend.getClass()
+
+    if not get_java_class(JStateBackend).isAssignableFrom(j_clz):
+        raise TypeError("The input %s is not an instance of StateBackend." % j_state_backend)
+
+    if get_java_class(JMemoryStateBackend).isAssignableFrom(j_state_backend.getClass()):
+        return MemoryStateBackend(j_memory_state_backend=j_state_backend)
+    elif get_java_class(JFsStateBackend).isAssignableFrom(j_state_backend.getClass()):
+        return FsStateBackend(j_fs_state_backend=j_state_backend)
+    elif get_java_class(JRocksDBStateBackend).isAssignableFrom(j_state_backend.getClass()):
+        return RocksDBStateBackend(j_rocks_db_state_backend=j_state_backend)
+    else:
+        return CustomStateBackend(j_state_backend)  # users' customized state backend
+
+
+class StateBackend(object):
+    """
+    A **State Backend** defines how the state of a streaming application is stored and
+    checkpointed. Different State Backends store their state in different fashions, and use
+    different data structures to hold the state of a running application.
+
+    For example, the :class:`MemoryStateBackend` keeps working state in the memory of the
+    TaskManager and stores checkpoints in the memory of the JobManager. The backend is
+    lightweight and without additional dependencies, but not highly available and supports only
+    small state.
+
+    The :class:`FsStateBackend` keeps working state in the memory of the TaskManager and stores
+    state checkpoints in a filesystem(typically a replicated highly-available filesystem,
+    like `HDFS <https://hadoop.apache.org/>`_, `Ceph <https://ceph.com/>`_,
+    `S3 <https://aws.amazon.com/documentation/s3/>`_, `GCS <https://cloud.google.com/storage/>`_,
+    etc).
+
+    The :class:`RocksDBStateBackend` stores working state in `RocksDB <http://rocksdb.org/>`_,
+    and checkpoints the state by default to a filesystem (similar to the :class:`FsStateBackend`).
+
+    **Raw Bytes Storage and Backends**
+
+    The :class:`StateBackend` creates services for *raw bytes storage* and for *keyed state*
+    and *operator state*.
+
+    The *raw bytes storage* (through the `org.apache.flink.runtime.state.CheckpointStreamFactory`)
+    is the fundamental service that simply stores bytes in a fault tolerant fashion. This service
+    is used by the JobManager to store checkpoint and recovery metadata and is typically also used
+    by the keyed- and operator state backends to store checkpointed state.
+
+    The `org.apache.flink.runtime.state.AbstractKeyedStateBackend and
+    `org.apache.flink.runtime.state.OperatorStateBackend` created by this state backend define how
+    to hold the working state for keys and operators. They also define how to checkpoint that
+    state, frequently using the raw bytes storage (via the
+    `org.apache.flink.runtime.state.CheckpointStreamFactory`). However, it is also possible that
+    for example a keyed state backend simply implements the bridge to a key/value store, and that
+    it does not need to store anything in the raw byte storage upon a checkpoint.
+
+    **Serializability**
+
+    State Backends need to be serializable(`java.io.Serializable`), because they distributed
+    across parallel processes (for distributed execution) together with the streaming application
+    code.
+
+    Because of that, :class:`StateBackend` implementations are meant to be like *factories* that
+    create the proper states stores that provide access to the persistent storage and hold the
+    keyed- and operator state data structures. That way, the State Backend can be very lightweight
+    (contain only configurations) which makes it easier to be serializable.
+
+    **Thread Safety**
+
+    State backend implementations have to be thread-safe. Multiple threads may be creating
+    streams and keyed-/operator state backends concurrently.
+    """
+
+    __metaclass__ = ABCMeta
+
+    def __init__(self, j_state_backend):
+        self._j_state_backend = j_state_backend
+
+
+class MemoryStateBackend(StateBackend):
+    """
+    This state backend holds the working state in the memory (JVM heap) of the TaskManagers.
+    The state backend checkpoints state directly to the JobManager's memory (hence the backend's
+    name), but the checkpoints will be persisted to a file system for high-availability setups and
+    savepoints. The MemoryStateBackend is consequently a FileSystem-based backend that can work
+    without a file system dependency in simple setups.
+
+    This state backend should be used only for experimentation, quick local setups,
+    or for streaming applications that have very small state: Because it requires checkpoints to
+    go through the JobManager's memory, larger state will occupy larger portions of the
+    JobManager's main memory, reducing operational stability.
+    For any other setup, the :class:`FsStateBackend` should be used. The :class:`FsStateBackend`
+    holds the working state on the TaskManagers in the same way, but checkpoints state directly to
+    files rather then to the JobManager's memory, thus supporting large state sizes.
+
+    **State Size Considerations**
+
+    State checkpointing with this state backend is subject to the following conditions:
+
+    - Each individual state must not exceed the configured maximum state size
+      (see :func:`get_max_state_size`.
+
+    - All state from one task (i.e., the sum of all operator states and keyed states from all
+      chained operators of the task) must not exceed what the RPC system supports, which is
+      be default < 10 MB. That limit can be configured up, but that is typically not advised.
+
+    - The sum of all states in the application times all retained checkpoints must comfortably
+      fit into the JobManager's JVM heap space.
+
+    **Persistence Guarantees**
+
+    For the use cases where the state sizes can be handled by this backend, the backend does
+    guarantee persistence for savepoints, externalized checkpoints (of configured), and checkpoints
+    (when high-availability is configured).
+
+    **Configuration**
+
+    As for all state backends, this backend can either be configured within the application (by
+    creating the backend with the respective constructor parameters and setting it on the execution
+    environment) or by specifying it in the Flink configuration.
+
+    If the state backend was specified in the application, it may pick up additional configuration
+    parameters from the Flink configuration. For example, if the backend if configured in the
+    application without a default savepoint directory, it will pick up a default savepoint
+    directory specified in the Flink configuration of the running job/cluster. That behavior is
+    implemented via the :func:`configure` method.
+    """
+
+    # The default maximal size that the snapshotted memory state may have (5 MiBytes).
+    DEFAULT_MAX_STATE_SIZE = 5 * 1024 * 1024
+
+    def __init__(self,
+                 checkpoint_path=None,
+                 savepoint_path=None,
+                 max_state_size=None,
+                 using_asynchronous_snapshots=None,
+                 j_memory_state_backend=None):
+        """
+        Creates a new MemoryStateBackend, setting optionally the paths to persist checkpoint
+        metadata and savepoints to, as well as configuring state thresholds and asynchronous
+        operations.
+
+        WARNING: Increasing the size of this value beyond the default value
+        (:data:`DEFAULT_MAX_STATE_SIZE`) should be done with care.
+        The checkpointed state needs to be send to the JobManager via limited size RPC messages,
+        and there and the JobManager needs to be able to hold all aggregated state in its memory.
+
+        :param checkpoint_path: The path to write checkpoint metadata to. If none, the value from
+                                the runtime configuration will be used.
+        :param savepoint_path: The path to write savepoints to. If none, the value from
+                               the runtime configuration will be used.
+        :param max_state_size: The maximal size of the serialized state. If none, the
+                               :data:`DEFAULT_MAX_STATE_SIZE` will be used.
+        :param using_asynchronous_snapshots: Flag to switch between synchronous and asynchronous
+                                             snapshot mode. If null, the value configured in the
+                                             runtime configuration will be used.
+        :param j_memory_state_backend: For internal use, please keep none.
+        """
+        if j_memory_state_backend is None:
+            gateway = get_gateway()
+            JTernaryBoolean = gateway.jvm.org.apache.flink.util.TernaryBoolean
+            JMemoryStateBackend = gateway.jvm.org.apache.flink.runtime.state.memory\
+                .MemoryStateBackend
+            if using_asynchronous_snapshots is None:
+                j_asynchronous_snapshots = JTernaryBoolean.UNDEFINED
+            elif using_asynchronous_snapshots is True:
+                j_asynchronous_snapshots = JTernaryBoolean.TRUE
+            elif using_asynchronous_snapshots is False:
+                j_asynchronous_snapshots = JTernaryBoolean.FALSE
+            else:
+                raise TypeError("Unsupported input for 'using_asynchronous_snapshots': %s, "
+                                "the value of the parameter should be None or"
+                                "True or False.")
+            if max_state_size is None:
+                max_state_size = JMemoryStateBackend.DEFAULT_MAX_STATE_SIZE
+            j_memory_state_backend = JMemoryStateBackend(checkpoint_path,
+                                                         savepoint_path,
+                                                         max_state_size,
+                                                         j_asynchronous_snapshots)
+
+        self._j_memory_state_backend = j_memory_state_backend
+        super(MemoryStateBackend, self).__init__(j_memory_state_backend)
+
+    def configure(self, config):
+        """
+        Creates a copy of this state backend that uses the values defined in the configuration
+        for fields where that were not specified in this state backend.
+
+        :param config: The configuration dict.
+        :return: The re-configured variant of the state backend.
+        """
+        return MemoryStateBackend(j_memory_state_backend=_configure(self, config))
+
+    def get_max_state_size(self):
+        """
+        Gets the maximum size that an individual state can have, as configured in the
+        constructor (by default :data:`DEFAULT_MAX_STATE_SIZE`).
+
+        :return: The maximum size that an individual state can have.
+        """
+        return self._j_memory_state_backend.getMaxStateSize()
+
+    def is_using_asynchronous_snapshots(self):
+        """
+        Gets whether the key/value data structures are asynchronously snapshotted.
+
+        If not explicitly configured, this is the default value of
+        ``org.apache.flink.configuration.CheckpointingOptions.ASYNC_SNAPSHOTS``.
+
+        :return: True if the key/value data structures are asynchronously snapshotted,
+                 false otherwise.
+        """
+        return self._j_memory_state_backend.isUsingAsynchronousSnapshots()
+
+    def __str__(self):
+        return self._j_memory_state_backend.toString()
+
+
+class FsStateBackend(StateBackend):
+    """
+    This state backend holds the working state in the memory (JVM heap) of the TaskManagers.
+    The state backend checkpoints state as files to a file system (hence the backend's name).
+
+    Each checkpoint individually will store all its files in a subdirectory that includes the
+    checkpoint number, such as ``hdfs://namenode:port/flink-checkpoints/chk-17/``.
+
+    **State Size Considerations**
+
+    Working state is kept on the TaskManager heap. If a TaskManager executes multiple
+    tasks concurrently (if the TaskManager has multiple slots, or if slot-sharing is used)
+    then the aggregate state of all tasks needs to fit into that TaskManager's memory.
+
+    This state backend stores small state chunks directly with the metadata, to avoid creating
+    many small files. The threshold for that is configurable. When increasing this threshold, the
+    size of the checkpoint metadata increases. The checkpoint metadata of all retained completed
+    checkpoints needs to fit into the JobManager's heap memory. This is typically not a problem,
+    unless the threshold :func:`get_min_file_size_threshold` is increased significantly.
+
+    **Persistence Guarantees**
+
+    Checkpoints from this state backend are as persistent and available as filesystem that is
+    written to. If the file system is a persistent distributed file system, this state backend
+    supports highly available setups. The backend additionally supports savepoints and externalized
+    checkpoints.
+
+    **Configuration**
+
+    As for all state backends, this backend can either be configured within the application (by
+    creating the backend with the respective constructor parameters and setting it on the execution
+    environment) or by specifying it in the Flink configuration.
+
+    If the state backend was specified in the application, it may pick up additional configuration
+    parameters from the Flink configuration. For example, if the backend if configured in the
+    application without a default savepoint directory, it will pick up a default savepoint
+    directory specified in the Flink configuration of the running job/cluster. That behavior is
+    implemented via the :func:`configure` method.
+    """
+
+    def __init__(self,
+                 checkpoint_directory_uri=None,
+                 default_savepoint_directory_uri=None,
+                 file_state_size_threshold=None,
+                 using_asynchronous_snapshots=None,
+                 j_fs_state_backend=None):
+        """
+        Creates a new state backend that stores its checkpoint data in the file system and location
+        defined by the given URI.
+
+        A file system for the file system scheme in the URI (e.g., 'file://', 'hdfs://', or
+        'S3://') must be accessible via ``org.apache.flink.core.fs.FileSystem.get(URI)``.
+
+        For a state backend targeting HDFS, this means that the URI must either specify the
+        authority (host and port), or that the Hadoop configuration that describes that information
+        must be in the classpath.
+
+        :param checkpoint_directory_uri: The path to write checkpoint metadata to, required.
+        :param default_savepoint_directory_uri: The path to write savepoints to. If none, the value
+                                                from the runtime configuration will be used, or
+                                                savepoint target locations need to be passed when
+                                                triggering a savepoint.
+        :param file_state_size_threshold: State below this size will be stored as part of the
+                                          metadata, rather than in files. If none, the value
+                                          configured in the runtime configuration will be used, or
+                                          the default value (1KB) if nothing is configured.
+        :param using_asynchronous_snapshots: Flag to switch between synchronous and asynchronous
+                                             snapshot mode. If none, the value configured in
+                                             the runtime configuration will be used.
+        :param j_fs_state_backend: For internal use, please keep none.
+        """
+        if j_fs_state_backend is None:
+            gateway = get_gateway()
+            JTernaryBoolean = gateway.jvm.org.apache.flink.util.TernaryBoolean
+            JFsStateBackend = gateway.jvm.org.apache.flink.runtime.state.filesystem\
+                .FsStateBackend
+            JPath = gateway.jvm.org.apache.flink.core.fs.Path
+            if checkpoint_directory_uri is None:
+                raise ValueError("The parameter 'checkpoint_directory_uri' is required!")
+            j_checkpoint_directory_uri = JPath(checkpoint_directory_uri).toUri()
+
+            if default_savepoint_directory_uri is None:
+                j_default_savepoint_directory_uri = None
+            else:
+                j_default_savepoint_directory_uri = JPath(default_savepoint_directory_uri).toUri()
+
+            if file_state_size_threshold is None:
+                file_state_size_threshold = -1
+
+            if using_asynchronous_snapshots is None:
+                j_asynchronous_snapshots = JTernaryBoolean.UNDEFINED
+            elif using_asynchronous_snapshots is True:
+                j_asynchronous_snapshots = JTernaryBoolean.TRUE
+            elif using_asynchronous_snapshots is False:
+                j_asynchronous_snapshots = JTernaryBoolean.FALSE
+            else:
+                raise TypeError("Unsupported input for 'using_asynchronous_snapshots': %s, "
+                                "the value of the parameter should be None or"
+                                "True or False.")
+
+            j_fs_state_backend = JFsStateBackend(j_checkpoint_directory_uri,
+                                                 j_default_savepoint_directory_uri,
+                                                 file_state_size_threshold,
+                                                 j_asynchronous_snapshots)
+
+        self._j_fs_state_backend = j_fs_state_backend
+        super(FsStateBackend, self).__init__(j_fs_state_backend)
+
+    def configure(self, config):
+        """
+        Creates a copy of this state backend that uses the values defined in the configuration
+        for fields where that were not specified in this state backend.
+
+        :param config: The configuration dict.
+        :return: The re-configured variant of the state backend.
+        """
+        return FsStateBackend(j_fs_state_backend=_configure(self, config))
+
+    def get_checkpoint_path(self):
+        """
+        Gets the base directory where all the checkpoints are stored.
+        The job-specific checkpoint directory is created inside this directory.
+
+        :return: The base directory for checkpoints.
+        """
+        return self._j_fs_state_backend.getCheckpointPath().toString()
+
+    def get_min_file_size_threshold(self):
+        """
+        Gets the threshold below which state is stored as part of the metadata, rather than in
+        files. This threshold ensures that the backend does not create a large amount of very
+        small files, where potentially the file pointers are larger than the state itself.
+
+        If not explicitly configured, this is the default value of
+        ``org.apache.flink.configuration.CheckpointingOptions.FS_SMALL_FILE_THRESHOLD``.
+
+        :return: The file size threshold, in bytes.
+        """
+        return self._j_fs_state_backend.getMinFileSizeThreshold()
+
+    def is_using_asynchronous_snapshots(self):
+        """
+        Gets whether the key/value data structures are asynchronously snapshotted.
+
+        If not explicitly configured, this is the default value of
+        ``org.apache.flink.configuration.CheckpointingOptions.ASYNC_SNAPSHOTS``.
+
+        :return: True if the key/value data structures are asynchronously snapshotted,
+                 false otherwise.
+        """
+        return self._j_fs_state_backend.isUsingAsynchronousSnapshots()
+
+
+class RocksDBStateBackend(StateBackend):
+    """
+    A State Backend that stores its state in ``RocksDB``. This state backend can
+    store very large state that exceeds memory and spills to disk.
+
+    All key/value state (including windows) is stored in the key/value index of RocksDB.
+    For persistence against loss of machines, checkpoints take a snapshot of the
+    RocksDB database, and persist that snapshot in a file system (by default) or
+    another configurable state backend.
+
+    The behavior of the RocksDB instances can be parametrized by setting RocksDB Options
+    using the methods :func:`set_predefined_options` and :func:`set_options`.
+    """
+
+    def __init__(self,
+                 checkpoint_data_uri=None,
+                 enable_incremental_checkpointing=None,
+                 checkpoint_stream_backend=None,
+                 j_rocks_db_state_backend=None):
+        """
+        Creates a new :class:`RocksDBStateBackend` that stores its checkpoint data in the given
+        state backend or the location of given URI.
+
+        If using state backend, typically, one would supply a filesystem or database state backend
+        here where the snapshots from RocksDB would be stored.
+
+        If using URI, a state backend that stores checkpoints in HDFS or S3 must specify the file
+        system host and port in the URI, or have the Hadoop configuration that describes the file
+        system (host / high-availability group / possibly credentials) either referenced from the
+        Flink config, or included in the classpath.
+
+        :param checkpoint_data_uri: The URI describing the filesystem and path to the checkpoint
+                                    data directory.
+        :param enable_incremental_checkpointing: True if incremental checkpointing is enabled.
+        :param checkpoint_stream_backend: The backend write the checkpoint streams to.
+        :param j_rocks_db_state_backend: For internal use, please keep none.
+        """
+        if j_rocks_db_state_backend is None:
+            gateway = get_gateway()
+            JTernaryBoolean = gateway.jvm.org.apache.flink.util.TernaryBoolean
+            JRocksDBStateBackend = gateway.jvm.org.apache.flink.contrib.streaming.state \
+                .RocksDBStateBackend
+
+            if enable_incremental_checkpointing not in (None, True, False):
+                raise TypeError("Unsupported input for 'enable_incremental_checkpointing': %s, "
+                                "the value of the parameter should be None or"
+                                "True or False.")
+
+            if checkpoint_data_uri is not None:
+                if enable_incremental_checkpointing is None:
+                    j_rocks_db_state_backend = JRocksDBStateBackend(checkpoint_data_uri)
+                else:
+                    j_rocks_db_state_backend = \
+                        JRocksDBStateBackend(checkpoint_data_uri, enable_incremental_checkpointing)
+            elif isinstance(checkpoint_stream_backend, StateBackend):
+                if enable_incremental_checkpointing is None:
+                    j_enable_incremental_checkpointing = JTernaryBoolean.UNDEFINED
+                elif enable_incremental_checkpointing is True:
+                    j_enable_incremental_checkpointing = JTernaryBoolean.TRUE
+                else:
+                    j_enable_incremental_checkpointing = JTernaryBoolean.FALSE
+
+                j_rocks_db_state_backend = \
+                    JRocksDBStateBackend(checkpoint_stream_backend._j_state_backend,
+                                         j_enable_incremental_checkpointing)
+
+        self._j_rocks_db_state_backend = j_rocks_db_state_backend
+        super(RocksDBStateBackend, self).__init__(j_rocks_db_state_backend)
+
+    def configure(self, config):
+        """
+        Creates a copy of this state backend that uses the values defined in the configuration
+        for fields where that were not specified in this state backend.
+
+        :param config: The configuration dict.
+        :return: The re-configured variant of the state backend.
+        """
+        return RocksDBStateBackend(j_rocks_db_state_backend=_configure(self, config))
+
+    def get_checkpoint_backend(self):
+        """
+        Gets the state backend that this RocksDB state backend uses to persist
+        its bytes to.
+
+        This RocksDB state backend only implements the RocksDB specific parts, it
+        relies on the 'CheckpointBackend' to persist the checkpoint and savepoint bytes
+        streams.
+
+        :return: The state backend to persist the checkpoint and savepoint bytes streams.
+        """
+        j_state_backend = self._j_rocks_db_state_backend.getCheckpointBackend()
+        return _from_j_state_backend(j_state_backend)
+
+    def set_db_storage_paths(self, *paths):
+        """
+        Sets the directories in which the local RocksDB database puts its files (like SST and
+        metadata files). These directories do not need to be persistent, they can be ephemeral,
+        meaning that they are lost on a machine failure, because state in RocksDB is persisted
+        in checkpoints.
+
+        If nothing is configured, these directories default to the TaskManager's local
+        temporary file directories.
+
+        Each distinct state will be stored in one path, but when the state backend creates
+        multiple states, they will store their files on different paths.
+
+        Passing ``None`` to this function restores the default behavior, where the configured
+        temp directories will be used.
+
+        :param paths: The paths across which the local RocksDB database files will be spread. this
+                      parameter is optional.
+        """
+        if len(paths) < 1:
+            self._j_rocks_db_state_backend.setDbStoragePath(None)
+        else:
+            gateway = get_gateway()
+            j_path_array = gateway.new_array(gateway.jvm.String, len(paths))
+            for i in xrange(0, len(paths)):
+                j_path_array[i] = paths[i]
+            self._j_rocks_db_state_backend.setDbStoragePaths(j_path_array)
+
+    def get_db_storage_paths(self):
+        """
+        Gets the configured local DB storage paths, or null, if none were configured.
+
+        Under these directories on the TaskManager, RocksDB stores its SST files and
+        metadata files. These directories do not need to be persistent, they can be ephermeral,
+        meaning that they are lost on a machine failure, because state in RocksDB is persisted
+        in checkpoints.
+
+        If nothing is configured, these directories default to the TaskManager's local
+        temporary file directories.
+
+        :return: The list of configured local DB storage paths.
+        """
+        return list(self._j_rocks_db_state_backend.getDbStoragePaths())
+
+    def is_incremental_checkpoints_enabled(self):
+        """
+        Gets whether incremental checkpoints are enabled for this state backend.
+
+        :return: True if incremental checkpoints are enabled, false otherwise.
+        """
+        return self._j_rocks_db_state_backend.isIncrementalCheckpointsEnabled()
+
+    def is_ttl_compaction_filter_enabled(self):
+        """
+        Gets whether compaction filter to cleanup state with TTL is enabled.
+
+        :return: True if enabled, false otherwise.
+        """
+        return self._j_rocks_db_state_backend.isTtlCompactionFilterEnabled()
+
+    def enable_ttl_compaction_filter(self):
+        """
+        Enable compaction filter to cleanup state with TTL.
+
+        ..note::
+            User can still decide in state TTL configuration in state descriptor
+            whether the filter is active for particular state or not.
+        """
+        self._j_rocks_db_state_backend.enableTtlCompactionFilter()
+
+    def set_predefined_options(self, options):
+        """
+        Sets the predefined options for RocksDB.
+
+        If user-configured options within ``RocksDBConfigurableOptions`` is set (through
+        flink-conf.yaml) or a user-defined options factory is set (via :func:`setOptions`),
+        then the options from the factory are applied on top of the here specified
+        predefined options and customized options.
+
+        :param options: The options to set (must not be null), see :class:`PredefinedOptions`.
+        """
+        gateway = get_gateway()
+        JPredefinedOptions = gateway.jvm.org.apache.flink.contrib.streaming.state.PredefinedOptions
+        if options == PredefinedOptions.DEFAULT:
+            self._j_rocks_db_state_backend.setPredefinedOptions(JPredefinedOptions.DEFAULT)
+        elif options == PredefinedOptions.SPINNING_DISK_OPTIMIZED:
+            self._j_rocks_db_state_backend.setPredefinedOptions(
+                JPredefinedOptions.SPINNING_DISK_OPTIMIZED)
+        elif options == PredefinedOptions.SPINNING_DISK_OPTIMIZED_HIGH_MEM:
+            self._j_rocks_db_state_backend.setPredefinedOptions(
+                JPredefinedOptions.SPINNING_DISK_OPTIMIZED_HIGH_MEM)
+        elif options == PredefinedOptions.FLASH_SSD_OPTIMIZED:
+            self._j_rocks_db_state_backend.setPredefinedOptions(
+                JPredefinedOptions.FLASH_SSD_OPTIMIZED)
+        else:
+            raise TypeError("Unsupported options: %s, the supported options are: "
+                            "PredefinedOptions.DEFAULT, PredefinedOptions.SPINNING_DISK_OPTIMIZED,"
+                            " PredefinedOptions.SPINNING_DISK_OPTIMIZED_HIGH_MEM and "
+                            "PredefinedOptions.FLASH_SSD_OPTIMIZED")
+
+    def get_predefined_options(self):
+        """
+        Gets the current predefined options for RocksDB.
+        The default options (if nothing was set via :func:`setPredefinedOptions`)
+        are :data:`PredefinedOptions.DEFAULT`.
+
+        If user-configured options within ``RocksDBConfigurableOptions`` is set (through
+        flink-conf.yaml) or a user-defined options factory is set (via :func:`setOptions`),
+        then the options from the factory are applied on top of the predefined and customized
+        options.
+
+        :return: Current predefined options.
+        """
+        j_predefined_options = self._j_rocks_db_state_backend.getPredefinedOptions()
+        gateway = get_gateway()
+        JPredefinedOptions = gateway.jvm.org.apache.flink.contrib.streaming.state.PredefinedOptions
+        if j_predefined_options == JPredefinedOptions.DEFAULT:
+            return PredefinedOptions.DEFAULT
+        elif j_predefined_options == JPredefinedOptions.FLASH_SSD_OPTIMIZED:
+            return PredefinedOptions.FLASH_SSD_OPTIMIZED
+        elif j_predefined_options == JPredefinedOptions.SPINNING_DISK_OPTIMIZED:
+            return PredefinedOptions.SPINNING_DISK_OPTIMIZED
+        elif j_predefined_options == JPredefinedOptions.SPINNING_DISK_OPTIMIZED_HIGH_MEM:
+            return PredefinedOptions.SPINNING_DISK_OPTIMIZED_HIGH_MEM
+        else:
+            raise Exception("Unsupported java options: %s" % j_predefined_options)
+
+    def set_options(self, options_factory_class_name):
+        """
+        Sets ``org.rocksdb.Options`` for the RocksDB instances.
+        Because the options are not serializable and hold native code references,
+        they must be specified through a factory.
+
+        The options created by the factory here are applied on top of the pre-defined
+        options profile selected via :func:`set_predefined_options`.
+        If the pre-defined options profile is the default (:data:`PredefinedOptions.DEFAULT`),
+        then the factory fully controls the RocksDB options.
+
+        :param options_factory_class_name: The fully-qualified class name of the options
+                                           factory in Java that lazily creates the RocksDB options.
+                                           The options factory must have a default constructor.
+        """
+        gateway = get_gateway()
+        JOptionsFactory = gateway.jvm.org.apache.flink.contrib.streaming.state.OptionsFactory
+        j_options_factory_clz = load_java_class(options_factory_class_name)
+        if not get_java_class(JOptionsFactory).isAssignableFrom(j_options_factory_clz):
+            raise ValueError("The input class not implements OptionsFactory.")
+        self._j_rocks_db_state_backend.setOptions(j_options_factory_clz.newInstance())
+
+    def get_options(self):
+        """
+        Gets the fully-qualified class name of the options factory in Java that lazily creates
+        the RocksDB options.
+
+        :return: The fully-qualified class name of the options factory in Java.
+        """
+        j_options_factory = self._j_rocks_db_state_backend.getOptions()
+        if j_options_factory is not None:
+            return j_options_factory.getClass().getName()
+        else:
+            return None
+
+    def get_number_of_transfering_threads(self):
+        """
+        Gets the number of threads used to transfer files while snapshotting/restoring.
+
+        :return: The number of threads used to transfer files while snapshotting/restoring.
+        """
+        return self._j_rocks_db_state_backend.getNumberOfTransferingThreads()
+
+    def set_number_of_transfering_threads(self, number_of_transfering_threads):
+        """
+        Sets the number of threads used to transfer files while snapshotting/restoring.
+
+        :param number_of_transfering_threads: The number of threads used to transfer files while
+                                              snapshotting/restoring.
+        """
+        self._j_rocks_db_state_backend.setNumberOfTransferingThreads(number_of_transfering_threads)
+
+    def __str__(self):
+        return self._j_rocks_db_state_backend.toString()
+
+
+class PredefinedOptions(object):
+    """
+    The :class:`PredefinedOptions` are configuration settings for the :class:`RocksDBStateBackend`.
+    The various pre-defined choices are configurations that have been empirically
+    determined to be beneficial for performance under different settings.
+
+    Some of these settings are based on experiments by the Flink community, some follow
+    guides from the RocksDB project.
+
+    :data:`DEFAULT`:
+
+    Default options for all settings, except that writes are not forced to the
+    disk.
+
+    ..note::
+        Because Flink does not rely on RocksDB data on disk for recovery,
+        there is no need to sync data to stable storage.
+
+    :data:`SPINNING_DISK_OPTIMIZED`:
+
+    Pre-defined options for regular spinning hard disks.
+
+    This constant configures RocksDB with some options that lead empirically
+    to better performance when the machines executing the system use
+    regular spinning hard disks.
+
+    The following options are set:
+
+    - setCompactionStyle(CompactionStyle.LEVEL)
+    - setLevelCompactionDynamicLevelBytes(true)
+    - setIncreaseParallelism(4)
+    - setUseFsync(false)
+    - setDisableDataSync(true)
+    - setMaxOpenFiles(-1)
+
+    .. note::
+        Because Flink does not rely on RocksDB data on disk for recovery,
+        there is no need to sync data to stable storage.
+
+    :data:`SPINNING_DISK_OPTIMIZED_HIGH_MEM`:
+
+    Pre-defined options for better performance on regular spinning hard disks,
+    at the cost of a higher memory consumption.
+
+    .. note::
+        These settings will cause RocksDB to consume a lot of memory for
+        block caching and compactions. If you experience out-of-memory problems related to,
+        RocksDB, consider switching back to :data:`SPINNING_DISK_OPTIMIZED`.
+
+    The following options are set:
+
+    - setLevelCompactionDynamicLevelBytes(true)
+    - setTargetFileSizeBase(256 MBytes)
+    - setMaxBytesForLevelBase(1 GByte)
+    - setWriteBufferSize(64 MBytes)
+    - setIncreaseParallelism(4)
+    - setMinWriteBufferNumberToMerge(3)
+    - setMaxWriteBufferNumber(4)
+    - setUseFsync(false)
+    - setMaxOpenFiles(-1)
+    - BlockBasedTableConfig.setBlockCacheSize(256 MBytes)
+    - BlockBasedTableConfigsetBlockSize(128 KBytes)
+
+    .. note::
+        Because Flink does not rely on RocksDB data on disk for recovery,
+        there is no need to sync data to stable storage.
+
+    :data:`FLASH_SSD_OPTIMIZED`:
+
+    Pre-defined options for Flash SSDs.
+
+    This constant configures RocksDB with some options that lead empirically
+    to better performance when the machines executing the system use SSDs.
+
+    The following options are set:
+
+    - setIncreaseParallelism(4)
+    - setUseFsync(false)
+    - setDisableDataSync(true)
+    - setMaxOpenFiles(-1)
+
+    .. note::
+        Because Flink does not rely on RocksDB data on disk for recovery,
+        there is no need to sync data to stable storage.
+    """
+    DEFAULT = 0
+    SPINNING_DISK_OPTIMIZED = 1
+    SPINNING_DISK_OPTIMIZED_HIGH_MEM = 2
+    FLASH_SSD_OPTIMIZED = 3
+
+
+class CustomStateBackend(StateBackend):
+    """
+    A wrapper of customized java state backend created from the provided `StateBackendFactory`.
+    """
+
+    def __init__(self, j_custom_state_backend):
+        super(CustomStateBackend, self).__init__(j_custom_state_backend)

--- a/flink-python/pyflink/common/tests/__init__.py
+++ b/flink-python/pyflink/common/tests/__init__.py
@@ -1,0 +1,17 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################

--- a/flink-python/pyflink/common/tests/test_check_point_config.py
+++ b/flink-python/pyflink/common/tests/test_check_point_config.py
@@ -1,0 +1,133 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from pyflink.common import CheckpointConfig, CheckpointingMode, ExternalizedCheckpointCleanup
+from pyflink.java_gateway import get_gateway
+from pyflink.streaming import StreamExecutionEnvironment
+from pyflink.testing.test_case_utils import PyFlinkTestCase
+
+
+class CheckpointConfigTests(PyFlinkTestCase):
+
+    def setUp(self):
+        self.env = StreamExecutionEnvironment\
+            .get_execution_environment()
+
+        self.checkpoint_config = self.env.get_checkpoint_config()
+
+    def test_constant(self):
+        gateway = get_gateway()
+        JCheckpointConfig = gateway.jvm.org.apache.flink.streaming.api.environment.CheckpointConfig
+
+        assert CheckpointConfig.DEFAULT_MAX_CONCURRENT_CHECKPOINTS == \
+            JCheckpointConfig.DEFAULT_MAX_CONCURRENT_CHECKPOINTS
+
+        assert CheckpointConfig.DEFAULT_MIN_PAUSE_BETWEEN_CHECKPOINTS == \
+            JCheckpointConfig.DEFAULT_MIN_PAUSE_BETWEEN_CHECKPOINTS
+
+        assert CheckpointConfig.DEFAULT_TIMEOUT == JCheckpointConfig.DEFAULT_TIMEOUT
+
+        assert CheckpointConfig.DEFAULT_MODE == \
+            CheckpointingMode._from_j_checkpointing_mode(JCheckpointConfig.DEFAULT_MODE)
+
+    def test_is_checkpointing_enabled(self):
+
+        assert self.checkpoint_config.is_checkpointing_enabled() is False
+
+        self.env.enable_checkpointing(1000)
+
+        assert self.checkpoint_config.is_checkpointing_enabled() is True
+
+    def test_get_set_checkpointing_mode(self):
+
+        assert self.checkpoint_config.get_checkpointing_mode() == CheckpointingMode.EXACTLY_ONCE
+
+        self.checkpoint_config.set_checkpointing_mode(CheckpointingMode.AT_LEAST_ONCE)
+
+        assert self.checkpoint_config.get_checkpointing_mode() == CheckpointingMode.AT_LEAST_ONCE
+
+        self.checkpoint_config.set_checkpointing_mode(CheckpointingMode.EXACTLY_ONCE)
+
+        assert self.checkpoint_config.get_checkpointing_mode() == CheckpointingMode.EXACTLY_ONCE
+
+    def test_get_set_checkpoint_interval(self):
+
+        assert self.checkpoint_config.get_checkpoint_interval() == -1
+
+        self.checkpoint_config.set_checkpoint_interval(1000)
+
+        assert self.checkpoint_config.get_checkpoint_interval() == 1000
+
+    def test_get_set_checkpoint_timeout(self):
+
+        assert self.checkpoint_config.get_checkpoint_timeout() == 600000
+
+        self.checkpoint_config.set_checkpoint_timeout(300000)
+
+        assert self.checkpoint_config.get_checkpoint_timeout() == 300000
+
+    def test_get_set_min_pause_between_checkpoints(self):
+
+        assert self.checkpoint_config.get_min_pause_between_checkpoints() == 0
+
+        self.checkpoint_config.set_min_pause_between_checkpoints(100000)
+
+        assert self.checkpoint_config.get_min_pause_between_checkpoints() == 100000
+
+    def test_get_set_max_concurrent_checkpoints(self):
+
+        assert self.checkpoint_config.get_max_concurrent_checkpoints() == 1
+
+        self.checkpoint_config.set_max_concurrent_checkpoints(2)
+
+        assert self.checkpoint_config.get_max_concurrent_checkpoints() == 2
+
+    def test_get_set_fail_on_checkpointing_errors(self):
+
+        assert self.checkpoint_config.is_fail_on_checkpointing_errors() is True
+
+        self.checkpoint_config.set_fail_on_checkpointing_errors(False)
+
+        assert self.checkpoint_config.is_fail_on_checkpointing_errors() is False
+
+    def test_get_set_externalized_checkpoints_cleanup(self):
+
+        assert self.checkpoint_config.is_externalized_checkpoints_enabled() is False
+
+        assert self.checkpoint_config.get_externalized_checkpoint_cleanup() is None
+
+        self.checkpoint_config.enable_externalized_checkpoints(
+            ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION)
+
+        assert self.checkpoint_config.is_externalized_checkpoints_enabled() is True
+
+        assert self.checkpoint_config.get_externalized_checkpoint_cleanup() == \
+            ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION
+
+        self.checkpoint_config.enable_externalized_checkpoints(
+            ExternalizedCheckpointCleanup.DELETE_ON_CANCELLATION)
+
+        assert self.checkpoint_config.get_externalized_checkpoint_cleanup() == \
+            ExternalizedCheckpointCleanup.DELETE_ON_CANCELLATION
+
+    def test_get_set_prefer_checkpoint_for_recovery(self):
+
+        assert self.checkpoint_config.is_prefer_checkpoint_for_recovery() is False
+
+        self.checkpoint_config.set_prefer_checkpoint_for_recovery(True)
+
+        assert self.checkpoint_config.is_prefer_checkpoint_for_recovery() is True

--- a/flink-python/pyflink/common/tests/test_execution_config.py
+++ b/flink-python/pyflink/common/tests/test_execution_config.py
@@ -1,0 +1,306 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from pyflink.batch import ExecutionEnvironment
+from pyflink.common import (ExecutionConfig, RestartStrategies, ExecutionMode,
+                            InputDependencyConstraint)
+from pyflink.java_gateway import get_gateway
+from pyflink.testing.test_case_utils import PyFlinkTestCase
+
+
+class ExecutionConfigTests(PyFlinkTestCase):
+
+    def setUp(self):
+        self.env = ExecutionEnvironment.get_execution_environment()
+        self.execution_config = self.env.get_config()
+
+    def test_constant(self):
+        gateway = get_gateway()
+        JExecutionConfig = gateway.jvm.org.apache.flink.api.common.ExecutionConfig
+
+        assert ExecutionConfig.PARALLELISM_DEFAULT == JExecutionConfig.PARALLELISM_DEFAULT
+        assert ExecutionConfig.PARALLELISM_UNKNOWN == JExecutionConfig.PARALLELISM_UNKNOWN
+
+    def test_get_set_closure_cleaner(self):
+
+        assert self.execution_config.is_closure_cleaner_enabled() is True
+
+        self.execution_config.disable_closure_cleaner()
+
+        assert self.execution_config.is_closure_cleaner_enabled() is False
+
+        self.execution_config.enable_closure_cleaner()
+
+        assert self.execution_config.is_closure_cleaner_enabled() is True
+
+    def test_get_set_auto_watermark_interval(self):
+
+        assert self.execution_config.get_auto_watermark_interval() == 0
+
+        self.execution_config.set_auto_watermark_interval(1000)
+
+        assert self.execution_config.get_auto_watermark_interval() == 1000
+
+    def test_get_set_latency_tracking_interval(self):
+
+        assert self.execution_config.get_latency_tracking_interval() == 0
+
+        assert self.execution_config.is_latency_tracking_configured() is False
+
+        self.execution_config.set_latency_tracking_interval(1000)
+
+        assert self.execution_config.get_latency_tracking_interval() == 1000
+
+        assert self.execution_config.is_latency_tracking_configured() is True
+
+    def test_get_set_parallelism(self):
+
+        self.execution_config.set_parallelism(8)
+
+        assert self.execution_config.get_parallelism() == 8
+
+        self.execution_config.set_parallelism(4)
+
+        assert self.execution_config.get_parallelism() == 4
+
+    def test_get_set_max_parallelism(self):
+
+        self.execution_config.set_max_parallelism(12)
+
+        assert self.execution_config.get_max_parallelism() == 12
+
+        self.execution_config.set_max_parallelism(16)
+
+        assert self.execution_config.get_max_parallelism() == 16
+
+    def test_get_set_task_cancellation_interval(self):
+
+        assert self.execution_config.get_task_cancellation_interval() == -1
+
+        self.execution_config.set_task_cancellation_interval(1000)
+
+        assert self.execution_config.get_task_cancellation_interval() == 1000
+
+    def test_get_set_task_cancellation_timeout(self):
+
+        assert self.execution_config.get_task_cancellation_timeout() == -1
+
+        self.execution_config.set_task_cancellation_timeout(3000)
+
+        assert self.execution_config.get_task_cancellation_timeout() == 3000
+
+    def test_get_set_restart_strategy(self):
+
+        self.execution_config.set_restart_strategy(RestartStrategies.no_restart())
+
+        assert self.execution_config.get_restart_strategy() == RestartStrategies.no_restart()
+
+        self.execution_config.set_restart_strategy(
+            RestartStrategies.failure_rate_restart(5, 10000, 5000))
+
+        assert isinstance(self.execution_config.get_restart_strategy(),
+                          RestartStrategies.FailureRateRestartStrategyConfiguration)
+
+        self.execution_config.set_restart_strategy(RestartStrategies.fixed_delay_restart(4, 10000))
+
+        assert isinstance(self.execution_config.get_restart_strategy(),
+                          RestartStrategies.FixedDelayRestartStrategyConfiguration)
+
+        self.execution_config.set_restart_strategy(RestartStrategies.fall_back_restart())
+
+        assert self.execution_config.get_restart_strategy() == \
+            RestartStrategies.fall_back_restart()
+
+    def test_get_set_execution_mode(self):
+
+        self.execution_config.set_execution_mode(ExecutionMode.BATCH)
+
+        assert self.execution_config.get_execution_mode() == ExecutionMode.BATCH
+
+        self.execution_config.set_execution_mode(ExecutionMode.PIPELINED)
+
+        assert self.execution_config.get_execution_mode() == ExecutionMode.PIPELINED
+
+        self.execution_config.set_execution_mode(ExecutionMode.BATCH_FORCED)
+
+        assert self.execution_config.get_execution_mode() == ExecutionMode.BATCH_FORCED
+
+        self.execution_config.set_execution_mode(ExecutionMode.PIPELINED_FORCED)
+
+        assert self.execution_config.get_execution_mode() == ExecutionMode.PIPELINED_FORCED
+
+    def test_get_set_default_input_dependency_constraint(self):
+
+        self.execution_config.set_default_input_dependency_constraint(
+            InputDependencyConstraint.ALL)
+
+        assert self.execution_config.get_default_input_dependency_constraint() == \
+            InputDependencyConstraint.ALL
+
+        self.execution_config.set_default_input_dependency_constraint(
+            InputDependencyConstraint.ANY)
+
+        assert self.execution_config.get_default_input_dependency_constraint() == \
+            InputDependencyConstraint.ANY
+
+    def test_disable_enable_force_kryo(self):
+
+        self.execution_config.disable_force_kryo()
+
+        assert self.execution_config.is_force_kryo_enabled() is False
+
+        self.execution_config.enable_force_kryo()
+
+        assert self.execution_config.is_force_kryo_enabled() is True
+
+    def test_disable_enable_generic_types(self):
+
+        self.execution_config.disable_generic_types()
+
+        assert self.execution_config.has_generic_types_disabled() is True
+
+        self.execution_config.enable_generic_types()
+
+        assert self.execution_config.has_generic_types_disabled() is False
+
+    def test_disable_enable_auto_generated_uids(self):
+
+        self.execution_config.disable_auto_generated_uids()
+
+        assert self.execution_config.has_auto_generated_uids_enabled() is False
+
+        self.execution_config.enable_auto_generated_uids()
+
+        assert self.execution_config.has_auto_generated_uids_enabled() is True
+
+    def test_disable_enable_force_avro(self):
+
+        self.execution_config.disable_force_avro()
+
+        assert self.execution_config.is_force_avro_enabled() is False
+
+        self.execution_config.enable_force_avro()
+
+        assert self.execution_config.is_force_avro_enabled() is True
+
+    def test_disable_enable_object_reuse(self):
+
+        self.execution_config.disable_object_reuse()
+
+        assert self.execution_config.is_object_reuse_enabled() is False
+
+        self.execution_config.enable_object_reuse()
+
+        assert self.execution_config.is_object_reuse_enabled() is True
+
+    def test_disable_enable_sysout_logging(self):
+
+        self.execution_config.disable_sysout_logging()
+
+        assert self.execution_config.is_sysout_logging_enabled() is False
+
+        self.execution_config.enable_sysout_logging()
+
+        assert self.execution_config.is_sysout_logging_enabled() is True
+
+    def test_get_set_global_job_parameters(self):
+
+        self.execution_config.set_global_job_parameters({"hello": "world"})
+
+        assert self.execution_config.get_global_job_parameters() == {"hello": "world"}
+
+    def test_add_default_kryo_serializer(self):
+
+        self.execution_config.add_default_kryo_serializer(
+            "org.apache.flink.runtime.state.StateBackendTestBase$TestPojo",
+            "org.apache.flink.runtime.state.StateBackendTestBase$CustomKryoTestSerializer")
+
+        dict = self.execution_config.get_default_kryo_serializer_classes()
+
+        assert dict == {'org.apache.flink.runtime.state.StateBackendTestBase$TestPojo':
+                        'org.apache.flink.runtime.state'
+                        '.StateBackendTestBase$CustomKryoTestSerializer'}
+
+    def test_register_type_with_kryo_serializer(self):
+
+        self.execution_config.register_type_with_kryo_serializer(
+            "org.apache.flink.runtime.state.StateBackendTestBase$TestPojo",
+            "org.apache.flink.runtime.state.StateBackendTestBase$CustomKryoTestSerializer")
+
+        dict = self.execution_config.get_registered_types_with_kryo_serializer_classes()
+
+        assert dict == {'org.apache.flink.runtime.state.StateBackendTestBase$TestPojo':
+                        'org.apache.flink.runtime.state'
+                        '.StateBackendTestBase$CustomKryoTestSerializer'}
+
+    def test_register_pojo_type(self):
+
+        self.execution_config.register_pojo_type(
+            "org.apache.flink.runtime.state.StateBackendTestBase$TestPojo")
+
+        type_list = self.execution_config.get_registered_pojo_types()
+
+        assert type_list == ["org.apache.flink.runtime.state.StateBackendTestBase$TestPojo"]
+
+    def test_register_kryo_type(self):
+
+        self.execution_config.register_kryo_type(
+            "org.apache.flink.runtime.state.StateBackendTestBase$TestPojo")
+
+        type_list = self.execution_config.get_registered_kryo_types()
+
+        assert type_list == ["org.apache.flink.runtime.state.StateBackendTestBase$TestPojo"]
+
+    def test_auto_type_registration(self):
+
+        assert self.execution_config.is_auto_type_registration_disabled() is False
+
+        self.execution_config.disable_auto_type_registration()
+
+        assert self.execution_config.is_auto_type_registration_disabled() is True
+
+    def test_get_set_use_snapshot_compression(self):
+
+        self.execution_config.set_use_snapshot_compression(False)
+
+        assert self.execution_config.is_use_snapshot_compression() is False
+
+        self.execution_config.set_use_snapshot_compression(True)
+
+        assert self.execution_config.is_use_snapshot_compression() is True
+
+    def test_equals_and_hash(self):
+
+        config1 = ExecutionEnvironment.get_execution_environment().get_config()
+
+        config2 = ExecutionEnvironment.get_execution_environment().get_config()
+
+        assert config1 == config2
+
+        assert hash(config1) == hash(config2)
+
+        config1.set_parallelism(12)
+
+        assert config1 != config2
+
+        assert hash(config1) != hash(config2)
+
+        config2.set_parallelism(12)
+
+        assert config1 == config2
+
+        assert hash(config1) == hash(config2)

--- a/flink-python/pyflink/common/tests/test_state_backend.py
+++ b/flink-python/pyflink/common/tests/test_state_backend.py
@@ -1,0 +1,224 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from pyflink.common import (MemoryStateBackend, FsStateBackend, RocksDBStateBackend,
+                            PredefinedOptions)
+from pyflink.java_gateway import get_gateway
+from pyflink.testing.test_case_utils import PyFlinkTestCase
+
+
+class MemoryStateBackendTests(PyFlinkTestCase):
+
+    def test_constant(self):
+        gateway = get_gateway()
+        JMemoryStateBackend = gateway.jvm.org.apache.flink.runtime.state.memory \
+            .MemoryStateBackend
+
+        assert MemoryStateBackend.DEFAULT_MAX_STATE_SIZE == \
+            JMemoryStateBackend.DEFAULT_MAX_STATE_SIZE
+
+    def test_create_memory_state_backend(self):
+
+        MemoryStateBackend("file://var/checkpoints/")
+
+        MemoryStateBackend("file://var/checkpoints/", "file://var/savepoints/")
+
+        MemoryStateBackend(
+            "file://var/checkpoints/", "file://var/savepoints/", 10000000)
+
+        MemoryStateBackend(
+            "file://var/checkpoints/", "file://var/savepoints/", 10000000, True)
+
+        MemoryStateBackend(
+            "file://var/checkpoints/", "file://var/savepoints/", 10000000, False)
+
+    def test_configure(self):
+
+        state_backend = MemoryStateBackend()
+
+        assert state_backend.is_using_asynchronous_snapshots() is True
+
+        state_backend = state_backend.configure({"state.backend.async": "False"})
+
+        assert state_backend.is_using_asynchronous_snapshots() is False
+
+    def test_is_using_asynchronous_snapshots(self):
+
+        state_backend = MemoryStateBackend()
+
+        assert state_backend.is_using_asynchronous_snapshots() is True
+
+        state_backend = MemoryStateBackend(using_asynchronous_snapshots=True)
+
+        assert state_backend.is_using_asynchronous_snapshots() is True
+
+        state_backend = MemoryStateBackend(using_asynchronous_snapshots=False)
+
+        assert state_backend.is_using_asynchronous_snapshots() is False
+
+    def test_get_max_state_size(self):
+
+        state_backend = MemoryStateBackend()
+
+        assert state_backend.get_max_state_size() == MemoryStateBackend.DEFAULT_MAX_STATE_SIZE
+
+        state_backend = MemoryStateBackend(max_state_size=50000)
+
+        assert state_backend.get_max_state_size() == 50000
+
+
+class FsStateBackendTests(PyFlinkTestCase):
+
+    def test_create_fs_state_backend(self):
+
+        FsStateBackend("file://var/checkpoints/")
+
+        FsStateBackend("file://var/checkpoints/", "file://var/savepoints/")
+
+        FsStateBackend("file://var/checkpoints/", "file://var/savepoints/", 2048)
+
+        FsStateBackend(
+            "file://var/checkpoints/", "file://var/savepoints/", 2048, True)
+
+        FsStateBackend(
+            "file://var/checkpoints/", "file://var/savepoints/", 2048, False)
+
+    def test_configure(self):
+
+        state_backend = FsStateBackend("file://var/checkpoints/")
+
+        assert state_backend.is_using_asynchronous_snapshots() is True
+
+        state_backend = state_backend.configure({"state.backend.async": "False"})
+
+        assert state_backend.is_using_asynchronous_snapshots() is False
+
+    def test_get_min_file_size_threshold(self):
+
+        state_backend = FsStateBackend("file://var/checkpoints/")
+
+        assert state_backend.get_min_file_size_threshold() == 1024
+
+        state_backend = FsStateBackend("file://var/checkpoints/", file_state_size_threshold=2048)
+
+        assert state_backend.get_min_file_size_threshold() == 2048
+
+    def test_get_checkpoint_path(self):
+
+        state_backend = FsStateBackend("file://var/checkpoints/")
+
+        assert state_backend.get_checkpoint_path() == "file://var/checkpoints"
+
+
+class RocksDBStateBackendTests(PyFlinkTestCase):
+
+    def test_create_rocks_db_state_backend(self):
+
+        RocksDBStateBackend("file://var/checkpoints/")
+
+        RocksDBStateBackend("file://var/checkpoints/", True)
+
+        RocksDBStateBackend("file://var/checkpoints/", False)
+
+        RocksDBStateBackend(
+            checkpoint_stream_backend=FsStateBackend("file://var/checkpoints/"))
+
+    def test_configure(self):
+
+        state_backend = RocksDBStateBackend("file://var/checkpoints/")
+
+        assert state_backend.is_incremental_checkpoints_enabled() is False
+
+        state_backend = state_backend.configure({"state.backend.incremental": "True"})
+
+        assert state_backend.is_incremental_checkpoints_enabled() is True
+
+    def test_get_checkpoint_backend(self):
+
+        state_backend = RocksDBStateBackend("file://var/checkpoints/")
+
+        checkpoint_backend = state_backend.get_checkpoint_backend()
+
+        assert isinstance(checkpoint_backend, FsStateBackend)
+        assert checkpoint_backend.get_checkpoint_path() == "file://var/checkpoints"
+
+    def test_get_set_db_storage_paths(self):
+
+        state_backend = RocksDBStateBackend("file://var/checkpoints/")
+
+        state_backend.set_db_storage_paths("file://var/db_storage_dir1/",
+                                           "file://var/db_storage_dir2/",
+                                           "file://var/db_storage_dir3/")
+
+        assert state_backend.get_db_storage_paths() == ['/db_storage_dir1',
+                                                        '/db_storage_dir2',
+                                                        '/db_storage_dir3']
+
+    def test_get_set_ttl_compaction_filter(self):
+
+        state_backend = RocksDBStateBackend("file://var/checkpoints/")
+
+        assert state_backend.is_ttl_compaction_filter_enabled() is False
+
+        state_backend.enable_ttl_compaction_filter()
+
+        assert state_backend.is_ttl_compaction_filter_enabled() is True
+
+    def test_get_set_predefined_options(self):
+
+        state_backend = RocksDBStateBackend("file://var/checkpoints/")
+
+        assert state_backend.get_predefined_options() == PredefinedOptions.DEFAULT
+
+        state_backend.set_predefined_options(PredefinedOptions.SPINNING_DISK_OPTIMIZED_HIGH_MEM)
+
+        assert state_backend.get_predefined_options() == \
+            PredefinedOptions.SPINNING_DISK_OPTIMIZED_HIGH_MEM
+
+        state_backend.set_predefined_options(PredefinedOptions.SPINNING_DISK_OPTIMIZED)
+
+        assert state_backend.get_predefined_options() == PredefinedOptions.SPINNING_DISK_OPTIMIZED
+
+        state_backend.set_predefined_options(PredefinedOptions.FLASH_SSD_OPTIMIZED)
+
+        assert state_backend.get_predefined_options() == PredefinedOptions.FLASH_SSD_OPTIMIZED
+
+        state_backend.set_predefined_options(PredefinedOptions.DEFAULT)
+
+        assert state_backend.get_predefined_options() == PredefinedOptions.DEFAULT
+
+    def test_get_set_options(self):
+
+        state_backend = RocksDBStateBackend("file://var/checkpoints/")
+
+        assert state_backend.get_options() is None
+
+        state_backend.set_options(
+            "org.apache.flink.contrib.streaming.state.DefaultConfigurableOptionsFactory")
+
+        assert state_backend.get_options() == \
+            "org.apache.flink.contrib.streaming.state.DefaultConfigurableOptionsFactory"
+
+    def test_get_set_number_of_transfering_threads(self):
+
+        state_backend = RocksDBStateBackend("file://var/checkpoints/")
+
+        assert state_backend.get_number_of_transfering_threads() == 1
+
+        state_backend.set_number_of_transfering_threads(4)
+
+        assert state_backend.get_number_of_transfering_threads() == 4

--- a/flink-python/pyflink/common/time_characteristic.py
+++ b/flink-python/pyflink/common/time_characteristic.py
@@ -1,0 +1,83 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+__all__ = ['TimeCharacteristic']
+
+
+class TimeCharacteristic(object):
+    """
+    The time characteristic defines how the system determines time for time-dependent
+    order and operations that depend on time (such as time windows).
+
+    :data:`ProcessingTime`:
+
+    Processing time for operators means that the operator uses the system clock of the machine
+    to determine the current time of the data stream. Processing-time windows trigger based
+    on wall-clock time and include whatever elements happen to have arrived at the operator at
+    that point in time.
+
+    Using processing time for window operations results in general in quite non-deterministic
+    results, because the contents of the windows depends on the speed in which elements arrive.
+    It is, however, the cheapest method of forming windows and the method that introduces the
+    least latency.
+
+    :data:`IngestionTime`:
+
+    Ingestion time means that the time of each individual element in the stream is determined
+    when the element enters the Flink streaming data flow. Operations like windows group the
+    elements based on that time, meaning that processing speed within the streaming dataflow
+    does not affect windowing, but only the speed at which sources receive elements.
+
+    Ingestion time is often a good compromise between processing time and event time.
+    It does not need any special manual form of watermark generation, and events are typically
+    not too much out-or-order when they arrive at operators; in fact, out-of-orderness can
+    only be introduced by streaming shuffles or split/join/union operations. The fact that
+    elements are not very much out-of-order means that the latency increase is moderate,
+    compared to event time.
+
+    :data:`EventTime`:
+
+    Event time means that the time of each individual element in the stream (also called event)
+    is determined by the event's individual custom timestamp. These timestamps either exist in
+    the elements from before they entered the Flink streaming dataflow, or are user-assigned at
+    the sources. The big implication of this is that it allows for elements to arrive in the
+    sources and in all operators out of order, meaning that elements with earlier timestamps may
+    arrive after elements with later timestamps.
+
+    Operators that window or order data with respect to event time must buffer data until they
+    can be sure that all timestamps for a certain time interval have been received. This is
+    handled by the so called "time watermarks".
+
+    Operations based on event time are very predictable - the result of windowing operations
+    is typically identical no matter when the window is executed and how fast the streams
+    operate. At the same time, the buffering and tracking of event time is also costlier than
+    operating with processing time, and typically also introduces more latency. The amount of
+    extra cost depends mostly on how much out of order the elements arrive, i.e., how long the
+    time span between the arrival of early and late elements is. With respect to the
+    "time watermarks", this means that the cost typically depends on how early or late the
+    watermarks can be generated for their timestamp.
+
+    In relation to :data:`IngestionTime`, the event time is similar, but refers the the
+    event's original time, rather than the time assigned at the data source. Practically, that
+    means that event time has generally more meaning, but also that it takes longer to determine
+    that all elements for a certain time have arrived.
+    """
+
+    ProcessingTime = 0
+    IngestionTime = 1
+    EventTime = 2

--- a/flink-python/pyflink/java_gateway.py
+++ b/flink-python/pyflink/java_gateway.py
@@ -123,3 +123,4 @@ def import_flink_view(gateway):
     java_import(gateway.jvm, "org.apache.flink.api.java.ExecutionEnvironment")
     java_import(gateway.jvm,
                 "org.apache.flink.streaming.api.environment.StreamExecutionEnvironment")
+    java_import(gateway.jvm, "org.apache.flink.api.common.restartstrategy.RestartStrategies")

--- a/flink-python/pyflink/streaming/__init__.py
+++ b/flink-python/pyflink/streaming/__init__.py
@@ -15,25 +15,6 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+from pyflink.streaming.stream_execution_environment import StreamExecutionEnvironment
 
-from pyflink.java_gateway import get_gateway
-
-
-def to_jarray(j_type, arr):
-    """
-    Convert python list to java type array
-
-    :param j_type: java type of element in array
-    :param arr: python type list
-    """
-    gateway = get_gateway()
-    j_arr = gateway.new_array(j_type, len(arr))
-    for i in range(0, len(arr)):
-        j_arr[i] = arr[i]
-    return j_arr
-
-
-def load_java_class(class_name):
-    gateway = get_gateway()
-    context_classloader = gateway.jvm.Thread.currentThread().getContextClassLoader()
-    return context_classloader.loadClass(class_name)
+__all__ = ['StreamExecutionEnvironment']

--- a/flink-python/pyflink/streaming/stream_execution_environment.py
+++ b/flink-python/pyflink/streaming/stream_execution_environment.py
@@ -1,0 +1,236 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from pyflink.java_gateway import get_gateway
+from pyflink.util.utils import load_java_class
+
+__all__ = ['StreamExecutionEnvironment']
+
+
+class StreamExecutionEnvironment(object):
+    """
+    The StreamExecutionEnvironment is the context in which a streaming program is executed. A
+    *LocalStreamEnvironment* will cause execution in the attached JVM, a
+    *RemoteStreamEnvironment* will cause execution on a remote setup.
+
+    The environment provides methods to control the job execution (such as setting the parallelism
+    or the fault tolerance/checkpointing parameters) and to interact with the outside world (data
+    access).
+    """
+
+    def __init__(self, j_stream_execution_environment):
+        self._j_stream_execution_environment = j_stream_execution_environment
+
+    def set_parallelism(self, parallelism):
+        """
+        Sets the parallelism for operations executed through this environment.
+        Setting a parallelism of x here will cause all operators (such as map,
+        batchReduce) to run with x parallel instances. This method overrides the
+        default parallelism for this environment. The
+        *LocalStreamEnvironment* uses by default a value equal to the
+        number of hardware contexts (CPU cores / threads). When executing the
+        program via the command line client from a JAR file, the default degree
+        of parallelism is the one configured for that setup.
+
+        :param parallelism: The parallelism.
+        :return: This object.
+        """
+        self._j_stream_execution_environment = \
+            self._j_stream_execution_environment.setParallelism(parallelism)
+        return self
+
+    def set_max_parallelism(self, max_parallelism):
+        """
+        Sets the maximum degree of parallelism defined for the program. The upper limit (inclusive)
+        is 32767.
+
+        The maximum degree of parallelism specifies the upper limit for dynamic scaling. It also
+        defines the number of key groups used for partitioned state.
+
+        :param max_parallelism: Maximum degree of parallelism to be used for the program,
+                                with 0 < maxParallelism <= 2^15 - 1.
+        :return: This object.
+        """
+        self._j_stream_execution_environment = \
+            self._j_stream_execution_environment.setMaxParallelism(max_parallelism)
+        return self
+
+    def get_parallelism(self):
+        """
+        Gets the parallelism with which operation are executed by default.
+        Operations can individually override this value to use a specific
+        parallelism.
+
+        :return: The parallelism used by operations, unless they override that value.
+        """
+        return self._j_stream_execution_environment.getParallelism()
+
+    def get_max_parallelism(self):
+        """
+        Gets the maximum degree of parallelism defined for the program.
+
+        The maximum degree of parallelism specifies the upper limit for dynamic scaling. It also
+        defines the number of key groups used for partitioned state.
+
+        :return: Maximum degree of parallelism.
+        """
+        return self._j_stream_execution_environment.getMaxParallelism()
+
+    def set_buffer_timeout(self, timeout_millis):
+        """
+        Sets the maximum time frequency (milliseconds) for the flushing of the
+        output buffers. By default the output buffers flush frequently to provide
+        low latency and to aid smooth developer experience. Setting the parameter
+        can result in three logical modes:
+
+        - A positive integer triggers flushing periodically by that integer
+        - 0 triggers flushing after every record thus minimizing latency
+        - -1 triggers flushing only when the output buffer is full thus maximizing throughput
+
+        :param timeout_millis: The maximum time between two output flushes.
+        :return: This object.
+        """
+        self._j_stream_execution_environment = \
+            self._j_stream_execution_environment.setBufferTimeout(timeout_millis)
+        return self
+
+    def get_buffer_timeout(self):
+        """
+        Gets the maximum time frequency (milliseconds) for the flushing of the
+        output buffers. For clarification on the extremal values see
+        :func:`set_buffer_timeout`.
+
+        :return: The timeout of the buffer.
+        """
+        return self._j_stream_execution_environment.getBufferTimeout()
+
+    def disable_operation_chaining(self):
+        """
+        Disables operator chaining for streaming operators. Operator chaining
+        allows non-shuffle operations to be co-located in the same thread fully
+        avoiding serialization and de-serialization.
+
+        :return: This object.
+        """
+        self._j_stream_execution_environment = \
+            self._j_stream_execution_environment.disableOperatorChaining()
+        return self
+
+    def is_chaining_enabled(self):
+        """
+        Returns whether operator chaining is enabled.
+
+        :return: True if chaining is enabled, false otherwise.
+        """
+        return self._j_stream_execution_environment.isChainingEnabled()
+
+    def add_default_kryo_serializer(self, type_class_name, serializer_class_name):
+        """
+        Adds a new Kryo default serializer to the Runtime.
+
+        :param type_class_name: The full-qualified java class name of the types serialized with the
+                                given serializer.
+        :param serializer_class_name: The full-qualified java class name of the serializer to use.
+        """
+        type_clz = load_java_class(type_class_name)
+        j_serializer_clz = load_java_class(serializer_class_name)
+        self._j_stream_execution_environment.addDefaultKryoSerializer(type_clz, j_serializer_clz)
+
+    def register_type_with_kryo_serializer(self, type_class_name, serializer_class_name):
+        """
+        Registers the given Serializer via its class as a serializer for the given type at the
+        KryoSerializer.
+
+        :param type_class_name: The full-qualified java class name of the types serialized with
+                                the given serializer.
+        :param serializer_class_name: The full-qualified java class name of the serializer to use.
+        """
+        type_clz = load_java_class(type_class_name)
+        j_serializer_clz = load_java_class(serializer_class_name)
+        self._j_stream_execution_environment.registerTypeWithKryoSerializer(
+            type_clz, j_serializer_clz)
+
+    def register_type(self, type_class_name):
+        """
+        Registers the given type with the serialization stack. If the type is eventually
+        serialized as a POJO, then the type is registered with the POJO serializer. If the
+        type ends up being serialized with Kryo, then it will be registered at Kryo to make
+        sure that only tags are written.
+
+        :param type_class_name: The full-qualified java class name of the type to register.
+        """
+        type_clz = load_java_class(type_class_name)
+        self._j_stream_execution_environment.registerType(type_clz)
+
+    def get_default_local_parallelism(self):
+        """
+        Gets the default parallelism that will be used for the local execution environment.
+
+        :return: The default local parallelism.
+        """
+        return self._j_stream_execution_environment.getDefaultLocalParallelism()
+
+    def set_default_local_parallelism(self, parallelism):
+        """
+        Sets the default parallelism that will be used for the local execution environment.
+
+        :param parallelism: The parallelism to use as the default local parallelism.
+        """
+        self._j_stream_execution_environment.setDefaultLocalParallelism(parallelism)
+
+    def execute(self, job_name=None):
+        """
+        Triggers the program execution. The environment will execute all parts of
+        the program that have resulted in a "sink" operation. Sink operations are
+        for example printing results or forwarding them to a message queue.
+
+        The program execution will be logged and displayed with the provided name
+
+        :param job_name: Desired name of the job, optional.
+        """
+        if job_name is None:
+            self._j_stream_execution_environment.execute()
+        else:
+            self._j_stream_execution_environment.execute(job_name)
+
+    def get_execution_plan(self):
+        """
+        Creates the plan with which the system will execute the program, and returns it as
+        a String using a JSON representation of the execution data flow graph.
+        Note that this needs to be called, before the plan is executed.
+
+        If the compiler could not be instantiated, or the master could not
+        be contacted to retrieve information relevant to the execution planning,
+        an exception will be thrown.
+
+        :return: The execution plan of the program, as a JSON String.
+        """
+        return self._j_stream_execution_environment.getExecutionPlan()
+
+    @classmethod
+    def get_execution_environment(cls):
+        """
+        Creates an execution environment that represents the context in which the
+        program is currently executed. If the program is invoked standalone, this
+        method returns a local execution environment.
+
+        :return: The execution environment of the context in which the program is executed.
+        """
+        gateway = get_gateway()
+        j_stream_exection_environment = gateway.jvm.org.apache.flink.streaming.api.environment\
+            .StreamExecutionEnvironment.getExecutionEnvironment()
+        return StreamExecutionEnvironment(j_stream_exection_environment)

--- a/flink-python/pyflink/streaming/stream_execution_environment.py
+++ b/flink-python/pyflink/streaming/stream_execution_environment.py
@@ -15,6 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+from pyflink.common import ExecutionConfig, RestartStrategies
 from pyflink.java_gateway import get_gateway
 from pyflink.util.utils import load_java_class
 
@@ -34,6 +35,14 @@ class StreamExecutionEnvironment(object):
 
     def __init__(self, j_stream_execution_environment):
         self._j_stream_execution_environment = j_stream_execution_environment
+
+    def get_config(self):
+        """
+        Gets the config object.
+
+        :return: The :class:`~pyflink.common.ExecutionConfig` object.
+        """
+        return ExecutionConfig(self._j_stream_execution_environment.getConfig())
 
     def set_parallelism(self, parallelism):
         """
@@ -137,6 +146,26 @@ class StreamExecutionEnvironment(object):
         :return: True if chaining is enabled, false otherwise.
         """
         return self._j_stream_execution_environment.isChainingEnabled()
+
+    def set_restart_strategy(self, restart_strategy_configuration):
+        """
+        Sets the restart strategy configuration. The configuration specifies which restart strategy
+        will be used for the execution graph in case of a restart.
+
+        :param restart_strategy_configuration: Restart strategy configuration to be set.
+        :return:
+        """
+        self._j_stream_execution_environment.setRestartStrategy(
+            restart_strategy_configuration._j_restart_strategy_configuration)
+
+    def get_restart_strategy(self):
+        """
+        Returns the specified restart strategy configuration.
+
+        :return: The restart strategy configuration to be used.
+        """
+        return RestartStrategies._from_j_restart_strategy(
+            self._j_stream_execution_environment.getRestartStrategy())
 
     def add_default_kryo_serializer(self, type_class_name, serializer_class_name):
         """

--- a/flink-python/pyflink/streaming/tests/__init__.py
+++ b/flink-python/pyflink/streaming/tests/__init__.py
@@ -15,25 +15,3 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-
-from pyflink.java_gateway import get_gateway
-
-
-def to_jarray(j_type, arr):
-    """
-    Convert python list to java type array
-
-    :param j_type: java type of element in array
-    :param arr: python type list
-    """
-    gateway = get_gateway()
-    j_arr = gateway.new_array(j_type, len(arr))
-    for i in range(0, len(arr)):
-        j_arr[i] = arr[i]
-    return j_arr
-
-
-def load_java_class(class_name):
-    gateway = get_gateway()
-    context_classloader = gateway.jvm.Thread.currentThread().getContextClassLoader()
-    return context_classloader.loadClass(class_name)

--- a/flink-python/pyflink/streaming/tests/test_stream_execution_environment.py
+++ b/flink-python/pyflink/streaming/tests/test_stream_execution_environment.py
@@ -20,7 +20,8 @@ import tempfile
 import json
 
 from pyflink.common import (ExecutionConfig, RestartStrategies, CheckpointConfig,
-                            CheckpointingMode, TimeCharacteristic)
+                            CheckpointingMode, MemoryStateBackend, CustomStateBackend,
+                            TimeCharacteristic)
 from pyflink.streaming import StreamExecutionEnvironment
 from pyflink.table import DataTypes, CsvTableSource, CsvTableSink, StreamTableEnvironment
 from pyflink.testing.test_case_utils import PyFlinkTestCase
@@ -139,6 +140,32 @@ class StreamExecutionEnvironmentTests(PyFlinkTestCase):
         mode = self.env.get_checkpointing_mode()
 
         assert mode == CheckpointingMode.AT_LEAST_ONCE
+
+    def test_get_state_backend(self):
+
+        state_backend = self.env.get_state_backend()
+
+        assert state_backend is None
+
+    def test_set_state_backend(self):
+
+        input_backend = MemoryStateBackend()
+
+        self.env.set_state_backend(input_backend)
+
+        output_backend = self.env.get_state_backend()
+
+        assert output_backend._j_memory_state_backend == input_backend._j_memory_state_backend
+
+    def test_set_state_backend_factory(self):
+
+        self.env.set_state_backend_factory(
+            "org.apache.flink.streaming.runtime.tasks"
+            ".StreamTaskTest$TestMemoryStateBackendFactory", {})
+
+        state_backend = self.env.get_state_backend()
+
+        assert isinstance(state_backend, CustomStateBackend)
 
     def test_get_set_stream_time_characteristic(self):
 

--- a/flink-python/pyflink/streaming/tests/test_stream_execution_environment.py
+++ b/flink-python/pyflink/streaming/tests/test_stream_execution_environment.py
@@ -19,7 +19,8 @@ import os
 import tempfile
 import json
 
-from pyflink.common import ExecutionConfig, RestartStrategies
+from pyflink.common import (ExecutionConfig, RestartStrategies, CheckpointConfig,
+                            CheckpointingMode)
 from pyflink.streaming import StreamExecutionEnvironment
 from pyflink.table import DataTypes, CsvTableSource, CsvTableSink, StreamTableEnvironment
 from pyflink.testing.test_case_utils import PyFlinkTestCase
@@ -114,6 +115,30 @@ class StreamExecutionEnvironmentTests(PyFlinkTestCase):
         self.env.disable_operation_chaining()
 
         assert self.env.is_chaining_enabled() is False
+
+    def test_get_checkpoint_config(self):
+
+        checkpoint_config = self.env.get_checkpoint_config()
+
+        assert isinstance(checkpoint_config, CheckpointConfig)
+
+    def test_get_set_checkpoint_interval(self):
+
+        self.env.enable_checkpointing(30000)
+
+        interval = self.env.get_checkpoint_interval()
+
+        assert interval == 30000
+
+    def test_get_set_checkpointing_mode(self):
+        mode = self.env.get_checkpointing_mode()
+        assert mode == CheckpointingMode.EXACTLY_ONCE
+
+        self.env.enable_checkpointing(30000, CheckpointingMode.AT_LEAST_ONCE)
+
+        mode = self.env.get_checkpointing_mode()
+
+        assert mode == CheckpointingMode.AT_LEAST_ONCE
 
     def test_get_execution_plan(self):
         tmp_dir = tempfile.gettempdir()

--- a/flink-python/pyflink/streaming/tests/test_stream_execution_environment.py
+++ b/flink-python/pyflink/streaming/tests/test_stream_execution_environment.py
@@ -19,6 +19,7 @@ import os
 import tempfile
 import json
 
+from pyflink.common import ExecutionConfig, RestartStrategies
 from pyflink.streaming import StreamExecutionEnvironment
 from pyflink.table import DataTypes, CsvTableSource, CsvTableSink, StreamTableEnvironment
 from pyflink.testing.test_case_utils import PyFlinkTestCase
@@ -28,6 +29,11 @@ class StreamExecutionEnvironmentTests(PyFlinkTestCase):
 
     def setUp(self):
         self.env = StreamExecutionEnvironment.get_execution_environment()
+
+    def test_get_config(self):
+        execution_config = self.env.get_config()
+
+        assert isinstance(execution_config, ExecutionConfig)
 
     def test_get_set_parallelism(self):
 
@@ -53,11 +59,25 @@ class StreamExecutionEnvironmentTests(PyFlinkTestCase):
 
         assert parallelism == 8
 
+    def test_set_get_restart_strategy(self):
+
+        self.env.set_restart_strategy(RestartStrategies.no_restart())
+
+        restart_strategy = self.env.get_restart_strategy()
+
+        assert restart_strategy == RestartStrategies.no_restart()
+
     def test_add_default_kryo_serializer(self):
 
         self.env.add_default_kryo_serializer(
             "org.apache.flink.runtime.state.StateBackendTestBase$TestPojo",
             "org.apache.flink.runtime.state.StateBackendTestBase$CustomKryoTestSerializer")
+
+        dict = self.env.get_config().get_default_kryo_serializer_classes()
+
+        assert dict == {'org.apache.flink.runtime.state.StateBackendTestBase$TestPojo':
+                        'org.apache.flink.runtime.state'
+                        '.StateBackendTestBase$CustomKryoTestSerializer'}
 
     def test_register_type_with_kryo_serializer(self):
 
@@ -65,9 +85,19 @@ class StreamExecutionEnvironmentTests(PyFlinkTestCase):
             "org.apache.flink.runtime.state.StateBackendTestBase$TestPojo",
             "org.apache.flink.runtime.state.StateBackendTestBase$CustomKryoTestSerializer")
 
+        dict = self.env.get_config().get_registered_types_with_kryo_serializer_classes()
+
+        assert dict == {'org.apache.flink.runtime.state.StateBackendTestBase$TestPojo':
+                        'org.apache.flink.runtime.state'
+                        '.StateBackendTestBase$CustomKryoTestSerializer'}
+
     def test_register_type(self):
 
         self.env.register_type("org.apache.flink.runtime.state.StateBackendTestBase$TestPojo")
+
+        type_list = self.env.get_config().get_registered_pojo_types()
+
+        assert type_list == ['org.apache.flink.runtime.state.StateBackendTestBase$TestPojo']
 
     def test_get_set_max_parallelism(self):
 

--- a/flink-python/pyflink/streaming/tests/test_stream_execution_environment.py
+++ b/flink-python/pyflink/streaming/tests/test_stream_execution_environment.py
@@ -1,0 +1,105 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import os
+import tempfile
+import json
+
+from pyflink.streaming import StreamExecutionEnvironment
+from pyflink.table import DataTypes, CsvTableSource, CsvTableSink, StreamTableEnvironment
+from pyflink.testing.test_case_utils import PyFlinkTestCase
+
+
+class StreamExecutionEnvironmentTests(PyFlinkTestCase):
+
+    def setUp(self):
+        self.env = StreamExecutionEnvironment.get_execution_environment()
+
+    def test_get_set_parallelism(self):
+
+        self.env.set_parallelism(10)
+
+        parallelism = self.env.get_parallelism()
+
+        assert parallelism == 10
+
+    def test_get_set_buffer_timeout(self):
+
+        self.env.set_buffer_timeout(12000)
+
+        timeout = self.env.get_buffer_timeout()
+
+        assert timeout == 12000
+
+    def test_get_set_default_local_parallelism(self):
+
+        self.env.set_default_local_parallelism(8)
+
+        parallelism = self.env.get_default_local_parallelism()
+
+        assert parallelism == 8
+
+    def test_add_default_kryo_serializer(self):
+
+        self.env.add_default_kryo_serializer(
+            "org.apache.flink.runtime.state.StateBackendTestBase$TestPojo",
+            "org.apache.flink.runtime.state.StateBackendTestBase$CustomKryoTestSerializer")
+
+    def test_register_type_with_kryo_serializer(self):
+
+        self.env.register_type_with_kryo_serializer(
+            "org.apache.flink.runtime.state.StateBackendTestBase$TestPojo",
+            "org.apache.flink.runtime.state.StateBackendTestBase$CustomKryoTestSerializer")
+
+    def test_register_type(self):
+
+        self.env.register_type("org.apache.flink.runtime.state.StateBackendTestBase$TestPojo")
+
+    def test_get_set_max_parallelism(self):
+
+        self.env.set_max_parallelism(12)
+
+        parallelism = self.env.get_max_parallelism()
+
+        assert parallelism == 12
+
+    def test_operation_chaining(self):
+
+        assert self.env.is_chaining_enabled() is True
+
+        self.env.disable_operation_chaining()
+
+        assert self.env.is_chaining_enabled() is False
+
+    def test_get_execution_plan(self):
+        tmp_dir = tempfile.gettempdir()
+        source_path = os.path.join(tmp_dir + '/streaming.csv')
+        tmp_csv = os.path.join(tmp_dir + '/streaming2.csv')
+        field_names = ["a", "b", "c"]
+        field_types = [DataTypes.INT(), DataTypes.STRING(), DataTypes.STRING()]
+
+        t_env = StreamTableEnvironment.create(self.env)
+        csv_source = CsvTableSource(source_path, field_names, field_types)
+        t_env.register_table_source("Orders", csv_source)
+        t_env.register_table_sink(
+            "Results",
+            field_names, field_types, CsvTableSink(tmp_csv))
+        t_env.scan("Orders").insert_into("Results")
+
+        plan = t_env.exec_env().get_execution_plan()
+
+        json.loads(plan)

--- a/flink-python/pyflink/streaming/tests/test_stream_execution_environment.py
+++ b/flink-python/pyflink/streaming/tests/test_stream_execution_environment.py
@@ -20,7 +20,7 @@ import tempfile
 import json
 
 from pyflink.common import (ExecutionConfig, RestartStrategies, CheckpointConfig,
-                            CheckpointingMode)
+                            CheckpointingMode, TimeCharacteristic)
 from pyflink.streaming import StreamExecutionEnvironment
 from pyflink.table import DataTypes, CsvTableSource, CsvTableSink, StreamTableEnvironment
 from pyflink.testing.test_case_utils import PyFlinkTestCase
@@ -139,6 +139,18 @@ class StreamExecutionEnvironmentTests(PyFlinkTestCase):
         mode = self.env.get_checkpointing_mode()
 
         assert mode == CheckpointingMode.AT_LEAST_ONCE
+
+    def test_get_set_stream_time_characteristic(self):
+
+        default_time_characteristic = self.env.get_stream_time_characteristic()
+
+        assert default_time_characteristic == TimeCharacteristic.ProcessingTime
+
+        self.env.set_stream_time_characteristic(TimeCharacteristic.EventTime)
+
+        time_characteristic = self.env.get_stream_time_characteristic()
+
+        assert time_characteristic == TimeCharacteristic.EventTime
 
     def test_get_execution_plan(self):
         tmp_dir = tempfile.gettempdir()

--- a/flink-python/pyflink/table/examples/batch/word_count.py
+++ b/flink-python/pyflink/table/examples/batch/word_count.py
@@ -67,7 +67,7 @@ def word_count():
          .select("word, count(1) as count") \
          .insert_into("Results")
 
-    t_env.execute()
+    t_env.exec_env().execute()
 
 
 if __name__ == '__main__':

--- a/flink-python/pyflink/table/table.py
+++ b/flink-python/pyflink/table/table.py
@@ -41,8 +41,9 @@ class Table(object):
 
     Example:
     ::
-        >>> t_config = TableConfig.Builder().as_streaming_execution().set_parallelism(1).build()
-        >>> t_env = TableEnvironment.create(t_config)
+        >>> env = StreamExecutionEnvironment.get_execution_environment()
+        >>> env.set_parallelism(1)
+        >>> t_env = StreamTableEnvironment.create(env)
         >>> ...
         >>> t_env.register_table_source("source", ...)
         >>> t = t_env.scan("source")
@@ -50,7 +51,7 @@ class Table(object):
         ...
         >>> t_env.register_table_sink("result", ...)
         >>> t.insert_into("result")
-        >>> t_env.execute()
+        >>> t_env.exec_env().execute()
 
     Operations such as :func:`~pyflink.table.Table.join`, :func:`~pyflink.table.Table.select`,
     :func:`~pyflink.table.Table.where` and :func:`~pyflink.table.Table.group_by`

--- a/flink-python/pyflink/table/table_config.py
+++ b/flink-python/pyflink/table/table_config.py
@@ -36,51 +36,43 @@ class TableConfig(object):
         self._is_stream = None  # type: bool
         self._parallelism = None  # type: int
 
-    def is_stream(self):
-        """
-        Configures execution mode, "true" for streaming and "false" for batch.
-        """
-        return self._is_stream
-
-    def _set_stream(self, is_stream):
-        self._is_stream = is_stream
-
-    def parallelism(self):
-        """
-        The parallelism for all operations.
-        """
-        return self._parallelism
-
-    def _set_parallelism(self, parallelism):
-        self._parallelism = parallelism
-
-    def timezone(self):
+    def get_timezone(self):
         """
         Returns the timezone id, either an abbreviation such as "PST", a full name such as
         "America/Los_Angeles", or a custom timezone_id such as "GMT-8:00".
         """
         return self._j_table_config.getTimeZone().getID()
 
-    def _set_timezone(self, timezone_id):
+    def set_timezone(self, timezone_id):
+        """
+        Sets the timezone id for date/time/timestamp conversions.
+
+        :param timezone_id: The timezone id, either an abbreviation such as "PST", a full name
+                            such as "America/Los_Angeles", or a custom timezone_id such as
+                            "GMT-8:00".
+        """
         if timezone_id is not None and isinstance(timezone_id, (str, unicode)):
             j_timezone = self._jvm.java.util.TimeZone.getTimeZone(timezone_id)
             self._j_table_config.setTimeZone(j_timezone)
         else:
             raise Exception("TableConfig.timezone should be a string!")
 
-    def null_check(self):
+    def get_null_check(self):
         """
         A boolean value, "True" enables NULL check and "False" disables NULL check.
         """
         return self._j_table_config.getNullCheck()
 
-    def _set_null_check(self, null_check):
+    def set_null_check(self, null_check):
+        """
+        Sets the NULL check. If enabled, all fields need to be checked for NULL first.
+        """
         if null_check is not None and isinstance(null_check, bool):
             self._j_table_config.setNullCheck(null_check)
         else:
             raise Exception("TableConfig.null_check should be a bool value!")
 
-    def max_generated_code_length(self):
+    def get_max_generated_code_length(self):
         """
         The current threshold where generated code will be split into sub-function calls. Java has
         a maximum method length of 64 KB. This setting allows for finer granularity if necessary.
@@ -88,101 +80,13 @@ class TableConfig(object):
         """
         return self._j_table_config.getMaxGeneratedCodeLength()
 
-    def _set_max_generated_code_length(self, max_generated_code_length):
+    def set_max_generated_code_length(self, max_generated_code_length):
+        """
+        Returns the current threshold where generated code will be split into sub-function calls.
+        Java has a maximum method length of 64 KB. This setting allows for finer granularity if
+        necessary. Default is 64000.
+        """
         if max_generated_code_length is not None and isinstance(max_generated_code_length, int):
             self._j_table_config.setMaxGeneratedCodeLength(max_generated_code_length)
         else:
             raise Exception("TableConfig.max_generated_code_length should be a int value!")
-
-    class Builder(object):
-
-        def __init__(self):
-            self._is_stream = None  # type: bool
-            self._parallelism = None  # type: int
-            self._timezone_id = None  # type: str
-            self._null_check = None  # type: bool
-            self._max_generated_code_length = None  # type: int
-
-        def as_streaming_execution(self):
-            """
-            Configures streaming execution mode.
-            If this method is called, :class:`StreamTableEnvironment` will be created.
-
-            :return: :class:`TableConfig.Builder`
-            """
-            self._is_stream = True
-            return self
-
-        def as_batch_execution(self):
-            """
-            Configures batch execution mode.
-            If this method is called, :class:`BatchTableEnvironment` will be created.
-
-            :return: :class:`TableConfig.Builder`
-            """
-            self._is_stream = False
-            return self
-
-        def set_parallelism(self, parallelism):
-            """
-            Sets the parallelism for all operations.
-
-            :param parallelism: The parallelism.
-            :return: :class:`TableConfig.Builder`
-            """
-            self._parallelism = parallelism
-            return self
-
-        def set_timezone(self, time_zone_id):
-            """
-            Sets the timezone for date/time/timestamp conversions.
-
-            :param time_zone_id: The time zone ID in string format, either an abbreviation such as
-                                 "PST", a full name such as "America/Los_Angeles", or a custom ID
-                                 such as "GMT-8:00".
-            :return: :class:`TableConfig.Builder`
-            """
-            self._timezone_id = time_zone_id
-            return self
-
-        def set_null_check(self, null_check):
-            """
-            Sets the NULL check. If enabled, all fields need to be checked for NULL first.
-
-            :param null_check: A boolean value, "True" enables NULL check and "False" disables
-                               NULL check.
-            :return: :class:`TableConfig.Builder`
-            """
-            self._null_check = null_check
-            return self
-
-        def set_max_generated_code_length(self, max_length):
-            """
-            Sets the current threshold where generated code will be split into sub-function calls.
-            Java has a maximum method length of 64 KB. This setting allows for finer granularity if
-            necessary. Default is 64000.
-
-            :param max_length: The maximum method length of generated java code.
-            :return: :class:`TableConfig.Builder`
-            """
-            self._max_generated_code_length = max_length
-            return self
-
-        def build(self):
-            """
-            Builds :class:`TableConfig` object.
-
-            :return: TableConfig
-            """
-            config = TableConfig()
-            if self._parallelism is not None:
-                config._set_parallelism(self._parallelism)
-            if self._is_stream is not None:
-                config._set_stream(self._is_stream)
-            if self._timezone_id is not None:
-                config._set_timezone(self._timezone_id)
-            if self._null_check is not None:
-                config._set_null_check(self._null_check)
-            if self._max_generated_code_length is not None:
-                config._set_max_generated_code_length(self._max_generated_code_length)
-            return config

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -19,7 +19,9 @@ import os
 import tempfile
 from abc import ABCMeta, abstractmethod
 
+from pyflink.batch import ExecutionEnvironment
 from pyflink.serializers import BatchedSerializer, PickleSerializer
+from pyflink.streaming import StreamExecutionEnvironment
 from pyflink.table.query_config import StreamQueryConfig, BatchQueryConfig, QueryConfig
 from pyflink.table.table_config import TableConfig
 from pyflink.table.table_descriptor import (StreamTableDescriptor, ConnectorDescriptor,
@@ -326,16 +328,12 @@ class TableEnvironment(object):
         """
         self._j_tenv.useDatabase(database_name)
 
-    def execute(self, job_name=None):
+    @abstractmethod
+    def exec_env(self):
         """
-        Triggers the program execution.
-
-        :param job_name: Optional, desired name of the job.
+        :return: The execution environment of this table environment.
         """
-        if job_name is not None:
-            self._j_tenv.execEnv().execute(job_name)
-        else:
-            self._j_tenv.execEnv().execute()
+        pass
 
     @abstractmethod
     def get_config(self):
@@ -378,32 +376,6 @@ class TableEnvironment(object):
         :return: A :class:`ConnectTableDescriptor` used to build the table source/sink.
         """
         pass
-
-    @classmethod
-    def create(cls, table_config):
-        """
-        Returns a :class:`StreamTableEnvironment` or a :class:`BatchTableEnvironment`
-        which matches the :class:`TableConfig`'s content.
-
-        :type table_config: The TableConfig for the new TableEnvironment.
-        :return: Desired :class:`TableEnvironment`.
-        """
-        gateway = get_gateway()
-        if table_config.is_stream():
-            j_execution_env = gateway.jvm.StreamExecutionEnvironment.getExecutionEnvironment()
-            j_tenv = gateway.jvm.StreamTableEnvironment.create(
-                j_execution_env, table_config._j_table_config)
-            t_env = StreamTableEnvironment(j_tenv)
-        else:
-            j_execution_env = gateway.jvm.ExecutionEnvironment.getExecutionEnvironment()
-            j_tenv = gateway.jvm.BatchTableEnvironment.create(
-                j_execution_env, table_config._j_table_config)
-            t_env = BatchTableEnvironment(j_tenv)
-
-        if table_config.parallelism() is not None:
-            t_env._j_tenv.execEnv().setParallelism(table_config.parallelism())
-
-        return t_env
 
     def from_elements(self, elements, schema=None, verify_schema=True):
         """
@@ -503,8 +475,6 @@ class StreamTableEnvironment(TableEnvironment):
         """
         table_config = TableConfig()
         table_config._j_table_config = self._j_tenv.getConfig()
-        table_config._set_stream(True)
-        table_config._set_parallelism(self._j_tenv.execEnv().getParallelism())
         return table_config
 
     def query_config(self):
@@ -546,6 +516,24 @@ class StreamTableEnvironment(TableEnvironment):
         return StreamTableDescriptor(
             self._j_tenv.connect(connector_descriptor._j_connector_descriptor))
 
+    def exec_env(self):
+        """
+        :return: The stream execution environment of this table environment.
+        """
+        return StreamExecutionEnvironment(self._j_tenv.execEnv())
+
+    @classmethod
+    def create(cls, stream_execution_environment, table_config=None):
+        gateway = get_gateway()
+        if table_config is not None:
+            j_tenv = gateway.jvm.StreamTableEnvironment.create(
+                stream_execution_environment._j_stream_execution_environment,
+                table_config._j_table_config)
+        else:
+            j_tenv = gateway.jvm.StreamTableEnvironment.create(
+                stream_execution_environment._j_stream_execution_environment)
+        return StreamTableEnvironment(j_tenv)
+
 
 class BatchTableEnvironment(TableEnvironment):
 
@@ -568,8 +556,6 @@ class BatchTableEnvironment(TableEnvironment):
         """
         table_config = TableConfig()
         table_config._j_table_config = self._j_tenv.getConfig()
-        table_config._set_stream(False)
-        table_config._set_parallelism(self._j_tenv.execEnv().getParallelism())
         return table_config
 
     def query_config(self):
@@ -610,3 +596,21 @@ class BatchTableEnvironment(TableEnvironment):
         # type: (ConnectorDescriptor) -> BatchTableDescriptor
         return BatchTableDescriptor(
             self._j_tenv.connect(connector_descriptor._j_connector_descriptor))
+
+    def exec_env(self):
+        """
+        :return: The stream execution environment of this table environment.
+        """
+        return ExecutionEnvironment(self._j_tenv.execEnv())
+
+    @classmethod
+    def create(cls, execution_environment, table_config=None):
+        gateway = get_gateway()
+        if table_config is not None:
+            j_tenv = gateway.jvm.BatchTableEnvironment.create(
+                execution_environment._j_execution_environment,
+                table_config._j_table_config)
+        else:
+            j_tenv = gateway.jvm.BatchTableEnvironment.create(
+                execution_environment._j_execution_environment)
+        return BatchTableEnvironment(j_tenv)

--- a/flink-python/pyflink/table/tests/test_aggregate.py
+++ b/flink-python/pyflink/table/tests/test_aggregate.py
@@ -35,7 +35,7 @@ class StreamTableAggregateTests(PyFlinkStreamTableTestCase):
 
         result = t.group_by("c").select("a.sum, c as b")
         result.insert_into("Results")
-        t_env.execute()
+        t_env.exec_env().execute()
         actual = source_sink_utils.results()
 
         expected = ['5,Hello']

--- a/flink-python/pyflink/table/tests/test_calc.py
+++ b/flink-python/pyflink/table/tests/test_calc.py
@@ -40,7 +40,7 @@ class StreamTableCalcTests(PyFlinkStreamTableTestCase):
 
         t.select("a + 1, b, c") \
             .insert_into("Results")
-        t_env.execute()
+        t_env.exec_env().execute()
         actual = source_sink_utils.results()
 
         expected = ['2,hi,hello', '3,hi,hello']
@@ -57,7 +57,7 @@ class StreamTableCalcTests(PyFlinkStreamTableTestCase):
 
         result = t.alias("d, e, f").select("d, e, f")
         result.insert_into("Results")
-        t_env.execute()
+        t_env.exec_env().execute()
         actual = source_sink_utils.results()
 
         expected = ['1,Hi,Hello', '2,Hi,Hello']
@@ -74,7 +74,7 @@ class StreamTableCalcTests(PyFlinkStreamTableTestCase):
 
         result = t.where("a > 1 && b = 'Hello'")
         result.insert_into("Results")
-        t_env.execute()
+        t_env.exec_env().execute()
         actual = source_sink_utils.results()
 
         expected = ['2,Hello,Hello']
@@ -91,7 +91,7 @@ class StreamTableCalcTests(PyFlinkStreamTableTestCase):
 
         result = t.filter("a > 1 && b = 'Hello'")
         result.insert_into("Results")
-        t_env.execute()
+        t_env.exec_env().execute()
         actual = source_sink_utils.results()
 
         expected = ['2,Hello,Hello']
@@ -128,7 +128,7 @@ class StreamTableCalcTests(PyFlinkStreamTableTestCase):
             field_names, field_types, source_sink_utils.TestAppendSink())
 
         t.insert_into("Results")
-        t_env.execute()
+        t_env.exec_env().execute()
         actual = source_sink_utils.results()
 
         expected = ['1,1.0,hi,hello,1970-01-02,01:00:00,1970-01-02 00:00:00.0,[1.0, null],'

--- a/flink-python/pyflink/table/tests/test_column_operation.py
+++ b/flink-python/pyflink/table/tests/test_column_operation.py
@@ -34,7 +34,7 @@ class StreamTableColumnsOperationTests(PyFlinkStreamTableTestCase):
 
         result = t.select("a").add_columns("a + 1 as b, a + 2 as c")
         result.insert_into("Results")
-        t_env.execute()
+        t_env.exec_env().execute()
         actual = source_sink_utils.results()
 
         expected = ['1,2,3', '2,3,4']
@@ -51,7 +51,7 @@ class StreamTableColumnsOperationTests(PyFlinkStreamTableTestCase):
 
         result = t.select("a").add_or_replace_columns("a + 1 as b, a + 2 as a")
         result.insert_into("Results")
-        t_env.execute()
+        t_env.exec_env().execute()
         actual = source_sink_utils.results()
 
         expected = ['3,2', '4,3']
@@ -68,7 +68,7 @@ class StreamTableColumnsOperationTests(PyFlinkStreamTableTestCase):
 
         result = t.select("a, b, c").rename_columns("a as d, c as f, b as e").select("d, e, f")
         result.insert_into("Results")
-        t_env.execute()
+        t_env.exec_env().execute()
         actual = source_sink_utils.results()
 
         expected = ['1,Hi,Hello', '2,Hello,Hello']
@@ -85,7 +85,7 @@ class StreamTableColumnsOperationTests(PyFlinkStreamTableTestCase):
 
         result = t.select("a, b, c").drop_columns("a, c").select("b")
         result.insert_into("Results")
-        t_env.execute()
+        t_env.exec_env().execute()
         actual = source_sink_utils.results()
 
         expected = ['Hi', 'Hello']

--- a/flink-python/pyflink/table/tests/test_descriptor.py
+++ b/flink-python/pyflink/table/tests/test_descriptor.py
@@ -827,7 +827,7 @@ class AbstractTableDescriptorTests(object):
         t_env.scan("source") \
              .select("a + 1, b, c") \
              .insert_into("sink")
-        t_env.execute()
+        t_env.exec_env().execute()
 
         with open(sink_path, 'r') as f:
             lines = f.read()
@@ -862,7 +862,7 @@ class AbstractTableDescriptorTests(object):
         t_env.scan("source") \
              .select("a + 1, b, c") \
              .insert_into("sink")
-        t_env.execute()
+        t_env.exec_env().execute()
 
         with open(sink_path, 'r') as f:
             lines = f.read()
@@ -904,7 +904,7 @@ class AbstractTableDescriptorTests(object):
         t_env.scan("source") \
              .select("a + 1, b, c") \
              .insert_into("sink")
-        t_env.execute()
+        t_env.exec_env().execute()
 
         with open(sink_path, 'r') as f:
             lines = f.read()
@@ -1011,7 +1011,7 @@ class StreamDescriptorEndToEndTests(PyFlinkStreamTableTestCase):
         t_env.scan("source") \
              .select("a + 1, b, c") \
              .insert_into("sink")
-        t_env.execute()
+        t_env.exec_env().execute()
 
         with open(sink_path, 'r') as f:
             lines = f.read()

--- a/flink-python/pyflink/table/tests/test_distinct.py
+++ b/flink-python/pyflink/table/tests/test_distinct.py
@@ -35,7 +35,7 @@ class StreamTableDistinctTests(PyFlinkStreamTableTestCase):
 
         result = t.distinct().select("a, c as b")
         result.insert_into("Results")
-        t_env.execute()
+        t_env.exec_env().execute()
         actual = source_sink_utils.results()
 
         expected = ['1,Hello', '2,Hello']

--- a/flink-python/pyflink/table/tests/test_join.py
+++ b/flink-python/pyflink/table/tests/test_join.py
@@ -36,7 +36,7 @@ class StreamTableJoinTests(PyFlinkStreamTableTestCase):
 
         result = t1.join(t2, "a = d").select("a, b + e")
         result.insert_into("Results")
-        t_env.execute()
+        t_env.exec_env().execute()
         actual = source_sink_utils.results()
 
         expected = ['2,HiFlink', '3,HelloPython', '3,HelloFlink']
@@ -55,7 +55,7 @@ class StreamTableJoinTests(PyFlinkStreamTableTestCase):
 
         result = t1.join(t2).where("a = d").select("a, b + e")
         result.insert_into("Results")
-        t_env.execute()
+        t_env.exec_env().execute()
         actual = source_sink_utils.results()
 
         expected = ['2,HiFlink', '3,HelloPython', '3,HelloFlink']
@@ -74,7 +74,7 @@ class StreamTableJoinTests(PyFlinkStreamTableTestCase):
 
         result = t1.left_outer_join(t2, "a = d").select("a, b + e")
         result.insert_into("Results")
-        t_env.execute()
+        t_env.exec_env().execute()
         actual = source_sink_utils.results()
 
         expected = ['1,null', '2,HiFlink', '3,HelloPython', '3,HelloFlink']
@@ -93,7 +93,7 @@ class StreamTableJoinTests(PyFlinkStreamTableTestCase):
 
         result = t1.left_outer_join(t2).where("a = d").select("a, b + e")
         result.insert_into("Results")
-        t_env.execute()
+        t_env.exec_env().execute()
         actual = source_sink_utils.results()
 
         expected = ['2,HiFlink', '3,HelloPython', '3,HelloFlink']
@@ -112,7 +112,7 @@ class StreamTableJoinTests(PyFlinkStreamTableTestCase):
 
         result = t1.right_outer_join(t2, "a = d").select("d, b + e")
         result.insert_into("Results")
-        t_env.execute()
+        t_env.exec_env().execute()
         actual = source_sink_utils.results()
 
         expected = ['2,HiFlink', '3,HelloPython', '4,null']
@@ -131,7 +131,7 @@ class StreamTableJoinTests(PyFlinkStreamTableTestCase):
 
         result = t1.full_outer_join(t2, "a = d").select("a, d, b + e")
         result.insert_into("Results")
-        t_env.execute()
+        t_env.exec_env().execute()
         actual = source_sink_utils.results()
 
         expected = ['1,null,null', '2,2,HiFlink', '3,3,HelloPython', 'null,4,null']

--- a/flink-python/pyflink/table/tests/test_set_operation.py
+++ b/flink-python/pyflink/table/tests/test_set_operation.py
@@ -38,7 +38,7 @@ class StreamTableSetOperationTests(PyFlinkStreamTableTestCase):
 
         result = t1.union_all(t2)
         result.insert_into("Results")
-        t_env.execute()
+        t_env.exec_env().execute()
 
         actual = source_sink_utils.results()
         expected = ['1,Hi,Hello',

--- a/flink-python/pyflink/testing/test_case_utils.py
+++ b/flink-python/pyflink/testing/test_case_utils.py
@@ -25,10 +25,13 @@ import unittest
 from abc import abstractmethod
 
 from py4j.java_gateway import JavaObject
+
+from pyflink.batch import ExecutionEnvironment
+from pyflink.streaming import StreamExecutionEnvironment
 from pyflink.table.table_source import CsvTableSource
 
 from pyflink.find_flink_home import _find_flink_home
-from pyflink.table import TableEnvironment, TableConfig
+from pyflink.table import BatchTableEnvironment, StreamTableEnvironment
 from pyflink.java_gateway import get_gateway
 
 if sys.version_info[0] >= 3:
@@ -101,8 +104,9 @@ class PyFlinkStreamTableTestCase(PyFlinkTestCase):
 
     def setUp(self):
         super(PyFlinkStreamTableTestCase, self).setUp()
-        self.t_config = TableConfig.Builder().as_streaming_execution().set_parallelism(1).build()
-        self.t_env = TableEnvironment.create(self.t_config)
+        self.env = StreamExecutionEnvironment.get_execution_environment()
+        self.env.set_parallelism(1)
+        self.t_env = StreamTableEnvironment.create(self.env)
 
 
 class PyFlinkBatchTableTestCase(PyFlinkTestCase):
@@ -112,8 +116,9 @@ class PyFlinkBatchTableTestCase(PyFlinkTestCase):
 
     def setUp(self):
         super(PyFlinkBatchTableTestCase, self).setUp()
-        self.t_config = TableConfig.Builder().as_batch_execution().set_parallelism(1).build()
-        self.t_env = TableEnvironment.create(self.t_config)
+        self.env = ExecutionEnvironment.get_execution_environment()
+        self.env.set_parallelism(1)
+        self.t_env = BatchTableEnvironment.create(self.env)
 
     def collect(self, table):
         j_table = table._j_table

--- a/flink-python/pyflink/util/utils.py
+++ b/flink-python/pyflink/util/utils.py
@@ -15,8 +15,13 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import sys
+from datetime import timedelta
 
 from pyflink.java_gateway import get_gateway
+
+if sys.version >= '3':
+    unicode = str
 
 
 def to_jarray(j_type, arr):
@@ -31,6 +36,24 @@ def to_jarray(j_type, arr):
     for i in range(0, len(arr)):
         j_arr[i] = arr[i]
     return j_arr
+
+
+def to_j_flink_time(time_delta):
+    gateway = get_gateway()
+    TimeUnit = gateway.jvm.java.util.concurrent.TimeUnit
+    Time = gateway.jvm.org.apache.flink.api.common.time.Time
+    if isinstance(time_delta, timedelta):
+        total_microseconds = round(time_delta.total_seconds() * 1000 * 1000)
+        return Time.of(total_microseconds, TimeUnit.MICROSECONDS)
+    else:
+        # time delta in milliseconds
+        total_milliseconds = time_delta
+        return Time.milliseconds(total_milliseconds)
+
+
+def from_j_flink_time(j_flink_time):
+    total_milliseconds = j_flink_time.toMilliseconds()
+    return timedelta(milliseconds=total_milliseconds)
 
 
 def load_java_class(class_name):

--- a/flink-python/pyflink/util/utils.py
+++ b/flink-python/pyflink/util/utils.py
@@ -38,6 +38,19 @@ def to_jarray(j_type, arr):
     return j_arr
 
 
+def to_j_config(config):
+    gateway = get_gateway()
+    Configuration = gateway.jvm.org.apache.flink.configuration.Configuration
+    j_config = Configuration()
+    for key in config:
+        if not isinstance(config[key], (str, unicode)):
+            value = str(config[key])
+        else:
+            value = config[key]
+        j_config.setString(key, value)
+    return j_config
+
+
 def to_j_flink_time(time_delta):
     gateway = get_gateway()
     TimeUnit = gateway.jvm.java.util.concurrent.TimeUnit

--- a/tools/travis_controller.sh
+++ b/tools/travis_controller.sh
@@ -159,6 +159,8 @@ if [ $STAGE == "$STAGE_COMPILE" ]; then
     
             # jars are re-built in subsequent stages, so no need to cache them (cannot be avoided)
             find "$CACHE_FLINK_DIR" -maxdepth 8 -type f -name '*.jar' \
+            ! -path "$CACHE_FLINK_DIR/flink-runtime/target/flink-runtime*tests.jar" \
+            ! -path "$CACHE_FLINK_DIR/flink-streaming-java/target/flink-streaming-java*tests.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/lib/flink-dist*.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/opt/flink-table*.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/opt/flink-python*java-binding.jar" \


### PR DESCRIPTION
Mirror of apache flink#8681
## What is the purpose of the change

This pull request add `StreamExecutionEnvironment` and `ExecutionEnvironment` for Python Table API so that the usage of Python Table API can align with Java Table API. All APIs used for configuration in `StreamExecutionEnvironment` and `ExecutionEnvironment` have been added. The transitive dependent classes are involved to Python API too, which contains: `ExecutionConfig`, `CheckpointConfig`, `ExternalizedCheckpointCleanup`, `CheckpointingMode`, `ExecutionMode`, `InputDependencyConstraint`, `RestartStrategies`, `StateBackend`, `MemoryStateBackend`, `FsStateBackend`, `RocksDBStateBackend`, `CustomStateBackend`, `PredefinedOptions` and `TimeCharacteristic`.


## Brief change log

  - *Add `StreamExecutionEnvironment` and `ExecutionEnvironment`.*
  - *Move execute() method from TableEnvironment to ExecutionEnvironment/StreamExecutionEnvironment.*
  - *Refactor TableConfig align to Java TableConfig.*
  - *Add `ExecutionConfig` and relevant APIs.*
  - *Add `CheckpointConfig` and relevant APIs.*
  - *Add `StateBackend` and relevant APIs.*


## Verifying this change

This change added integration tests in `test_execution_environment.py`, `test_stream_execution_environment.py`, `test_execution_config.py`, `test_check_point_config.py`, `test_state_backend.py`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (python docs)

