### PR TITLE
Mirror of apache flink#8675

### DIFF
--- a/docs/ops/python_shell.zh.md
+++ b/docs/ops/python_shell.zh.md
@@ -1,0 +1,179 @@
+---
+title: "Python REPL"
+nav-parent_id: ops
+nav-pos: 7
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+Flink附带了一个集成的交互式Python Shell。
+它既能够用在本地启动的local模式，也能够用在集群启动的cluster模式下。
+
+为了使用Flink的Python Shell，你只需要在Flink的binary目录下执行:
+
+{% highlight bash %}
+bin/pyflink-shell.sh local
+{% endhighlight %}
+
+关于如何在一个Cluster集群上运行Python shell，可以参考下面的启动那一节的内容
+
+## 使用
+
+当前Python shell支持Table API的功能。
+在启动之后，Table Environment的相关内容将会被自动加载。
+可以通过变量"bt_env"来使用BatchTableEnvironment，通过变量"st_env"来使用StreamTableEnvironment。
+
+### Table API
+
+下面的内容是关于如何通过Table API来实现一个wordcount的作业:
+<div class="codetabs" markdown="1">
+<div data-lang="stream" markdown="1">
+{% highlight python %}
+>>> import tempfile
+>>> import os
+>>> sink_path = tempfile.gettempdir() + '/streaming.csv'
+>>> if os.path.isfile(sink_path):
+>>>     os.remove(sink_path)
+>>> t = st_env.from_elements([(1, 'hi', 'hello'), (2, 'hi', 'hello')], ['a', 'b', 'c'])
+>>> st_env.connect(FileSystem().path(sink_path))\
+>>>     .with_format(OldCsv()
+>>>         .field_delimiter(',')
+>>>         .field("a", DataTypes.BIGINT())
+>>>         .field("b", DataTypes.STRING())
+>>>         .field("c", DataTypes.STRING()))\
+>>>     .with_schema(Schema()
+>>>         .field("a", DataTypes.BIGINT())
+>>>         .field("b", DataTypes.STRING())
+>>>         .field("c", DataTypes.STRING()))\
+>>>     .register_table_sink("stream_sink")
+>>> t.select("a + 1, b, c")\
+>>>     .insert_into("stream_sink")
+>>> st_env.execute()
+{% endhighlight %}
+</div>
+<div data-lang="batch" markdown="1">
+{% highlight python %}
+>>> import tempfile
+>>> import os
+>>> sink_path = tempfile.gettempdir() + '/batch.csv'
+>>> if os.path.isfile(sink_path):
+>>>     os.remove(sink_path)
+>>> t = bt_env.from_elements([(1, 'hi', 'hello'), (2, 'hi', 'hello')], ['a', 'b', 'c'])
+>>> bt_env.connect(FileSystem().path(sink_path))\
+>>>     .with_format(OldCsv()
+>>>         .field_delimiter(',')
+>>>         .field("a", DataTypes.BIGINT())
+>>>         .field("b", DataTypes.STRING())
+>>>         .field("c", DataTypes.STRING()))\
+>>>     .with_schema(Schema()
+>>>         .field("a", DataTypes.BIGINT())
+>>>         .field("b", DataTypes.STRING())
+>>>         .field("c", DataTypes.STRING()))\
+>>>     .register_table_sink("batch_sink")
+>>> t.select("a + 1, b, c")\
+>>>     .insert_into("batch_sink")
+>>> bt_env.execute()
+{% endhighlight %}
+</div>
+</div>
+
+## 启动
+
+为了概览Python Shell提供的可选参数，可以使用:
+
+{% highlight bash %}
+bin/pyflink-shell.sh --help
+{% endhighlight %}
+
+### Local
+
+可以指定Python Shell运行在local本地，只需要执行:
+
+{% highlight bash %}
+bin/pyflink-shell.sh local
+{% endhighlight %}
+
+
+### Remote
+
+可以指定Python Shell运行在一个指定的JobManager上，通过关键字`remote`和对应的JobManager
+的地址和端口号来进行指定:
+
+{% highlight bash %}
+bin/pyflink-shell.sh remote <hostname> <portnumber>
+{% endhighlight %}
+
+### Yarn Python Shell cluster
+
+可以指定Python Shell运行在YARN集群之上。YARN的container的数量可以通过参数`-n <arg>`进行
+指定。Python shell在Yarn上部署一个新的Flink集群，并进行连接。除了指定container数量，你也
+可以指定JobManager的内存，YARN应用的名字等参数。
+例如，运行Python Shell部署一个包含两个TaskManager的Yarn集群:
+
+{% highlight bash %}
+ bin/pyflink-shell.sh yarn -n 2
+{% endhighlight %}
+
+关于所有可选的参数，可以查看本页面底部的完整说明。
+
+
+### Yarn Session
+
+如果你已经通过Flink Yarn Session部署了一个Flink集群，能够通过以下的命令连接到这个集群:
+
+{% highlight bash %}
+ bin/pyflink-shell.sh yarn
+{% endhighlight %}
+
+
+## 完整的参考
+
+{% highlight bash %}
+Flink Python Shell
+使用: pyflink-shell.sh [local|remote|yarn] [options] <args>...
+
+命令: local [选项]
+启动一个部署在local本地的Flink Python shell
+
+命令: remote [选项] <host> <port>
+启动一个部署在remote集群的Flink Python shell
+  <host>
+        JobManager的主机名
+  <port>
+        JobManager的端口号
+
+命令: yarn [选项]
+启动一个部署在Yarn集群的Flink Python Shell
+  -n arg | --container arg
+        需要分配的YARN container的数量 (=TaskManager的数量)
+  -jm arg | --jobManagerMemory arg
+        具有可选单元的JobManager的container的内存（默认值：MB）
+  -nm <value> | --name <value>
+        自定义YARN Application的名字
+  -qu <arg> | --queue <arg>
+        指定YARN的queue
+  -s <arg> | --slots <arg>
+        每个TaskManager上slots的数量
+  -tm <arg> | --taskManagerMemory <arg>
+        具有可选单元的每个TaskManager的container的内存（默认值：MB）
+-h | --help
+    打印输出使用文档
+{% endhighlight %}
+
+{% top %}

--- a/docs/redirects/python_shell.md
+++ b/docs/redirects/python_shell.md
@@ -1,0 +1,24 @@
+---
+title: "Python Shell"
+layout: redirect
+redirect: /ops/python_shell.html
+permalink: /apis/python_shell.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -774,22 +774,24 @@ public class CliFrontend {
 		String jarFilePath = options.getJarFilePath();
 		List<URL> classpaths = options.getClasspaths();
 
-		String entryPointClass;
+		// Get assembler class
+		String entryPointClass = options.getEntryPointClassName();
 		File jarFile = null;
 		if (options.isPython()) {
 			// If the job is specified a jar file
 			if (jarFilePath != null) {
 				jarFile = getJarFile(jarFilePath);
 			}
-			// The entry point class of python job is PythonDriver
-			entryPointClass = "org.apache.flink.python.client.PythonDriver";
+			// If the job is Python Shell job, the entry point class name is PythonGateWayServer.
+			// Otherwise, the entry point class of python job is PythonDriver
+			if (options.getEntryPointClassName() == null) {
+				entryPointClass = "org.apache.flink.python.client.PythonDriver";
+			}
 		} else {
 			if (jarFilePath == null) {
 				throw new IllegalArgumentException("Java program should be specified a JAR file.");
 			}
 			jarFile = getJarFile(jarFilePath);
-			// Get assembler class
-			entryPointClass = options.getEntryPointClassName();
 		}
 
 		PackagedProgram program = entryPointClass == null ?

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptions.java
@@ -77,7 +77,11 @@ public abstract class ProgramOptions extends CommandLineOptions {
 			line.getOptionValues(ARGS_OPTION.getOpt()) :
 			line.getArgs();
 
-		isPython = line.hasOption(PY_OPTION.getOpt()) | line.hasOption(PYMODULE_OPTION.getOpt());
+		this.entryPointClass = line.hasOption(CLASS_OPTION.getOpt()) ?
+			line.getOptionValue(CLASS_OPTION.getOpt()) : null;
+
+		isPython = line.hasOption(PY_OPTION.getOpt()) | line.hasOption(PYMODULE_OPTION.getOpt())
+			| "org.apache.flink.python.client.PythonGatewayServer".equals(entryPointClass);
 		// If specified the option -py(--python)
 		if (line.hasOption(PY_OPTION.getOpt())) {
 			// Cannot use option -py and -pym simultaneously.
@@ -150,9 +154,6 @@ public abstract class ProgramOptions extends CommandLineOptions {
 			}
 		}
 		this.classpaths = classpaths;
-
-		this.entryPointClass = line.hasOption(CLASS_OPTION.getOpt()) ?
-			line.getOptionValue(CLASS_OPTION.getOpt()) : null;
 
 		if (line.hasOption(PARALLELISM_OPTION.getOpt())) {
 			String parString = line.getOptionValue(PARALLELISM_OPTION.getOpt());

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -182,7 +182,8 @@ public class PackagedProgram {
 	 */
 	public PackagedProgram(File jarFile, List<URL> classpaths, @Nullable String entryPointClassName, String... args) throws ProgramInvocationException {
 		// Whether the job is a Python job.
-		isPython = entryPointClassName != null && entryPointClassName.equals("org.apache.flink.python.client.PythonDriver");
+		isPython = entryPointClassName != null && (entryPointClassName.equals("org.apache.flink.python.client.PythonDriver")
+			|| entryPointClassName.equals("org.apache.flink.python.client.PythonGatewayServer"));
 
 		URL jarFileUrl = null;
 		if (jarFile != null) {

--- a/flink-dist/src/main/flink-bin/bin/pyflink-gateway-server.sh
+++ b/flink-dist/src/main/flink-bin/bin/pyflink-gateway-server.sh
@@ -67,4 +67,11 @@ if [[ -n "$FLINK_TESTING" ]]; then
   done < <(find "$FLINK_SOURCE_ROOT_DIR" ! -type d \( -name 'flink-*-tests.jar' -o -path "${FLINK_SOURCE_ROOT_DIR}/flink-connectors/flink-connector-elasticsearch-base/target/flink*.jar" -o -path "${FLINK_SOURCE_ROOT_DIR}/flink-connectors/flink-connector-kafka-base/target/flink*.jar" \) -print0 | sort -z)
 fi
 
-exec $JAVA_RUN $JVM_ARGS "${log_setting[@]}" -cp ${FLINK_CLASSPATH}:${TABLE_JAR_PATH}:${PYTHON_JAR_PATH}:${FLINK_TEST_CLASSPATH} ${DRIVER} ${ARGS[@]}
+ARGS_COUNT=${#ARGS[@]}
+if [[ ${ARGS[0]} == "local" ]]; then
+  ARGS=("${ARGS[@]:1:$ARGS_COUNT}")
+  exec $JAVA_RUN $JVM_ARGS "${log_setting[@]}" -cp ${FLINK_CLASSPATH}:${TABLE_JAR_PATH}:${PYTHON_JAR_PATH}:${FLINK_TEST_CLASSPATH} ${DRIVER} ${ARGS[@]}
+else
+  ARGS=("${ARGS[@]:1:$ARGS_COUNT}")
+  exec "$FLINK_BIN_DIR"/flink run ${ARGS[@]} -c ${DRIVER} -j ${TABLE_JAR_PATH}
+fi

--- a/flink-dist/src/main/flink-bin/bin/pyflink-shell.sh
+++ b/flink-dist/src/main/flink-bin/bin/pyflink-shell.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+bin=`dirname "$0"`
+bin=`cd "$bin"; pwd`
+
+. "$bin"/config.sh
+
+FLINK_CLASSPATH=`constructFlinkClassPath`
+PYTHON_JAR_PATH=`echo "$FLINK_ROOT_DIR"/opt/flink-python*java-binding.jar`
+
+
+PYFLINK_PYTHON="${PYFLINK_PYTHON:-"python"}"
+
+# So that python can find out Flink's Jars
+export FLINK_BIN_DIR=$FLINK_BIN_DIR
+export FLINK_ROOT_DIR
+
+# Add pyflink & py4j to PYTHONPATH
+export PYTHONPATH="$FLINK_OPT_DIR/python/pyflink.zip:$PYTHONPATH"
+PY4J_ZIP=`echo "$FLINK_OPT_DIR"/python/py4j-*-src.zip`
+export PYTHONPATH="$PY4J_ZIP:$PYTHONPATH"
+
+PARSER="org.apache.flink.python.client.PythonShellParser"
+function parse_options() {
+    ${JAVA_RUN} ${JVM_ARGS} -cp ${FLINK_CLASSPATH}:${PYTHON_JAR_PATH} ${PARSER} "$@"
+    printf "%d\0" $?
+}
+
+# Turn off posix mode since it does not allow process substitution
+set +o posix
+# If the command has option --help | -h, the script will directly
+# run the PythonShellParser program to stdout the help message.
+if [[ "$@" =~ '--help' ]] || [[ "$@" =~ '-h' ]]; then
+    ${JAVA_RUN} ${JVM_ARGS} -cp ${FLINK_CLASSPATH}:${PYTHON_JAR_PATH} ${PARSER} "$@"
+    exit 0
+fi
+OPTIONS=()
+while IFS= read -d '' -r ARG; do
+  OPTIONS+=("$ARG")
+done < <(parse_options "$@")
+
+COUNT=${#OPTIONS[@]}
+LAST=$((COUNT - 1))
+LAUNCHER_EXIT_CODE=${OPTIONS[$LAST]}
+
+# Certain JVM failures result in errors being printed to stdout (instead of stderr), which causes
+# the code that parses the output of the launcher to get confused. In those cases, check if the
+# exit code is an integer, and if it's not, handle it as a special error case.
+if ! [[ ${LAUNCHER_EXIT_CODE} =~ ^[0-9]+$ ]]; then
+  echo "${OPTIONS[@]}" | head -n-1 1>&2
+  exit 1
+fi
+
+if [[ ${LAUNCHER_EXIT_CODE} != 0 ]]; then
+  exit ${LAUNCHER_EXIT_CODE}
+fi
+
+OPTIONS=("${OPTIONS[@]:0:$LAST}")
+
+export SUBMIT_ARGS=${OPTIONS[@]}
+# -i: interactive
+# -m: execute shell.py in the zip package
+${PYFLINK_PYTHON} -i -m pyflink.shell

--- a/flink-python/pyflink/java_gateway.py
+++ b/flink-python/pyflink/java_gateway.py
@@ -17,6 +17,7 @@
 ################################################################################
 import os
 import platform
+import shlex
 import shutil
 import signal
 import struct
@@ -65,6 +66,9 @@ def launch_gateway():
     script = "./bin/pyflink-gateway-server.sh"
     command = [os.path.join(FLINK_HOME, script)]
     command += ['-c', 'org.apache.flink.python.client.PythonGatewayServer']
+
+    submit_args = os.environ.get("SUBMIT_ARGS", "local")
+    command += shlex.split(submit_args)
 
     # Create a temporary directory where the gateway server should write the connection information.
     conn_info_dir = tempfile.mkdtemp()

--- a/flink-python/pyflink/shell.py
+++ b/flink-python/pyflink/shell.py
@@ -1,0 +1,128 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import platform
+
+from pyflink.table import *
+
+print("Using Python version %s (%s, %s)" % (
+    platform.python_version(),
+    platform.python_build()[0],
+    platform.python_build()[1]))
+
+welcome_msg = u'''
+                         \u2592\u2593\u2588\u2588\u2593\u2588\u2588\u2592
+                     \u2593\u2588\u2588\u2588\u2588\u2592\u2592\u2588\u2593 \
+                     \u2592\u2593\u2588\u2588\u2588\u2593\u2592
+                  \u2593\u2588\u2588\u2588\u2593\u2591\u2591        \u2592 \
+                  \u2592\u2592\u2593\u2588\u2588\u2592  \u2592
+                \u2591\u2588\u2588\u2592   \u2592\u2592\u2593\u2593\u2588 \
+                \u2593\u2593\u2592\u2591      \u2592\u2588\u2588\u2588\u2588
+                \u2588\u2588\u2592         \u2591\u2592\u2593\u2588\u2588 \
+                \u2588\u2592    \u2592\u2588\u2592\u2588\u2592
+                  \u2591\u2593\u2588            \u2588\u2588\u2588   \u2593 \
+                  \u2591\u2592\u2588\u2588
+                    \u2593\u2588       \u2592\u2592\u2592\u2592\u2592\u2593\u2588\u2588\u2593\u2591\u2592\u2591\u2593\u2593\u2588
+                  \u2588\u2591 \u2588   \u2592\u2592\u2591       \u2588\u2588\u2588\u2593\u2593\u2588 \u2592\u2588\u2592\u2592\u2592
+                  \u2588\u2588\u2588\u2588\u2591   \u2592\u2593\u2588\u2593      \u2588\u2588\u2592\u2592\u2592 \u2593\u2588\u2588\u2588\u2592
+               \u2591\u2592\u2588\u2593\u2593\u2588\u2588       \u2593\u2588\u2592    \u2593\u2588\u2592\u2593\u2588\u2588\u2593 \u2591\u2588\u2591
+         \u2593\u2591\u2592\u2593\u2588\u2588\u2588\u2588\u2592 \u2588\u2588         \u2592\u2588    \u2588\u2593\u2591\u2592\u2588\u2592\u2591\u2592\u2588\u2592
+        \u2588\u2588\u2588\u2593\u2591\u2588\u2588\u2593  \u2593\u2588           \u2588   \u2588\u2593 \u2592\u2593\u2588\u2593\u2593\u2588\u2592
+      \u2591\u2588\u2588\u2593  \u2591\u2588\u2591            \u2588  \u2588\u2592 \u2592\u2588\u2588\u2588\u2588\u2588\u2593\u2592 \u2588\u2588\u2593\u2591\u2592
+     \u2588\u2588\u2588\u2591 \u2591 \u2588\u2591          \u2593 \u2591\u2588 \u2588\u2588\u2588\u2588\u2588\u2592\u2591\u2591    \u2591\u2588\u2591\u2593  \u2593\u2591
+    \u2588\u2588\u2593\u2588 \u2592\u2592\u2593\u2592          \u2593\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2593\u2591       \u2592\u2588\u2592 \u2592\u2593 \u2593\u2588\u2588\u2593
+ \u2592\u2588\u2588\u2593 \u2593\u2588 \u2588\u2593\u2588       \u2591\u2592\u2588\u2588\u2588\u2588\u2588\u2593\u2593\u2592\u2591         \u2588\u2588\u2592\u2592  \u2588 \u2592  \u2593\u2588\u2592
+ \u2593\u2588\u2593  \u2593\u2588 \u2588\u2588\u2593 \u2591\u2593\u2593\u2593\u2593\u2593\u2593\u2593\u2592              \u2592\u2588\u2588\u2593           \u2591\u2588\u2592
+ \u2593\u2588    \u2588 \u2593\u2588\u2588\u2588\u2593\u2592\u2591              \u2591\u2593\u2593\u2593\u2588\u2588\u2588\u2593          \u2591\u2592\u2591 \u2593\u2588
+ \u2588\u2588\u2593    \u2588\u2588\u2592    \u2591\u2592\u2593\u2593\u2588\u2588\u2588\u2593\u2593\u2593\u2593\u2593\u2588\u2588\u2588\u2588\u2588\u2588\u2593\u2592            \u2593\u2588\u2588\u2588  \u2588
+\u2593\u2588\u2588\u2588\u2592 \u2588\u2588\u2588   \u2591\u2593\u2593\u2592\u2591\u2591   \u2591\u2593\u2588\u2588\u2588\u2588\u2593\u2591                  \u2591\u2592\u2593\u2592  \u2588\u2593
+\u2588\u2593\u2592\u2592\u2593\u2593\u2588\u2588  \u2591\u2592\u2592\u2591\u2591\u2591\u2592\u2592\u2592\u2592\u2593\u2588\u2588\u2593\u2591                            \u2588\u2593
+\u2588\u2588 \u2593\u2591\u2592\u2588   \u2593\u2593\u2593\u2593\u2592\u2591\u2591  \u2592\u2588\u2593       \u2592\u2593\u2593\u2588\u2588\u2593    \u2593\u2592          \u2592\u2592\u2593
+\u2593\u2588\u2593 \u2593\u2592\u2588  \u2588\u2593\u2591  \u2591\u2592\u2593\u2593\u2588\u2588\u2592            \u2591\u2593\u2588\u2592   \u2592\u2592\u2592\u2591\u2592\u2592\u2593\u2588\u2588\u2588\u2588\u2588\u2592
+ \u2588\u2588\u2591 \u2593\u2588\u2592\u2588\u2592  \u2592\u2593\u2593\u2592  \u2593\u2588                \u2588\u2591      \u2591\u2591\u2591\u2591   \u2591\u2588\u2592
+ \u2593\u2588   \u2592\u2588\u2593   \u2591     \u2588\u2591                \u2592\u2588              \u2588\u2593
+  \u2588\u2593   \u2588\u2588         \u2588\u2591                 \u2593\u2593        \u2592\u2588\u2593\u2593\u2593\u2592\u2588\u2591
+   \u2588\u2593 \u2591\u2593\u2588\u2588\u2591       \u2593\u2592                  \u2593\u2588\u2593\u2592\u2591\u2591\u2591\u2592\u2593\u2588\u2591    \u2592\u2588
+    \u2588\u2588   \u2593\u2588\u2593\u2591      \u2592                    \u2591\u2592\u2588\u2592\u2588\u2588\u2592      \u2593\u2593
+     \u2593\u2588\u2592   \u2592\u2588\u2593\u2592\u2591                         \u2592\u2592 \u2588\u2592\u2588\u2593\u2592\u2592\u2591\u2591\u2592\u2588\u2588
+      \u2591\u2588\u2588\u2592    \u2592\u2593\u2593\u2592                     \u2593\u2588\u2588\u2593\u2592\u2588\u2592 \u2591\u2593\u2593\u2593\u2593\u2592\u2588\u2593
+        \u2591\u2593\u2588\u2588\u2592                          \u2593\u2591  \u2592\u2588\u2593\u2588  \u2591\u2591\u2592\u2592\u2592
+            \u2592\u2593\u2593\u2593\u2593\u2593\u2592\u2592\u2592\u2592\u2592\u2592\u2592\u2592\u2592\u2592\u2592\u2592\u2592\u2592\u2592\u2592\u2592\u2592\u2592\u2592\u2592\u2592\u2592\u2591\u2591\u2593\u2593  \u2593\u2591\u2592\u2588\u2591
+
+              F L I N K - P Y T H O N - S H E L L
+
+NOTE: Use the prebound Table Environment to implement batch or streaming Table programs.
+
+  Batch - Use the 'bt_env' variable
+
+    *
+    * import tempfile
+    * import os
+    * sink_path = tempfile.gettempdir() + '/batch.csv'
+    * if os.path.isfile(sink_path):
+    *   os.remove(sink_path)
+    * t = bt_env.from_elements([(1, 'hi', 'hello'), (2, 'hi', 'hello')], ['a', 'b', 'c'])
+    * bt_env.connect(FileSystem().path(sink_path))\\
+    *    .with_format(OldCsv()
+    *                .field_delimiter(',')
+    *                .field("a", DataTypes.BIGINT())
+    *                .field("b", DataTypes.STRING())
+    *                .field("c", DataTypes.STRING()))\\
+    *    .with_schema(Schema()
+    *                .field("a", DataTypes.BIGINT())
+    *                .field("b", DataTypes.STRING())
+    *                .field("c", DataTypes.STRING()))\\
+    *    .register_table_sink("batch_sink")
+    * 
+    * t.select("a + 1, b, c")\\
+    *   .insert_into("batch_sink")
+    *                
+    * bt_env.execute()
+
+  Streaming - Use the 'st_env' variable
+
+    *
+    * import tempfile
+    * import os
+    * sink_path = tempfile.gettempdir() + '/streaming.csv'
+    * if os.path.isfile(sink_path):
+    *   os.remove(sink_path)
+    * t = st_env.from_elements([(1, 'hi', 'hello'), (2, 'hi', 'hello')], ['a', 'b', 'c'])
+    * st_env.connect(FileSystem().path(sink_path))\\
+    *    .with_format(OldCsv()
+    *                .field_delimiter(',')
+    *                .field("a", DataTypes.BIGINT())
+    *                .field("b", DataTypes.STRING())
+    *                .field("c", DataTypes.STRING()))\\
+    *    .with_schema(Schema()
+    *                .field("a", DataTypes.BIGINT())
+    *                .field("b", DataTypes.STRING())
+    *                .field("c", DataTypes.STRING()))\\
+    *    .register_table_sink("stream_sink")
+    * 
+    * t.select("a + 1, b, c")\\
+    *   .insert_into("stream_sink")
+    *
+    * st_env.execute()
+      '''
+print(welcome_msg)
+
+bt_config = TableConfig.Builder().as_batch_execution().build()
+bt_env = TableEnvironment.create(bt_config)
+
+st_config = TableConfig.Builder().as_streaming_execution().build()
+st_env = TableEnvironment.create(st_config)

--- a/flink-python/src/main/java/org/apache/flink/python/client/PythonShellParser.java
+++ b/flink-python/src/main/java/org/apache/flink/python/client/PythonShellParser.java
@@ -1,0 +1,329 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.python.client;
+
+import org.apache.flink.util.Preconditions;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Command line parser for Python shell.
+ */
+public class PythonShellParser {
+	private static final Option OPTION_HELP = Option
+		.builder("h")
+		.required(false)
+		.longOpt("help")
+		.desc(
+			"Show the help message with descriptions of all options.")
+		.build();
+
+	private static final Option OPTION_CONTAINER = Option
+		.builder("n")
+		.required(false)
+		.longOpt("container")
+		.hasArg()
+		.desc(
+			"Number of YARN container to allocate (=Number of Task Managers)")
+		.build();
+
+	private static final Option OPTION_JM_MEMORY = Option
+		.builder("jm")
+		.required(false)
+		.longOpt("jobManagerMemory")
+		.hasArg()
+		.desc(
+			"Memory for JobManager Container with optional unit (default: MB)")
+		.build();
+
+	private static final Option OPTION_NAME = Option
+		.builder("nm")
+		.required(false)
+		.longOpt("name")
+		.hasArg()
+		.desc(
+			"Set a custom name for the application on YARN")
+		.build();
+
+	private static final Option OPTION_QUEUE = Option
+		.builder("qu")
+		.required(false)
+		.longOpt("queue")
+		.hasArg()
+		.desc(
+			"Specify YARN queue.")
+		.build();
+
+	private static final Option OPTION_SLOTS = Option
+		.builder("s")
+		.required(false)
+		.longOpt("slots")
+		.hasArg()
+		.desc(
+			"Number of slots per TaskManager")
+		.build();
+
+	private static final Option OPTION_TM_MEMORY = Option
+		.builder("tm")
+		.required(false)
+		.longOpt("taskManagerMemory")
+		.hasArg()
+		.desc(
+			"Memory per TaskManager Container with optional unit (default: MB)")
+		.build();
+
+	// cluster types
+	private static final String LOCAL_RUN = "local";
+	private static final String REMOTE_RUN = "remote";
+	private static final String YARN_RUN = "yarn";
+
+	// Options that will be used in mini cluster.
+	private static final Options LOCAL_OPTIONS = getLocalOptions(new Options());
+
+	// Options that will be used in remote cluster.
+	private static final Options REMOTE_OPTIONS = getRemoteOptions(new Options());
+
+	// Options that will be used in yarn cluster.
+	private static final Options YARN_OPTIONS = getYarnOptions(new Options());
+
+	public static void main(String[] args) {
+		if (args.length < 1) {
+			printError("You should specify cluster type or -h | --help option");
+			System.exit(1);
+		}
+		String command = args[0];
+		List<String> commandOptions = null;
+		try {
+			switch (command) {
+				case LOCAL_RUN:
+					commandOptions = parseLocal(args);
+					break;
+				case REMOTE_RUN:
+					commandOptions = parseRemote(args);
+					break;
+				case YARN_RUN:
+					commandOptions = parseYarn(args);
+					break;
+				case "-h":
+				case "--help":
+					printHelp();
+					break;
+				default:
+					printError(String.format("\"%s\" is not a valid cluster type or -h | --help option.\n", command));
+					System.exit(1);
+			}
+			if (commandOptions != null) {
+				for (String option : commandOptions) {
+					System.out.print(option);
+					System.out.print('\0');
+				}
+			}
+		} catch (Throwable e) {
+			printError("Error while running the command.");
+			e.printStackTrace();
+			System.exit(1);
+		}
+	}
+
+	private static void buildGeneralOptions(Options options) {
+		options.addOption(OPTION_HELP);
+	}
+
+	private static Options getLocalOptions(Options options) {
+		buildGeneralOptions(options);
+		return options;
+	}
+
+	private static Options getRemoteOptions(Options options) {
+		buildGeneralOptions(options);
+		return options;
+	}
+
+	private static Options getYarnOptions(Options options) {
+		buildGeneralOptions(options);
+		options.addOption(OPTION_CONTAINER);
+		options.addOption(OPTION_JM_MEMORY);
+		options.addOption(OPTION_NAME);
+		options.addOption(OPTION_QUEUE);
+		options.addOption(OPTION_SLOTS);
+		options.addOption(OPTION_TM_MEMORY);
+		return options;
+	}
+
+	/**
+	 * Prints the error message and help for the client.
+	 *
+	 * @param msg error message
+	 */
+	private static void printError(String msg) {
+		System.err.println(msg);
+		System.err.println("Valid cluster type are \"local\", \"remote <hostname> <portnumber>\", \"yarn\".");
+		System.err.println();
+		System.err.println("Specify the help option (-h or --help) to get help on the command.");
+	}
+
+	/**
+	 * Prints the help for the client.
+	 */
+	private static void printHelp() {
+		System.out.print("Flink Python Shell\n");
+		System.out.print("Usage: pyflink-shell.sh [local|remote|yarn] [options] <args>...\n");
+		System.out.print('\n');
+		printLocalHelp();
+		printRemoteHelp();
+		printYarnHelp();
+		System.out.println("-h | --help");
+		System.out.println("      Prints this usage text");
+		System.exit(0);
+	}
+
+	private static void printYarnHelp() {
+		HelpFormatter formatter = new HelpFormatter();
+		formatter.setLeftPadding(5);
+		formatter.setWidth(80);
+		System.out.println("Command: yarn [options]");
+		System.out.println("Starts Flink Python shell connecting to a yarn cluster");
+		formatter.printHelp(" ", YARN_OPTIONS);
+	}
+
+	private static void printRemoteHelp() {
+		HelpFormatter formatter = new HelpFormatter();
+		formatter.setLeftPadding(5);
+		formatter.setWidth(80);
+		System.out.println("Command: remote [options] <host> <port>");
+		System.out.println("Starts Flink Python shell connecting to a remote cluster");
+		System.out.println("  <host>");
+		System.out.println("        Remote host name as string");
+		System.out.println("  <port>");
+		System.out.println("        Remote port as integer");
+		System.out.println();
+		formatter.printHelp(" ", REMOTE_OPTIONS);
+	}
+
+	private static void printLocalHelp() {
+		HelpFormatter formatter = new HelpFormatter();
+		formatter.setLeftPadding(5);
+		formatter.setWidth(80);
+		System.out.println("Command: local [options]");
+		System.out.println("Starts Flink Python shell with a local Flink cluster");
+		formatter.printHelp(" ", LOCAL_OPTIONS);
+	}
+
+	/**
+	 * Constructs yarn options. The python shell option will add prefix 'y' to align yarn options in `flink run`.
+	 *
+	 * @param options     Options that will be used in `flink run`.
+	 * @param yarnOption  Python shell yarn options.
+	 * @param commandLine Parsed Python shell parser options.
+	 */
+	private static void constructYarnOption(List<String> options, Option yarnOption, CommandLine commandLine) {
+		if (commandLine.hasOption(yarnOption.getOpt())) {
+			options.add("-y" + yarnOption.getOpt());
+			options.add(commandLine.getOptionValue(yarnOption.getOpt()));
+		}
+	}
+
+	/**
+	 * Parses Python shell yarn options and transfer to yarn options which will be used in `flink run` to
+	 * submit flink job.
+	 *
+	 * @param args Python shell yarn options.
+	 * @return Yarn options usrd in `flink run`.
+	 */
+	static List<String> parseYarn(String[] args) {
+		String[] params = new String[args.length - 1];
+		System.arraycopy(args, 1, params, 0, params.length);
+		CommandLine commandLine = parse(YARN_OPTIONS, params);
+		if (commandLine.hasOption(OPTION_HELP.getOpt())) {
+			printHelp();
+		}
+		List<String> options = new ArrayList<>();
+		options.add(args[0]);
+		options.add("-m");
+		options.add("yarn-cluster");
+		constructYarnOption(options, OPTION_CONTAINER, commandLine);
+		constructYarnOption(options, OPTION_JM_MEMORY, commandLine);
+		constructYarnOption(options, OPTION_NAME, commandLine);
+		constructYarnOption(options, OPTION_QUEUE, commandLine);
+		constructYarnOption(options, OPTION_SLOTS, commandLine);
+		constructYarnOption(options, OPTION_TM_MEMORY, commandLine);
+		return options;
+	}
+
+	/**
+	 * Parses Python shell options and transfer to options which will be used in `flink run -m ${jobmanager_address}` to
+	 * submit flink job in a remote jobmanager.
+	 * The Python shell options "remote ${hostname} ${portnumber}" will be transferred to "-m ${hostname}:${portnumber}".
+	 *
+	 * @param args Python shell options.
+	 * @return Options used in `flink run`.
+	 */
+	static List<String> parseRemote(String[] args) {
+		Preconditions.checkArgument(args.length >= 3, "Specifies the <hostname> <portnumber> in 'remote' mode");
+		String[] params = new String[args.length - 3];
+		System.arraycopy(args, 3, params, 0, params.length);
+		CommandLine commandLine = parse(REMOTE_OPTIONS, params);
+		if (commandLine.hasOption(OPTION_HELP.getOpt())) {
+			printHelp();
+		}
+		String host = args[1];
+		String port = args[2];
+		List<String> options = new ArrayList<>();
+		options.add(args[0]);
+		options.add("-m");
+		options.add(host + ":" + port);
+		return options;
+	}
+
+	/**
+	 * Parses Python shell options and transfer to options which will be used in `java` to exec a flink job in
+	 * local mini cluster.
+	 *
+	 * @param args Python shell options.
+	 * @return Options used in `java` run.
+	 */
+	static List<String> parseLocal(String[] args) {
+		String[] params = new String[args.length - 1];
+		System.arraycopy(args, 1, params, 0, params.length);
+		CommandLine commandLine = parse(LOCAL_OPTIONS, params);
+		if (commandLine.hasOption(OPTION_HELP.getOpt())) {
+			printHelp();
+		}
+		List<String> options = new ArrayList<>();
+		options.add("local");
+		return options;
+	}
+
+	private static CommandLine parse(Options options, String[] args) {
+		final DefaultParser parser = new DefaultParser();
+		try {
+			return parser.parse(options, args, true);
+		} catch (ParseException e) {
+			throw new RuntimeException("Parser parses options failed.", e);
+		}
+	}
+}

--- a/flink-python/src/test/java/org/apache/flink/python/client/PythonShellParserTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/client/PythonShellParserTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.python.client;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * Tests for the {@link PythonShellParser}.
+ */
+public class PythonShellParserTest {
+	@Test
+	public void testParseLocalWithoutOptions() {
+		String[] args = {"local"};
+		List<String> commandOptions = PythonShellParser.parseLocal(args);
+		String[] expectedCommandOptions = {"local"};
+		Assert.assertArrayEquals(expectedCommandOptions, commandOptions.toArray());
+	}
+
+	@Test
+	public void testParseRemoteWithoutOptions() {
+		String[] args = {"remote", "localhost", "8081"};
+		List<String> commandOptions = PythonShellParser.parseRemote(args);
+		String[] expectedCommandOptions = {"remote", "-m", "localhost:8081"};
+		Assert.assertArrayEquals(expectedCommandOptions, commandOptions.toArray());
+	}
+
+	@Test
+	public void testParseYarnWithoutOptions() {
+		String[] args = {"yarn"};
+		List<String> commandOptions = PythonShellParser.parseYarn(args);
+		String[] expectedCommandOptions = {"yarn", "-m", "yarn-cluster"};
+		Assert.assertArrayEquals(expectedCommandOptions, commandOptions.toArray());
+	}
+
+	@Test
+	public void testParseYarnWithOptions() {
+		String[] args = {"yarn", "-n", "2", "-jm", "1024m", "-tm", "4096m"};
+		List<String> commandOptions = PythonShellParser.parseYarn(args);
+		String[] expectedCommandOptions = {"yarn", "-m", "yarn-cluster", "-yn", "2", "-yjm", "1024m", "-ytm", "4096m"};
+		Assert.assertArrayEquals(expectedCommandOptions, commandOptions.toArray());
+	}
+}

--- a/flink-python/tox.ini
+++ b/flink-python/tox.ini
@@ -36,4 +36,4 @@ commands =
 # up to 100 characters in length, not 79.
 ignore=E226,E241,E305,E402,E722,E731,E741,W503,W504
 max-line-length=100
-exclude=.tox/*,dev/*,lib/*,target/*,build/*
+exclude=.tox/*,dev/*,lib/*,target/*,build/*,pyflink/shell.py


### PR DESCRIPTION
Mirror of apache flink#8675
## What is the purpose of the change
In this PR, we want to add an interactive shell for the Python Table API. It will have the similar functionality like the Scala Shell.
## Brief change log

  - *Add the Option of -a | -addclasspath in CliFrontendParser for adding external jars in `flink run`*
  - *Add shell.py in flink-python/pyflink as the starting script in python shell*
  - *Add bin/pyflink-shell.sh as the startting script of python shell*
  - *Add class PythonShellParser to parse python shell options*
  - *correct bin/pyflink-gateway-server.sh* 


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)

