### PR TITLE
Mirror of apache flink#8679

### DIFF
--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -172,11 +172,11 @@ These examples about how to manage a job in CLI.
 
 -   Cancel a job with a savepoint:
 
-        ./bin/flink cancel -s [targetDirectory] <jobID>
+        ./bin/flink cancel -s [targetDirectory] -st [savepointTimeout] <jobID>
 
 -   Stop a job with a savepoint (streaming jobs only):
 
-        ./bin/flink stop -s [targetDirectory] -d <jobID>
+        ./bin/flink stop -s [targetDirectory] -st [savepointTimeout] -d <jobID>
         
 
 **NOTE**: The difference between cancelling and stopping a (streaming) job is the following:
@@ -321,6 +321,7 @@ Action "run" compiles and runs a program.
                                           standard out.
      -s,--fromSavepoint <savepointPath>   Path to a savepoint to restore the job
                                           from (for example
+     -st,--savepointTimeout <savepointTimeout> Timeout of a savepoint.
                                           hdfs:///flink/savepoint-1537).
      -sae,--shutdownOnAttachedExit        If the job is submitted in attached
                                           mode, perform a best-effort cluster
@@ -430,6 +431,7 @@ Action "stop" stops a running program with a savepoint (streaming jobs only).
                                           directory is specified, the configured
                                           default will be used
                                           ("state.savepoints.dir").
+     -st,--savepointTimeout <savepointTimeout> Timeout of a savepoint.
   Options for default mode:
      -m,--jobmanager <arg>           Address of the JobManager (master) to which
                                      to connect. Use this flag to connect to a
@@ -449,6 +451,7 @@ Action "cancel" cancels a running program.
                                             no directory is specified, the
                                             configured default directory
                                             (state.savepoints.dir) is used.
+     -st,--savepointTimeout <savepointTimeout> Timeout of a savepoint.
   Options for yarn-cluster mode:
      -m,--jobmanager <arg>            Address of the JobManager (master) to
                                       which to connect. Use this flag to connect
@@ -470,7 +473,7 @@ Action "cancel" cancels a running program.
 
 Action "savepoint" triggers savepoints for a running job or disposes existing ones.
 
-  Syntax: savepoint [OPTIONS] <Job ID> [<target directory>]
+  Syntax: savepoint [OPTIONS] <Job ID> [<target directory>] [<savepoint timeout>]
   "savepoint" action options:
      -d,--dispose <arg>       Path of savepoint to dispose.
      -j,--jarfile <jarfile>   Flink program JAR file.

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CancelOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CancelOptions.java
@@ -18,9 +18,12 @@
 
 package org.apache.flink.client.cli;
 
+import org.apache.flink.util.Preconditions;
+
 import org.apache.commons.cli.CommandLine;
 
 import static org.apache.flink.client.cli.CliFrontendParser.CANCEL_WITH_SAVEPOINT_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.SAVEPOINT_TIMEOUT_OPTION;
 
 /**
  * Command line options for the CANCEL command.
@@ -35,11 +38,21 @@ public class CancelOptions extends CommandLineOptions {
 	/** Optional target directory for the savepoint. Overwrites cluster default. */
 	private final String targetDirectory;
 
+	/** Optional timeout for the savepoint. */
+	private final long savepointTimeout;
+
 	public CancelOptions(CommandLine line) {
 		super(line);
 		this.args = line.getArgs();
 		this.withSavepoint = line.hasOption(CANCEL_WITH_SAVEPOINT_OPTION.getOpt());
 		this.targetDirectory = line.getOptionValue(CANCEL_WITH_SAVEPOINT_OPTION.getOpt());
+		if (this.withSavepoint && line.hasOption(SAVEPOINT_TIMEOUT_OPTION.getOpt())) {
+			this.savepointTimeout = Long.parseLong(line.getOptionValue(SAVEPOINT_TIMEOUT_OPTION.getOpt()));
+			Preconditions.checkArgument(savepointTimeout == -1L || savepointTimeout >= 1L,
+				"Checkpoint timeout must be larger than zero or equal to -1.");
+		} else {
+			this.savepointTimeout = -1L;
+		}
 	}
 
 	public String[] getArgs() {
@@ -52,5 +65,9 @@ public class CancelOptions extends CommandLineOptions {
 
 	public String getSavepointTargetDirectory() {
 		return targetDirectory;
+	}
+
+	public long getSavepointTimeout() {
+		return savepointTimeout;
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -85,6 +85,9 @@ public class CliFrontendParser {
 	public static final Option SAVEPOINT_PATH_OPTION = new Option("s", "fromSavepoint", true,
 			"Path to a savepoint to restore the job from (for example hdfs:///flink/savepoint-1537).");
 
+	public static final Option SAVEPOINT_TIMEOUT_OPTION = new Option("st", "savepointTimeout", true,
+			"Timeout of a savepoint.");
+
 	public static final Option SAVEPOINT_ALLOW_NON_RESTORED_OPTION = new Option("n", "allowNonRestoredState", false,
 			"Allow to skip savepoint state that cannot be restored. " +
 					"You need to allow this if you removed an operator from your " +
@@ -165,6 +168,9 @@ public class CliFrontendParser {
 		SAVEPOINT_PATH_OPTION.setRequired(false);
 		SAVEPOINT_PATH_OPTION.setArgName("savepointPath");
 
+		SAVEPOINT_TIMEOUT_OPTION.setRequired(false);
+		SAVEPOINT_TIMEOUT_OPTION.setArgName("savepointTimeout");
+
 		SAVEPOINT_ALLOW_NON_RESTORED_OPTION.setRequired(false);
 
 		ZOOKEEPER_NAMESPACE_OPTION.setRequired(false);
@@ -232,6 +238,7 @@ public class CliFrontendParser {
 		Options options = buildGeneralOptions(new Options());
 		options = getProgramSpecificOptions(options);
 		options.addOption(SAVEPOINT_PATH_OPTION);
+		options.addOption(SAVEPOINT_TIMEOUT_OPTION);
 		return options.addOption(SAVEPOINT_ALLOW_NON_RESTORED_OPTION);
 	}
 
@@ -249,12 +256,14 @@ public class CliFrontendParser {
 
 	static Options getCancelCommandOptions() {
 		Options options = buildGeneralOptions(new Options());
-		return options.addOption(CANCEL_WITH_SAVEPOINT_OPTION);
+		return options.addOption(CANCEL_WITH_SAVEPOINT_OPTION)
+				.addOption(SAVEPOINT_TIMEOUT_OPTION);
 	}
 
 	static Options getStopCommandOptions() {
 		return buildGeneralOptions(new Options())
 				.addOption(STOP_WITH_SAVEPOINT)
+				.addOption(SAVEPOINT_TIMEOUT_OPTION)
 				.addOption(STOP_AND_DRAIN);
 	}
 
@@ -271,6 +280,7 @@ public class CliFrontendParser {
 	private static Options getRunOptionsWithoutDeprecatedOptions(Options options) {
 		Options o = getProgramSpecificOptionsWithoutDeprecatedOptions(options);
 		o.addOption(SAVEPOINT_PATH_OPTION);
+		o.addOption(SAVEPOINT_TIMEOUT_OPTION);
 		return o.addOption(SAVEPOINT_ALLOW_NON_RESTORED_OPTION);
 	}
 
@@ -286,12 +296,14 @@ public class CliFrontendParser {
 	}
 
 	private static Options getCancelOptionsWithoutDeprecatedOptions(Options options) {
-		return options.addOption(CANCEL_WITH_SAVEPOINT_OPTION);
+		return options.addOption(CANCEL_WITH_SAVEPOINT_OPTION)
+				.addOption(SAVEPOINT_TIMEOUT_OPTION);
 	}
 
 	private static Options getStopOptionsWithoutDeprecatedOptions(Options options) {
 		return options
 				.addOption(STOP_WITH_SAVEPOINT)
+				.addOption(SAVEPOINT_TIMEOUT_OPTION)
 				.addOption(STOP_AND_DRAIN);
 	}
 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/RunOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/RunOptions.java
@@ -18,14 +18,31 @@
 
 package org.apache.flink.client.cli;
 
+import org.apache.flink.util.Preconditions;
+
 import org.apache.commons.cli.CommandLine;
+
+import static org.apache.flink.client.cli.CliFrontendParser.SAVEPOINT_TIMEOUT_OPTION;
 
 /**
  * Command line options for the RUN command.
  */
 public class RunOptions extends ProgramOptions {
 
+	private final long savepointTimeout;
+
 	public RunOptions(CommandLine line) throws CliArgsException {
 		super(line);
+		if (getSavepointRestoreSettings().restoreSavepoint() && line.hasOption(SAVEPOINT_TIMEOUT_OPTION.getOpt())) {
+			this.savepointTimeout = Long.parseLong(line.getOptionValue(SAVEPOINT_TIMEOUT_OPTION.getOpt()));
+			Preconditions.checkArgument(savepointTimeout == -1L || savepointTimeout >= 1L,
+				"Checkpoint timeout must be larger than zero or equal to -1.");
+		} else {
+			this.savepointTimeout = -1L;
+		}
+	}
+
+	public long getSavepointTimeout() {
+		return savepointTimeout;
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/StopOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/StopOptions.java
@@ -18,8 +18,11 @@
 
 package org.apache.flink.client.cli;
 
+import org.apache.flink.util.Preconditions;
+
 import org.apache.commons.cli.CommandLine;
 
+import static org.apache.flink.client.cli.CliFrontendParser.SAVEPOINT_TIMEOUT_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.STOP_AND_DRAIN;
 import static org.apache.flink.client.cli.CliFrontendParser.STOP_WITH_SAVEPOINT;
 
@@ -35,6 +38,9 @@ class StopOptions extends CommandLineOptions {
 	/** Optional target directory for the savepoint. Overwrites cluster default. */
 	private final String targetDirectory;
 
+	/** Optional timeout for the savepoint. Overwrites cluster default. */
+	private final long timeout;
+
 	private final boolean advanceToEndOfEventTime;
 
 	StopOptions(CommandLine line) {
@@ -43,6 +49,13 @@ class StopOptions extends CommandLineOptions {
 
 		this.savepointFlag = line.hasOption(STOP_WITH_SAVEPOINT.getOpt());
 		this.targetDirectory = line.getOptionValue(STOP_WITH_SAVEPOINT.getOpt());
+		if (line.hasOption(SAVEPOINT_TIMEOUT_OPTION.getOpt())) {
+			this.timeout = Long.parseLong(line.getOptionValue(SAVEPOINT_TIMEOUT_OPTION.getOpt()));
+			Preconditions.checkArgument(timeout == -1L || timeout >= 1L,
+				"Checkpoint timeout must be larger than zero or equal to -1.");
+		} else {
+			this.timeout = -1L;
+		}
 
 		this.advanceToEndOfEventTime = line.hasOption(STOP_AND_DRAIN.getOpt());
 	}
@@ -57,6 +70,10 @@ class StopOptions extends CommandLineOptions {
 
 	String getTargetDirectory() {
 		return targetDirectory;
+	}
+
+	long getTimeout() {
+		return timeout;
 	}
 
 	boolean shouldAdvanceToEndOfEventTime() {

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -354,10 +354,11 @@ public abstract class ClusterClient<T> {
 	 * Cancels a job identified by the job id and triggers a savepoint.
 	 * @param jobId the job id
 	 * @param savepointDirectory directory the savepoint should be written to
+	 * @param timeout the savepoint timeout
 	 * @return path where the savepoint is located
 	 * @throws Exception In case an error occurred.
 	 */
-	public abstract String cancelWithSavepoint(JobID jobId, @Nullable String savepointDirectory) throws Exception;
+	public abstract String cancelWithSavepoint(JobID jobId, @Nullable String savepointDirectory, long timeout) throws Exception;
 
 	/**
 	 * Stops a program on Flink cluster whose job-manager is configured in this client's configuration.
@@ -368,12 +369,13 @@ public abstract class ClusterClient<T> {
 	 * @param jobId the job ID of the streaming program to stop
 	 * @param advanceToEndOfEventTime flag indicating if the source should inject a {@code MAX_WATERMARK} in the pipeline
 	 * @param savepointDirectory directory the savepoint should be written to
+	 * @param timeout the specified savepoint timeout
 	 * @return a {@link CompletableFuture} containing the path where the savepoint is located
 	 * @throws Exception
 	 *             If the job ID is invalid (ie, is unknown or refers to a batch job) or if sending the stop signal
 	 *             failed. That might be due to an I/O problem, ie, the job-manager is unreachable.
 	 */
-	public abstract String stopWithSavepoint(final JobID jobId, final boolean advanceToEndOfEventTime, @Nullable final String savepointDirectory) throws Exception;
+	public abstract String stopWithSavepoint(final JobID jobId, final boolean advanceToEndOfEventTime, @Nullable final String savepointDirectory, final long timeout) throws Exception;
 
 	/**
 	 * Triggers a savepoint for the job identified by the job id. The savepoint will be written to the given savepoint
@@ -381,10 +383,11 @@ public abstract class ClusterClient<T> {
 	 *
 	 * @param jobId job id
 	 * @param savepointDirectory directory the savepoint should be written to
+	 * @param savepointTimeout timeout for savepoint
 	 * @return path future where the savepoint is located
 	 * @throws FlinkException if no connection to the cluster could be established
 	 */
-	public abstract CompletableFuture<String> triggerSavepoint(JobID jobId, @Nullable String savepointDirectory) throws FlinkException;
+	public abstract CompletableFuture<String> triggerSavepoint(JobID jobId, @Nullable String savepointDirectory, long savepointTimeout) throws FlinkException;
 
 	public abstract CompletableFuture<Acknowledge> disposeSavepoint(String savepointPath) throws FlinkException;
 

--- a/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
@@ -112,18 +112,18 @@ public class MiniClusterClient extends ClusterClient<MiniClusterClient.MiniClust
 	}
 
 	@Override
-	public String cancelWithSavepoint(JobID jobId, @Nullable String savepointDirectory) throws Exception {
-		return miniCluster.triggerSavepoint(jobId, savepointDirectory, true).get();
+	public String cancelWithSavepoint(JobID jobId, @Nullable String savepointDirectory, long timeout) throws Exception {
+		return miniCluster.triggerSavepoint(jobId, savepointDirectory, true, -1L).get();
 	}
 
 	@Override
-	public String stopWithSavepoint(JobID jobId, boolean advanceToEndOfEventTime, @Nullable String savepointDirector) throws Exception {
-		return miniCluster.stopWithSavepoint(jobId, savepointDirector, advanceToEndOfEventTime).get();
+	public String stopWithSavepoint(JobID jobId, boolean advanceToEndOfEventTime, @Nullable String savepointDirector, long timeout) throws Exception {
+		return miniCluster.stopWithSavepoint(jobId, savepointDirector, advanceToEndOfEventTime, timeout).get();
 	}
 
 	@Override
-	public CompletableFuture<String> triggerSavepoint(JobID jobId, @Nullable String savepointDirectory) {
-		return miniCluster.triggerSavepoint(jobId, savepointDirectory, false);
+	public CompletableFuture<String> triggerSavepoint(JobID jobId, @Nullable String savepointDirectory, long savepointTimeout) {
+		return miniCluster.triggerSavepoint(jobId, savepointDirectory, false, -1L);
 	}
 
 	@Override

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -398,7 +398,8 @@ public class RestClusterClient<T> extends ClusterClient<T> implements NewCluster
 	public String stopWithSavepoint(
 			final JobID jobId,
 			final boolean advanceToEndOfTime,
-			@Nullable final String savepointDirectory) throws Exception {
+			@Nullable final String savepointDirectory,
+			final long timeout) throws Exception {
 
 		final StopWithSavepointTriggerHeaders stopWithSavepointTriggerHeaders = StopWithSavepointTriggerHeaders.getInstance();
 
@@ -409,7 +410,7 @@ public class RestClusterClient<T> extends ClusterClient<T> implements NewCluster
 		final CompletableFuture<TriggerResponse> responseFuture = sendRequest(
 				stopWithSavepointTriggerHeaders,
 				stopWithSavepointTriggerMessageParameters,
-				new StopWithSavepointRequestBody(savepointDirectory, advanceToEndOfTime));
+				new StopWithSavepointRequestBody(savepointDirectory, advanceToEndOfTime, timeout));
 
 		return responseFuture.thenCompose(savepointTriggerResponseBody -> {
 			final TriggerId savepointTriggerId = savepointTriggerResponseBody.getTriggerId();
@@ -423,21 +424,23 @@ public class RestClusterClient<T> extends ClusterClient<T> implements NewCluster
 	}
 
 	@Override
-	public String cancelWithSavepoint(JobID jobId, @Nullable String savepointDirectory) throws Exception {
-		return triggerSavepoint(jobId, savepointDirectory, true).get();
+	public String cancelWithSavepoint(JobID jobId, @Nullable String savepointDirectory, long timeout) throws Exception {
+		return triggerSavepoint(jobId, savepointDirectory, true, timeout).get();
 	}
 
 	@Override
 	public CompletableFuture<String> triggerSavepoint(
 			final JobID jobId,
-			final @Nullable String savepointDirectory) {
-		return triggerSavepoint(jobId, savepointDirectory, false);
+			final @Nullable String savepointDirectory,
+			long savepointTimeout) {
+		return triggerSavepoint(jobId, savepointDirectory, false, savepointTimeout);
 	}
 
 	private CompletableFuture<String> triggerSavepoint(
 			final JobID jobId,
 			final @Nullable String savepointDirectory,
-			final boolean cancelJob) {
+			final boolean cancelJob,
+			long savepointTimeout) {
 		final SavepointTriggerHeaders savepointTriggerHeaders = SavepointTriggerHeaders.getInstance();
 		final SavepointTriggerMessageParameters savepointTriggerMessageParameters =
 			savepointTriggerHeaders.getUnresolvedMessageParameters();
@@ -446,7 +449,7 @@ public class RestClusterClient<T> extends ClusterClient<T> implements NewCluster
 		final CompletableFuture<TriggerResponse> responseFuture = sendRequest(
 			savepointTriggerHeaders,
 			savepointTriggerMessageParameters,
-			new SavepointTriggerRequestBody(savepointDirectory, cancelJob));
+			new SavepointTriggerRequestBody(savepointDirectory, cancelJob, savepointTimeout));
 
 		return responseFuture.thenCompose(savepointTriggerResponseBody -> {
 			final TriggerId savepointTriggerId = savepointTriggerResponseBody.getTriggerId();

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendCancelTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendCancelTest.java
@@ -30,6 +30,7 @@ import org.mockito.Mockito;
 
 import java.util.Collections;
 
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Matchers.notNull;
@@ -100,20 +101,20 @@ public class CliFrontendCancelTest extends CliFrontendTestBase {
 			testFrontend.cancel(parameters);
 
 			Mockito.verify(clusterClient, times(1))
-				.cancelWithSavepoint(any(JobID.class), isNull(String.class));
+				.cancelWithSavepoint(any(JobID.class), isNull(String.class), eq(-1L));
 		}
 
 		{
 			// Cancel with savepoint (with target directory)
 			JobID jid = new JobID();
 
-			String[] parameters = { "-s", "targetDirectory", jid.toString() };
+			String[] parameters = { "-s", "targetDirectory", jid.toString(), "-st", "100000" };
 			final ClusterClient<String> clusterClient = createClusterClient();
 			MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
 			testFrontend.cancel(parameters);
 
 			Mockito.verify(clusterClient, times(1))
-				.cancelWithSavepoint(any(JobID.class), notNull(String.class));
+				.cancelWithSavepoint(any(JobID.class), notNull(String.class), eq(100000L));
 		}
 	}
 

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import static org.apache.flink.client.cli.CliFrontendTestUtils.getTestJarPath;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -94,6 +95,28 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 			assertTrue(savepointSettings.restoreSavepoint());
 			assertEquals("expectedSavepointPath", savepointSettings.getRestorePath());
 			assertTrue(savepointSettings.allowNonRestoredState());
+		}
+
+		// test configure savepoint path (with savepoint timeout)
+		{
+			String[] parameters = {"-s", "expectedSavepointPath", "-st", "100000" , getTestJarPath()};
+			RunOptions options = CliFrontendParser.parseRunCommand(parameters);
+			SavepointRestoreSettings savepointSettings = options.getSavepointRestoreSettings();
+			assertTrue(savepointSettings.restoreSavepoint());
+			assertEquals("expectedSavepointPath", savepointSettings.getRestorePath());
+			assertEquals(100000L, options.getSavepointTimeout());
+			assertFalse(savepointSettings.allowNonRestoredState());
+		}
+
+		// test ignore savepoint timeout
+		{
+			String[] parameters = {"-st", "100000" , getTestJarPath()};
+			RunOptions options = CliFrontendParser.parseRunCommand(parameters);
+			SavepointRestoreSettings savepointSettings = options.getSavepointRestoreSettings();
+			assertFalse(savepointSettings.restoreSavepoint());
+			assertNull(savepointSettings.getRestorePath());
+			assertEquals(-1L, options.getSavepointTimeout());
+			assertFalse(savepointSettings.allowNonRestoredState());
 		}
 
 		// test jar arguments

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendStopWithSavepointTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendStopWithSavepointTest.java
@@ -73,7 +73,7 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
 		testFrontend.stop(parameters);
 
 		Mockito.verify(clusterClient, times(1))
-				.stopWithSavepoint(eq(jid), eq(false), isNull());
+				.stopWithSavepoint(eq(jid), eq(false), isNull(), eq(-1L));
 	}
 
 	@Test
@@ -86,7 +86,7 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
 		testFrontend.stop(parameters);
 
 		Mockito.verify(clusterClient, times(1))
-				.stopWithSavepoint(eq(jid), eq(false), isNull());
+				.stopWithSavepoint(eq(jid), eq(false), isNull(), eq(-1L));
 	}
 
 	@Test
@@ -99,7 +99,20 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
 		testFrontend.stop(parameters);
 
 		Mockito.verify(clusterClient, times(1))
-				.stopWithSavepoint(eq(jid), eq(false), eq("test-target-dir"));
+				.stopWithSavepoint(eq(jid), eq(false), eq("test-target-dir"), eq(-1L));
+	}
+
+	@Test
+	public void testStopWithExplicitSavepointTimeout() throws Exception {
+		JobID jid = new JobID();
+
+		String[] parameters = { "-s", jid.toString(), "-st", "100000" };
+		final ClusterClient<String> clusterClient = createClusterClient(null);
+		MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
+		testFrontend.stop(parameters);
+
+		Mockito.verify(clusterClient, times(1))
+			.stopWithSavepoint(eq(jid), eq(false), isNull(), eq(100000L));
 	}
 
 	@Test
@@ -112,7 +125,20 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
 		testFrontend.stop(parameters);
 
 		Mockito.verify(clusterClient, times(1))
-				.stopWithSavepoint(eq(jid), eq(true), isNull());
+				.stopWithSavepoint(eq(jid), eq(true), isNull(), eq(-1L));
+	}
+
+	@Test
+	public void testStopWithMaxWMAndSavepointTimeout() throws Exception {
+		JobID jid = new JobID();
+
+		String[] parameters = { "-d", jid.toString(), "-st", "100000" };
+		final ClusterClient<String> clusterClient = createClusterClient(null);
+		MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
+		testFrontend.stop(parameters);
+
+		Mockito.verify(clusterClient, times(1))
+			.stopWithSavepoint(eq(jid), eq(true), isNull(), eq(100000L));
 	}
 
 	@Test
@@ -125,7 +151,7 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
 		testFrontend.stop(parameters);
 
 		Mockito.verify(clusterClient, times(1))
-				.stopWithSavepoint(eq(jid), eq(true), isNull());
+				.stopWithSavepoint(eq(jid), eq(true), isNull(), eq(-1L));
 	}
 
 	@Test
@@ -138,7 +164,20 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
 		testFrontend.stop(parameters);
 
 		Mockito.verify(clusterClient, times(1))
-				.stopWithSavepoint(eq(jid), eq(true), eq("test-target-dir"));
+				.stopWithSavepoint(eq(jid), eq(true), eq("test-target-dir"), eq(-1L));
+	}
+
+	@Test
+	public void testStopWithMaxWMAndExplicitSavepointTimeout() throws Exception {
+		JobID jid = new JobID();
+
+		String[] parameters = { "-d", "-s", "-st", "100000", jid.toString() };
+		final ClusterClient<String> clusterClient = createClusterClient(null);
+		MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
+		testFrontend.stop(parameters);
+
+		Mockito.verify(clusterClient, times(1))
+			.stopWithSavepoint(eq(jid), eq(true), isNull(), eq(100000L));
 	}
 
 	@Test(expected = CliArgsException.class)
@@ -173,7 +212,7 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
 		testFrontend.stop(parameters);
 
 		Mockito.verify(clusterClient, times(1))
-				.stopWithSavepoint(eq(jid), eq(false), eq("test-target-dir"));
+				.stopWithSavepoint(eq(jid), eq(false), eq("test-target-dir"), eq(-1L));
 	}
 
 	@Test
@@ -199,7 +238,7 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
 		final ClusterClient<String> clusterClient = mock(ClusterClient.class);
 
 		if (exception != null) {
-			doThrow(exception).when(clusterClient).stopWithSavepoint(any(JobID.class), anyBoolean(), anyString());
+			doThrow(exception).when(clusterClient).stopWithSavepoint(any(JobID.class), anyBoolean(), anyString(), eq(-1L));
 		}
 
 		return clusterClient;

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientSavepointTriggerTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientSavepointTriggerTest.java
@@ -129,6 +129,7 @@ public class RestClusterClientSavepointTriggerTest extends TestLogger {
 			request -> {
 				assertNull(request.getTargetDirectory());
 				assertFalse(request.isCancelJob());
+				assertEquals(20000L, request.getTimeout());
 				return triggerId;
 			},
 			trigger -> {
@@ -138,7 +139,7 @@ public class RestClusterClientSavepointTriggerTest extends TestLogger {
 
 			final RestClusterClient<?> restClusterClient = createRestClusterClient(restServerEndpoint.getServerAddress().getPort());
 
-			final String savepointPath = restClusterClient.triggerSavepoint(new JobID(), null).get();
+			final String savepointPath = restClusterClient.triggerSavepoint(new JobID(), null, 20000L).get();
 			assertEquals(expectedReturnedSavepointDir, savepointPath);
 		}
 	}
@@ -153,6 +154,7 @@ public class RestClusterClientSavepointTriggerTest extends TestLogger {
 			triggerRequestBody -> {
 				assertEquals(expectedSubmittedSavepointDir, triggerRequestBody.getTargetDirectory());
 				assertFalse(triggerRequestBody.isCancelJob());
+				assertEquals(1000L, triggerRequestBody.getTimeout());
 				return triggerId;
 			},
 			statusRequestTriggerId -> {
@@ -162,7 +164,7 @@ public class RestClusterClientSavepointTriggerTest extends TestLogger {
 
 			final RestClusterClient<?> restClusterClient = createRestClusterClient(restServerEndpoint.getServerAddress().getPort());
 
-			final String savepointPath = restClusterClient.triggerSavepoint(new JobID(), expectedSubmittedSavepointDir).get();
+			final String savepointPath = restClusterClient.triggerSavepoint(new JobID(), expectedSubmittedSavepointDir, 1000L).get();
 			assertEquals(expectedReturnedSavepointDir, savepointPath);
 		}
 	}
@@ -175,6 +177,7 @@ public class RestClusterClientSavepointTriggerTest extends TestLogger {
 		try (final RestServerEndpoint restServerEndpoint = createRestServerEndpoint(
 			request -> {
 				assertTrue(request.isCancelJob());
+				assertEquals(10000L, request.getTimeout());
 				return triggerId;
 			},
 			trigger -> {
@@ -184,7 +187,7 @@ public class RestClusterClientSavepointTriggerTest extends TestLogger {
 
 			final RestClusterClient<?> restClusterClient = createRestClusterClient(restServerEndpoint.getServerAddress().getPort());
 
-			final String savepointPath = restClusterClient.cancelWithSavepoint(new JobID(), null);
+			final String savepointPath = restClusterClient.cancelWithSavepoint(new JobID(), null, 10000L);
 			assertEquals(expectedSavepointDir, savepointPath);
 		}
 	}
@@ -200,7 +203,7 @@ public class RestClusterClientSavepointTriggerTest extends TestLogger {
 			final RestClusterClient<?> restClusterClient = createRestClusterClient(restServerEndpoint.getServerAddress().getPort());
 
 			try {
-				restClusterClient.triggerSavepoint(new JobID(), null).get();
+				restClusterClient.triggerSavepoint(new JobID(), null, -1L).get();
 			} catch (ExecutionException e) {
 				final Throwable cause = e.getCause();
 				assertThat(cause, instanceOf(SerializedThrowable.class));
@@ -229,7 +232,7 @@ public class RestClusterClientSavepointTriggerTest extends TestLogger {
 
 			final RestClusterClient<?> restClusterClient = createRestClusterClient(restServerEndpoint.getServerAddress().getPort());
 
-			final String savepointPath = restClusterClient.triggerSavepoint(new JobID(), null).get();
+			final String savepointPath = restClusterClient.triggerSavepoint(new JobID(), null, -1L).get();
 			assertEquals(expectedSavepointDir, savepointPath);
 		}
 	}

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -1506,6 +1506,9 @@
         },
         "cancel-job" : {
           "type" : "boolean"
+        },
+        "timeout" : {
+          "type" : "integer"
         }
       }
     },
@@ -1578,6 +1581,9 @@
         },
         "endOfEventTime" : {
           "type" : "boolean"
+        },
+        "timeout" : {
+          "type" : "integer"
         }
       }
     },

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -562,12 +562,13 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 			final JobID jobId,
 			final String targetDirectory,
 			final boolean cancelJob,
-			final Time timeout) {
+			final Time timeout,
+			long savepointTimeout) {
 		final CompletableFuture<JobMasterGateway> jobMasterGatewayFuture = getJobMasterGatewayFuture(jobId);
 
 		return jobMasterGatewayFuture.thenCompose(
 			(JobMasterGateway jobMasterGateway) ->
-				jobMasterGateway.triggerSavepoint(targetDirectory, cancelJob, timeout));
+				jobMasterGateway.triggerSavepoint(targetDirectory, cancelJob, timeout, savepointTimeout));
 	}
 
 	@Override
@@ -575,12 +576,13 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 			final JobID jobId,
 			final String targetDirectory,
 			final boolean advanceToEndOfEventTime,
-			final Time timeout) {
+			final Time timeout,
+			final long savepointTimeout) {
 		final CompletableFuture<JobMasterGateway> jobMasterGatewayFuture = getJobMasterGatewayFuture(jobId);
 
 		return jobMasterGatewayFuture.thenCompose(
 				(JobMasterGateway jobMasterGateway) ->
-						jobMasterGateway.stopWithSavepoint(targetDirectory, advanceToEndOfEventTime, timeout));
+						jobMasterGateway.stopWithSavepoint(targetDirectory, advanceToEndOfEventTime, timeout, savepointTimeout));
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -621,18 +621,20 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	public CompletableFuture<String> triggerSavepoint(
 			@Nullable final String targetDirectory,
 			final boolean cancelJob,
-			final Time timeout) {
+			final Time timeout,
+			final long savepointTimeout) {
 
-		return schedulerNG.triggerSavepoint(targetDirectory, cancelJob);
+		return schedulerNG.triggerSavepoint(targetDirectory, cancelJob, savepointTimeout);
 	}
 
 	@Override
 	public CompletableFuture<String> stopWithSavepoint(
 			@Nullable final String targetDirectory,
 			final boolean advanceToEndOfEventTime,
-			final Time timeout) {
+			final Time timeout,
+			final long savepointTimeout) {
 
-		return schedulerNG.stopWithSavepoint(targetDirectory, advanceToEndOfEventTime);
+		return schedulerNG.stopWithSavepoint(targetDirectory, advanceToEndOfEventTime, savepointTimeout);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -222,12 +222,14 @@ public interface JobMasterGateway extends
 	 * @param targetDirectory to which to write the savepoint data or null if the
 	 *                           default savepoint directory should be used
 	 * @param timeout for the rpc call
+	 * @param savepointTimeout Timeout for savepoint
 	 * @return Future which is completed with the savepoint path once completed
 	 */
 	CompletableFuture<String> triggerSavepoint(
 		@Nullable final String targetDirectory,
 		final boolean cancelJob,
-		@RpcTimeout final Time timeout);
+		@RpcTimeout final Time timeout,
+		final long savepointTimeout);
 
 	/**
 	 * Stops the job with a savepoint.
@@ -237,12 +239,14 @@ public interface JobMasterGateway extends
 	 * @param advanceToEndOfEventTime Flag indicating if the source should inject a {@code MAX_WATERMARK} in the pipeline
 	 *                              to fire any registered event-time timers
 	 * @param timeout for the rpc call
+	 * @param savepointTimeout Timeout for savepoint
 	 * @return Future which is completed with the savepoint path once completed
 	 */
 	CompletableFuture<String> stopWithSavepoint(
 		@Nullable final String targetDirectory,
 		final boolean advanceToEndOfEventTime,
-		@RpcTimeout final Time timeout);
+		@RpcTimeout final Time timeout,
+		final long savepointTimeout);
 
 	/**
 	 * Requests the statistics on operator back pressure.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -551,12 +551,12 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 		return runDispatcherCommand(dispatcherGateway -> dispatcherGateway.cancelJob(jobId, rpcTimeout));
 	}
 
-	public CompletableFuture<String> triggerSavepoint(JobID jobId, String targetDirectory, boolean cancelJob) {
-		return runDispatcherCommand(dispatcherGateway -> dispatcherGateway.triggerSavepoint(jobId, targetDirectory, cancelJob, rpcTimeout));
+	public CompletableFuture<String> triggerSavepoint(JobID jobId, String targetDirectory, boolean cancelJob, long timeout) {
+		return runDispatcherCommand(dispatcherGateway -> dispatcherGateway.triggerSavepoint(jobId, targetDirectory, cancelJob, rpcTimeout, timeout));
 	}
 
-	public CompletableFuture<String> stopWithSavepoint(JobID jobId, String targetDirectory, boolean advanceToEndOfEventTime) {
-		return runDispatcherCommand(dispatcherGateway -> dispatcherGateway.stopWithSavepoint(jobId, targetDirectory, advanceToEndOfEventTime, rpcTimeout));
+	public CompletableFuture<String> stopWithSavepoint(JobID jobId, String targetDirectory, boolean advanceToEndOfEventTime, long timeout) {
+		return runDispatcherCommand(dispatcherGateway -> dispatcherGateway.stopWithSavepoint(jobId, targetDirectory, advanceToEndOfEventTime, rpcTimeout, timeout));
 	}
 
 	public CompletableFuture<Acknowledge> disposeSavepoint(String savepointPath) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlers.java
@@ -141,6 +141,7 @@ public class SavepointHandlers extends AbstractAsynchronousOperationHandlers<Asy
 
 			final JobID jobId = request.getPathParameter(JobIDPathParameter.class);
 			final String requestedTargetDirectory = request.getRequestBody().getTargetDirectory();
+			final long savepointTimeout = request.getRequestBody().getTimeout();
 
 			if (requestedTargetDirectory == null && defaultSavepointDir == null) {
 				throw new RestHandlerException(
@@ -152,7 +153,7 @@ public class SavepointHandlers extends AbstractAsynchronousOperationHandlers<Asy
 
 			final boolean advanceToEndOfEventTime = request.getRequestBody().shouldAdvanceToEndOfEventTime();
 			final String targetDirectory = requestedTargetDirectory != null ? requestedTargetDirectory : defaultSavepointDir;
-			return gateway.stopWithSavepoint(jobId, targetDirectory, advanceToEndOfEventTime, RpcUtils.INF_TIMEOUT);
+			return gateway.stopWithSavepoint(jobId, targetDirectory, advanceToEndOfEventTime, RpcUtils.INF_TIMEOUT, savepointTimeout);
 		}
 	}
 
@@ -172,6 +173,7 @@ public class SavepointHandlers extends AbstractAsynchronousOperationHandlers<Asy
 		protected CompletableFuture<String> triggerOperation(HandlerRequest<SavepointTriggerRequestBody, SavepointTriggerMessageParameters> request, RestfulGateway gateway) throws RestHandlerException {
 			final JobID jobId = request.getPathParameter(JobIDPathParameter.class);
 			final String requestedTargetDirectory = request.getRequestBody().getTargetDirectory();
+			final long savepointTimeout = request.getRequestBody().getTimeout();
 
 			if (requestedTargetDirectory == null && defaultSavepointDir == null) {
 				throw new RestHandlerException(
@@ -183,7 +185,7 @@ public class SavepointHandlers extends AbstractAsynchronousOperationHandlers<Asy
 
 			final boolean cancelJob = request.getRequestBody().isCancelJob();
 			final String targetDirectory = requestedTargetDirectory != null ? requestedTargetDirectory : defaultSavepointDir;
-			return gateway.triggerSavepoint(jobId, targetDirectory, cancelJob, RpcUtils.INF_TIMEOUT);
+			return gateway.triggerSavepoint(jobId, targetDirectory, cancelJob, RpcUtils.INF_TIMEOUT, savepointTimeout);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerRequestBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerRequestBody.java
@@ -34,6 +34,8 @@ public class SavepointTriggerRequestBody implements RequestBody {
 
 	private static final String FIELD_NAME_CANCEL_JOB = "cancel-job";
 
+	private static final String FIELD_NAME_TIMEOUT = "timeout";
+
 	@JsonProperty(FIELD_NAME_TARGET_DIRECTORY)
 	@Nullable
 	private final String targetDirectory;
@@ -41,17 +43,26 @@ public class SavepointTriggerRequestBody implements RequestBody {
 	@JsonProperty(FIELD_NAME_CANCEL_JOB)
 	private final boolean cancelJob;
 
+	@JsonProperty(FIELD_NAME_TIMEOUT)
+	private final long timeout;
+
 	@JsonCreator
 	public SavepointTriggerRequestBody(
 			@Nullable @JsonProperty(FIELD_NAME_TARGET_DIRECTORY) final String targetDirectory,
-			@JsonProperty(value = FIELD_NAME_CANCEL_JOB, defaultValue = "false") final boolean cancelJob) {
+			@JsonProperty(value = FIELD_NAME_CANCEL_JOB, defaultValue = "false") final boolean cancelJob,
+			@JsonProperty(value = FIELD_NAME_TIMEOUT, defaultValue = "-1") final long timeout) {
 		this.targetDirectory = targetDirectory;
 		this.cancelJob = cancelJob;
+		this.timeout = timeout;
 	}
 
 	@Nullable
 	public String getTargetDirectory() {
 		return targetDirectory;
+	}
+
+	public long getTimeout() {
+		return timeout;
 	}
 
 	public boolean isCancelJob() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/stop/StopWithSavepointRequestBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/stop/StopWithSavepointRequestBody.java
@@ -34,6 +34,8 @@ public class StopWithSavepointRequestBody implements RequestBody {
 
 	private static final String FIELD_NAME_END_OF_EVENT_TIME = "endOfEventTime";
 
+	private static final String FIELD_NAME_TIMEOUT = "timeout";
+
 	@JsonProperty(FIELD_NAME_TARGET_DIRECTORY)
 	@Nullable
 	private final String targetDirectory;
@@ -41,17 +43,26 @@ public class StopWithSavepointRequestBody implements RequestBody {
 	@JsonProperty(FIELD_NAME_END_OF_EVENT_TIME)
 	private final boolean endOfEventTime;
 
+	@JsonProperty(FIELD_NAME_TIMEOUT)
+	private final long timeout;
+
 	@JsonCreator
 	public StopWithSavepointRequestBody(
 			@Nullable @JsonProperty(FIELD_NAME_TARGET_DIRECTORY) final String targetDirectory,
-			@JsonProperty(value = FIELD_NAME_END_OF_EVENT_TIME, defaultValue = "false") final boolean endOfEventTime) {
+			@JsonProperty(value = FIELD_NAME_END_OF_EVENT_TIME, defaultValue = "false") final boolean endOfEventTime,
+			@JsonProperty(value = FIELD_NAME_TIMEOUT, defaultValue = "-1") final long timeout) {
 		this.targetDirectory = targetDirectory;
 		this.endOfEventTime = endOfEventTime;
+		this.timeout = timeout;
 	}
 
 	@Nullable
 	public String getTargetDirectory() {
 		return targetDirectory;
+	}
+
+	public long getTimeout() {
+		return timeout;
 	}
 
 	public boolean shouldAdvanceToEndOfEventTime() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacyScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacyScheduler.java
@@ -467,7 +467,7 @@ public class LegacyScheduler implements SchedulerNG {
 	}
 
 	@Override
-	public CompletableFuture<String> triggerSavepoint(final String targetDirectory, final boolean cancelJob) {
+	public CompletableFuture<String> triggerSavepoint(final String targetDirectory, final boolean cancelJob, long timeout) {
 		mainThreadExecutor.assertRunningInMainThread();
 
 		final CheckpointCoordinator checkpointCoordinator = executionGraph.getCheckpointCoordinator();
@@ -488,7 +488,7 @@ public class LegacyScheduler implements SchedulerNG {
 		}
 
 		return checkpointCoordinator
-			.triggerSavepoint(System.currentTimeMillis(), targetDirectory)
+			.triggerSavepoint(System.currentTimeMillis(), targetDirectory, timeout)
 			.thenApply(CompletedCheckpoint::getExternalPointer)
 			.handleAsync((path, throwable) -> {
 				if (throwable != null) {
@@ -574,7 +574,7 @@ public class LegacyScheduler implements SchedulerNG {
 	}
 
 	@Override
-	public CompletableFuture<String> stopWithSavepoint(final String targetDirectory, final boolean advanceToEndOfEventTime) {
+	public CompletableFuture<String> stopWithSavepoint(final String targetDirectory, final boolean advanceToEndOfEventTime, long timeout) {
 		mainThreadExecutor.assertRunningInMainThread();
 
 		final CheckpointCoordinator checkpointCoordinator = executionGraph.getCheckpointCoordinator();
@@ -602,7 +602,7 @@ public class LegacyScheduler implements SchedulerNG {
 		checkpointCoordinator.stopCheckpointScheduler();
 
 		final CompletableFuture<String> savepointFuture = checkpointCoordinator
-			.triggerSynchronousSavepoint(now, advanceToEndOfEventTime, targetDirectory)
+			.triggerSynchronousSavepoint(now, advanceToEndOfEventTime, targetDirectory, timeout)
 			.handle((completedCheckpoint, throwable) -> {
 				if (throwable != null) {
 					log.info("Failed during stopping job {} with a savepoint. Reason: {}", jobGraph.getJobID(), throwable.getMessage());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
@@ -111,11 +111,11 @@ public interface SchedulerNG {
 
 	// ------------------------------------------------------------------------
 
-	CompletableFuture<String> triggerSavepoint(@Nullable String targetDirectory, boolean cancelJob);
+	CompletableFuture<String> triggerSavepoint(@Nullable String targetDirectory, boolean cancelJob, long timeout);
 
 	void acknowledgeCheckpoint(JobID jobID, ExecutionAttemptID executionAttemptID, long checkpointId, CheckpointMetrics checkpointMetrics, TaskStateSnapshot checkpointState);
 
 	void declineCheckpoint(DeclineCheckpoint decline);
 
-	CompletableFuture<String> stopWithSavepoint(String targetDirectory, boolean advanceToEndOfEventTime);
+	CompletableFuture<String> stopWithSavepoint(String targetDirectory, boolean advanceToEndOfEventTime, long timeout);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
@@ -114,6 +114,7 @@ public interface RestfulGateway extends RpcGateway {
 	 * @param jobId           ID of the job for which the savepoint should be triggered.
 	 * @param targetDirectory Target directory for the savepoint.
 	 * @param timeout         Timeout for the asynchronous operation
+	 * @param savepointTimeout Timeout for the savepoint
 	 * @return A future to the {@link CompletedCheckpoint#getExternalPointer() external pointer} of
 	 * the savepoint.
 	 */
@@ -121,7 +122,8 @@ public interface RestfulGateway extends RpcGateway {
 			JobID jobId,
 			String targetDirectory,
 			boolean cancelJob,
-			@RpcTimeout Time timeout) {
+			@RpcTimeout Time timeout,
+			long savepointTimeout) {
 		throw new UnsupportedOperationException();
 	}
 
@@ -134,13 +136,15 @@ public interface RestfulGateway extends RpcGateway {
 	 * @param advanceToEndOfEventTime Flag indicating if the source should inject a {@code MAX_WATERMARK} in the pipeline
 	 *                              to fire any registered event-time timers
 	 * @param timeout for the rpc call
+	 * @param savepointTimeout Timeout for savepoint
 	 * @return Future which is completed with the savepoint path once completed
 	 */
 	default CompletableFuture<String> stopWithSavepoint(
 			final JobID jobId,
 			final String targetDirectory,
 			final boolean advanceToEndOfEventTime,
-			@RpcTimeout final Time timeout) {
+			@RpcTimeout final Time timeout,
+			long savepointTimeout) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -1464,7 +1464,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 		// trigger the first checkpoint. this should succeed
 		String savepointDir = tmpFolder.newFolder().getAbsolutePath();
-		CompletableFuture<CompletedCheckpoint> savepointFuture = coord.triggerSavepoint(timestamp, savepointDir);
+		CompletableFuture<CompletedCheckpoint> savepointFuture = coord.triggerSavepoint(timestamp, savepointDir, -1L);
 		assertFalse(savepointFuture.isDone());
 
 		// validate that we have a pending savepoint
@@ -1542,7 +1542,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		// trigger another checkpoint and see that this one replaces the other checkpoint
 		// ---------------
 		final long timestampNew = timestamp + 7;
-		savepointFuture = coord.triggerSavepoint(timestampNew, savepointDir);
+		savepointFuture = coord.triggerSavepoint(timestampNew, savepointDir, -1L);
 		assertFalse(savepointFuture.isDone());
 
 		long checkpointIdNew = coord.getPendingCheckpoints().entrySet().iterator().next().getKey();
@@ -1615,7 +1615,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		String savepointDir = tmpFolder.newFolder().getAbsolutePath();
 
 		// Trigger savepoint and checkpoint
-		CompletableFuture<CompletedCheckpoint> savepointFuture1 = coord.triggerSavepoint(timestamp, savepointDir);
+		CompletableFuture<CompletedCheckpoint> savepointFuture1 = coord.triggerSavepoint(timestamp, savepointDir, -1L);
 		long savepointId1 = counter.getLast();
 		assertEquals(1, coord.getNumberOfPendingCheckpoints());
 
@@ -1639,7 +1639,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		assertTrue(coord.triggerCheckpoint(timestamp + 3, false));
 		assertEquals(2, coord.getNumberOfPendingCheckpoints());
 
-		CompletableFuture<CompletedCheckpoint> savepointFuture2 = coord.triggerSavepoint(timestamp + 4, savepointDir);
+		CompletableFuture<CompletedCheckpoint> savepointFuture2 = coord.triggerSavepoint(timestamp + 4, savepointDir, -1L);
 		long savepointId2 = counter.getLast();
 		assertEquals(3, coord.getNumberOfPendingCheckpoints());
 
@@ -1922,7 +1922,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 		// Trigger savepoints
 		for (int i = 0; i < numSavepoints; i++) {
-			savepointFutures.add(coord.triggerSavepoint(i, savepointDir));
+			savepointFutures.add(coord.triggerSavepoint(i, savepointDir, -1L));
 		}
 
 		// After triggering multiple savepoints, all should in progress
@@ -1971,10 +1971,10 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 		String savepointDir = tmpFolder.newFolder().getAbsolutePath();
 
-		CompletableFuture<CompletedCheckpoint> savepoint0 = coord.triggerSavepoint(0, savepointDir);
+		CompletableFuture<CompletedCheckpoint> savepoint0 = coord.triggerSavepoint(0, savepointDir, -1L);
 		assertFalse("Did not trigger savepoint", savepoint0.isDone());
 
-		CompletableFuture<CompletedCheckpoint> savepoint1 = coord.triggerSavepoint(1, savepointDir);
+		CompletableFuture<CompletedCheckpoint> savepoint1 = coord.triggerSavepoint(1, savepointDir, -1L);
 		assertFalse("Did not trigger savepoint", savepoint1.isDone());
 	}
 
@@ -2307,7 +2307,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// trigger a savepoint and wait it to be finished
 			String savepointDir = tmpFolder.newFolder().getAbsolutePath();
 			timestamp = System.currentTimeMillis();
-			CompletableFuture<CompletedCheckpoint> savepointFuture = coord.triggerSavepoint(timestamp, savepointDir);
+			CompletableFuture<CompletedCheckpoint> savepointFuture = coord.triggerSavepoint(timestamp, savepointDir, -1L);
 
 
 			KeyGroupRange keyGroupRangeForSavepoint = KeyGroupRange.of(1, 1);
@@ -3322,7 +3322,8 @@ public class CheckpointCoordinatorTest extends TestLogger {
 					CheckpointProperties.forCheckpoint(CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
 					null,
 					true,
-					false);
+					false,
+					-1L);
 			fail("The triggerCheckpoint call expected an exception");
 		} catch (CheckpointException e) {
 			assertEquals(CheckpointFailureReason.PERIODIC_SCHEDULER_SHUTDOWN, e.getCheckpointFailureReason());
@@ -3335,7 +3336,8 @@ public class CheckpointCoordinatorTest extends TestLogger {
 					CheckpointProperties.forCheckpoint(CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
 					null,
 					false,
-					false);
+					false,
+					-1L);
 		} catch (CheckpointException e) {
 			fail("Unexpected exception : " + e.getCheckpointFailureReason().message());
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -1428,7 +1428,7 @@ public class JobMasterTest extends TestLogger {
 	}
 
 	/**
-	 * Tests that the timeout in {@link JobMasterGateway#triggerSavepoint(String, boolean, Time)}
+	 * Tests that the timeout in {@link JobMasterGateway#triggerSavepoint(String, boolean, Time, long)}
 	 * is respected.
 	 */
 	@Test
@@ -1459,7 +1459,8 @@ public class JobMasterTest extends TestLogger {
 			public CompletableFuture<String> triggerSavepoint(
 				@Nullable final String targetDirectory,
 				final boolean cancelJob,
-				final Time timeout) {
+				final Time timeout,
+				final long savepointTimeout) {
 				return new CompletableFuture<>();
 			}
 		};
@@ -1469,8 +1470,8 @@ public class JobMasterTest extends TestLogger {
 			startFuture.get(testingTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 
 			final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
-			final CompletableFuture<String> savepointFutureLowTimeout = jobMasterGateway.triggerSavepoint("/tmp", false, Time.milliseconds(1));
-			final CompletableFuture<String> savepointFutureHighTimeout = jobMasterGateway.triggerSavepoint("/tmp", false, RpcUtils.INF_TIMEOUT);
+			final CompletableFuture<String> savepointFutureLowTimeout = jobMasterGateway.triggerSavepoint("/tmp", false, Time.milliseconds(1), -1L);
+			final CompletableFuture<String> savepointFutureHighTimeout = jobMasterGateway.triggerSavepoint("/tmp", false, RpcUtils.INF_TIMEOUT, -1L);
 
 			try {
 				savepointFutureLowTimeout.get(testingTimeout.getSize(), testingTimeout.getUnit());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
@@ -290,12 +290,12 @@ public class TestingJobMasterGateway implements JobMasterGateway {
 	}
 
 	@Override
-	public CompletableFuture<String> triggerSavepoint(@Nullable final String targetDirectory, final boolean cancelJob, final Time timeout) {
+	public CompletableFuture<String> triggerSavepoint(@Nullable final String targetDirectory, final boolean cancelJob, final Time timeout, final long savepointTimeout) {
 		return triggerSavepointFunction.apply(targetDirectory, cancelJob);
 	}
 
 	@Override
-	public CompletableFuture<String> stopWithSavepoint(@Nullable final String targetDirectory, final boolean advanceToEndOfEventTime, final Time timeout) {
+	public CompletableFuture<String> stopWithSavepoint(@Nullable final String targetDirectory, final boolean advanceToEndOfEventTime, final Time timeout, final long savepointTimeout) {
 		return stopWithSavepointFunction.apply(targetDirectory, advanceToEndOfEventTime);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/async/AbstractAsynchronousOperationHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/async/AbstractAsynchronousOperationHandlersTest.java
@@ -342,7 +342,7 @@ public class AbstractAsynchronousOperationHandlersTest extends TestLogger {
 
 			@Override
 			protected CompletableFuture<String> triggerOperation(HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request, RestfulGateway gateway) throws RestHandlerException {
-				return gateway.triggerSavepoint(new JobID(), null, false, timeout);
+				return gateway.triggerSavepoint(new JobID(), null, false, timeout, -1L);
 			}
 
 			@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
@@ -194,7 +194,7 @@ public class SavepointHandlersTest extends TestLogger {
 			final String targetDirectory
 	) throws HandlerRequestException {
 		return new HandlerRequest<>(
-			new SavepointTriggerRequestBody(targetDirectory, false),
+			new SavepointTriggerRequestBody(targetDirectory, false, -1L),
 			new SavepointTriggerMessageParameters(),
 			Collections.singletonMap(JobIDPathParameter.KEY, JOB_ID.toString()),
 			Collections.emptyMap());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/StopWithSavepointHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/StopWithSavepointHandlersTest.java
@@ -196,7 +196,7 @@ public class StopWithSavepointHandlersTest extends TestLogger {
 			final String targetDirectory
 	) throws HandlerRequestException {
 		return new HandlerRequest<>(
-				new StopWithSavepointRequestBody(targetDirectory, false),
+				new StopWithSavepointRequestBody(targetDirectory, false, -1L),
 				new SavepointTriggerMessageParameters(),
 				Collections.singletonMap(JobIDPathParameter.KEY, JOB_ID.toString()),
 				Collections.emptyMap());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerRequestBodyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerRequestBodyTest.java
@@ -44,8 +44,8 @@ public class SavepointTriggerRequestBodyTest
 	@Parameterized.Parameters
 	public static Collection<Object[]> data() {
 		return Arrays.asList(new Object[][]{
-			{new SavepointTriggerRequestBody("/tmp", true)},
-			{new SavepointTriggerRequestBody("/tmp", false)}
+			{new SavepointTriggerRequestBody("/tmp", true, -1L)},
+			{new SavepointTriggerRequestBody("/tmp", false, -1L)}
 		});
 	}
 
@@ -64,5 +64,6 @@ public class SavepointTriggerRequestBodyTest
 			final SavepointTriggerRequestBody expected,
 			final SavepointTriggerRequestBody actual) {
 		assertEquals(expected.getTargetDirectory(), actual.getTargetDirectory());
+		assertEquals(expected.getTimeout(), actual.getTimeout());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/TestingRestfulGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/TestingRestfulGateway.java
@@ -178,12 +178,12 @@ public class TestingRestfulGateway implements RestfulGateway {
 	}
 
 	@Override
-	public CompletableFuture<String> triggerSavepoint(JobID jobId, String targetDirectory, boolean cancelJob, Time timeout) {
+	public CompletableFuture<String> triggerSavepoint(JobID jobId, String targetDirectory, boolean cancelJob, Time timeout, long savepointTimeout) {
 		return triggerSavepointFunction.apply(jobId, targetDirectory);
 	}
 
 	@Override
-	public CompletableFuture<String> stopWithSavepoint(JobID jobId, String targetDirectory, boolean advanceToEndOfTime, Time timeout) {
+	public CompletableFuture<String> stopWithSavepoint(JobID jobId, String targetDirectory, boolean advanceToEndOfTime, Time timeout, long savepointTimeout) {
 		return stopWithSavepointFunction.apply(jobId, targetDirectory);
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointIT.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointIT.java
@@ -194,7 +194,8 @@ public class JobMasterStopWithSavepointIT extends AbstractTestBase {
 		return miniClusterResource.getMiniCluster().stopWithSavepoint(
 				jobGraph.getJobID(),
 				savepointDirectory.toAbsolutePath().toString(),
-				terminate);
+				terminate,
+				-1L);
 	}
 
 	private JobStatus getJobStatus() throws InterruptedException, ExecutionException {

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTriggerSavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTriggerSavepointITCase.java
@@ -61,7 +61,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.isOneOf;
 
 /**
- * Tests for {@link org.apache.flink.runtime.jobmaster.JobMaster#triggerSavepoint(String, boolean, Time)}.
+ * Tests for {@link org.apache.flink.runtime.jobmaster.JobMaster#triggerSavepoint(String, boolean, Time, long)}.
  *
  * @see org.apache.flink.runtime.jobmaster.JobMaster
  */
@@ -181,7 +181,7 @@ public class JobMasterTriggerSavepointITCase extends AbstractTestBase {
 		setUpWithCheckpointInterval(10L);
 
 		try {
-			clusterClient.cancelWithSavepoint(jobGraph.getJobID(), null);
+			clusterClient.cancelWithSavepoint(jobGraph.getJobID(), null, -1L);
 		} catch (Exception e) {
 			if (!ExceptionUtils.findThrowableWithMessage(e, "savepoint directory").isPresent()) {
 				throw e;
@@ -250,7 +250,7 @@ public class JobMasterTriggerSavepointITCase extends AbstractTestBase {
 	private String cancelWithSavepoint() throws Exception {
 		return clusterClient.cancelWithSavepoint(
 			jobGraph.getJobID(),
-			savepointDirectory.toAbsolutePath().toString());
+			savepointDirectory.toAbsolutePath().toString(), -1L);
 	}
 
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
@@ -210,7 +210,7 @@ public class RescalingITCase extends TestLogger {
 			// clear the CollectionSink set for the restarted job
 			CollectionSink.clearElementsSet();
 
-			CompletableFuture<String> savepointPathFuture = client.triggerSavepoint(jobID, null);
+			CompletableFuture<String> savepointPathFuture = client.triggerSavepoint(jobID, null, -1L);
 
 			final String savepointPath = savepointPathFuture.get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
 
@@ -274,7 +274,7 @@ public class RescalingITCase extends TestLogger {
 			// wait until the operator is started
 			StateSourceBase.workStartedLatch.await();
 
-			CompletableFuture<String> savepointPathFuture = client.triggerSavepoint(jobID, null);
+			CompletableFuture<String> savepointPathFuture = client.triggerSavepoint(jobID, null, -1L);
 
 			final String savepointPath = savepointPathFuture.get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
 
@@ -358,7 +358,7 @@ public class RescalingITCase extends TestLogger {
 			// clear the CollectionSink set for the restarted job
 			CollectionSink.clearElementsSet();
 
-			CompletableFuture<String> savepointPathFuture = client.triggerSavepoint(jobID, null);
+			CompletableFuture<String> savepointPathFuture = client.triggerSavepoint(jobID, null, -1L);
 
 			final String savepointPath = savepointPathFuture.get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
 
@@ -468,7 +468,7 @@ public class RescalingITCase extends TestLogger {
 			CompletableFuture<String> savepointPathFuture = FutureUtils.retryWithDelay(
 				() -> {
 					try {
-						return client.triggerSavepoint(jobID, null);
+						return client.triggerSavepoint(jobID, null, -1L);
 					} catch (FlinkException e) {
 						return FutureUtils.completedExceptionally(e);
 					}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -192,7 +192,7 @@ public class SavepointITCase extends TestLogger {
 
 			StatefulCounter.getProgressLatch().await();
 
-			return client.cancelWithSavepoint(jobId, null);
+			return client.cancelWithSavepoint(jobId, null, -1L);
 		} finally {
 			cluster.after();
 			StatefulCounter.resetForTest(parallelism);
@@ -279,7 +279,7 @@ public class SavepointITCase extends TestLogger {
 		final JobID jobID = new JobID();
 
 		try {
-			client.triggerSavepoint(jobID, null).get();
+			client.triggerSavepoint(jobID, null, -1L).get();
 
 			fail();
 		} catch (ExecutionException e) {
@@ -317,7 +317,7 @@ public class SavepointITCase extends TestLogger {
 			client.setDetached(true);
 			client.submitJob(graph, SavepointITCase.class.getClassLoader());
 
-			client.triggerSavepoint(graph.getJobID(), null).get();
+			client.triggerSavepoint(graph.getJobID(), null, -1L).get();
 
 			fail();
 		} catch (ExecutionException e) {
@@ -438,7 +438,7 @@ public class SavepointITCase extends TestLogger {
 			// wait for the Tasks to be ready
 			StatefulCounter.getProgressLatch().await(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
 
-			savepointPath = client.triggerSavepoint(jobID, null).get();
+			savepointPath = client.triggerSavepoint(jobID, null, -1L).get();
 			LOG.info("Retrieved savepoint: " + savepointPath + ".");
 		} finally {
 			// Shut down the Flink cluster (thereby canceling the job)
@@ -684,7 +684,7 @@ public class SavepointITCase extends TestLogger {
 			for (OneShotLatch latch : iterTestSnapshotWait) {
 				latch.await();
 			}
-			savepointPath = client.triggerSavepoint(jobGraph.getJobID(), null).get();
+			savepointPath = client.triggerSavepoint(jobGraph.getJobID(), null, -1L).get();
 
 			client.cancel(jobGraph.getJobID());
 			while (!client.getJobStatus(jobGraph.getJobID()).get().isGloballyTerminalState()) {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/SavepointMigrationTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/SavepointMigrationTestBase.java
@@ -173,7 +173,7 @@ public abstract class SavepointMigrationTestBase extends TestBaseUtils {
 
 		LOG.info("Triggering savepoint.");
 
-		CompletableFuture<String> savepointPathFuture = client.triggerSavepoint(jobSubmissionResult.getJobID(), null);
+		CompletableFuture<String> savepointPathFuture = client.triggerSavepoint(jobSubmissionResult.getJobID(), null, -1L);
 
 		String jobmanagerSavepointPath = savepointPathFuture.get(DEADLINE.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
 

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
@@ -361,7 +361,7 @@ public class ClassLoaderITCase extends TestLogger {
 		for (int i = 0; i < 20; i++) {
 			LOG.info("Triggering savepoint (" + (i + 1) + "/20).");
 			try {
-				savepointPath = clusterClient.triggerSavepoint(jobId, null)
+				savepointPath = clusterClient.triggerSavepoint(jobId, null, -1L)
 					.get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
 			} catch (Exception cause) {
 				LOG.info("Failed to trigger savepoint. Retrying...", cause);

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/AbstractOperatorRestoreTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/AbstractOperatorRestoreTestBase.java
@@ -138,7 +138,8 @@ public abstract class AbstractOperatorRestoreTestBase extends TestLogger {
 			try {
 				savepointPath = clusterClient.cancelWithSavepoint(
 					jobToMigrate.getJobID(),
-					targetDirectory.getAbsolutePath());
+					targetDirectory.getAbsolutePath(),
+					-1L);
 			} catch (Exception e) {
 				String exceptionString = ExceptionUtils.stringifyException(e);
 				if (!(exceptionString.matches("(.*\n)*.*savepoint for the job .* failed(.*\n)*") // legacy

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/TimestampITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/TimestampITCase.java
@@ -194,7 +194,7 @@ public class TimestampITCase extends TestLogger {
 					// send stop until the job is stopped
 					do {
 						try {
-							clusterClient.stopWithSavepoint(id, false, "test");
+							clusterClient.stopWithSavepoint(id, false, "test", -1L);
 						}
 						catch (Exception e) {
 							if (

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/util/FakeClusterClient.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/util/FakeClusterClient.java
@@ -69,12 +69,12 @@ public class FakeClusterClient extends ClusterClient<ApplicationId> {
 		// no op
 	}
 
-	public String cancelWithSavepoint(JobID jobId, @Nullable String savepointDirectory) {
+	public String cancelWithSavepoint(JobID jobId, @Nullable String savepointDirectory, long timeout) {
 		throw new UnsupportedOperationException("Not needed in test.");
 	}
 
 	@Override
-	public String stopWithSavepoint(JobID jobId, boolean advanceToEndOfEventTime, @Nullable String savepointDirectory) throws Exception {
+	public String stopWithSavepoint(JobID jobId, boolean advanceToEndOfEventTime, @Nullable String savepointDirectory, long timeout) throws Exception {
 		throw new UnsupportedOperationException("Not needed in test.");
 	}
 
@@ -82,7 +82,7 @@ public class FakeClusterClient extends ClusterClient<ApplicationId> {
 		// no op
 	}
 
-	public CompletableFuture<String> triggerSavepoint(JobID jobId, @Nullable String savepointDirectory) {
+	public CompletableFuture<String> triggerSavepoint(JobID jobId, @Nullable String savepointDirectory, long savepointTimeout) {
 		throw new UnsupportedOperationException("Not needed in test.");
 	}
 


### PR DESCRIPTION
Mirror of apache flink#8679
## What is the purpose of the change

*This pull request supports specify the savepoint timeout via CLI*

## Brief change log

  - *Specify savepoint timeout via CLI*

## Verifying this change

This change is already covered by existing tests, such as *CliFrontEndXXXTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)

