### PR TITLE
Mirror of apache flink#8925

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -21,6 +21,7 @@ package org.apache.flink.configuration;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.docs.ConfigGroup;
 import org.apache.flink.annotation.docs.ConfigGroups;
+import org.apache.flink.annotation.docs.Documentation;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 
@@ -139,6 +140,18 @@ public class NettyShuffleEnvironmentOptions {
 				" The floating buffers are distributed based on backlog (real-time output buffers in the subpartition) feedback, and can" +
 				" help relieve back-pressure caused by unbalanced data distribution among the subpartitions. This value should be" +
 				" increased in case of higher round trip times between nodes and/or larger number of machines in the cluster.");
+
+	/**
+	 * The timeout for requesting exclusive buffers for each channel.
+	 */
+	@Documentation.ExcludeFromDocumentation("This option is purely implementation related, and may be removed as the implementation changes.")
+	public static final ConfigOption<Long> NETWORK_EXCLUSIVE_BUFFERS_REQUEST_TIMEOUT_MILLISECONDS =
+		key("taskmanager.network.memory.exclusive-buffers-request-timeout-ms")
+			.defaultValue(30000L)
+			.withDescription("The timeout for requesting exclusive buffers for each channel. Since the number of maximum buffers and " +
+					"the number of required buffers is not the same for local buffer pools, there may be deadlock cases that the upstream" +
+					"tasks have occupied all the buffers and the downstream tasks are waiting for the exclusive buffers. The timeout breaks" +
+					"the tie by failing the request of exclusive buffers and ask users to increase the number of total buffers.");
 
 	// ------------------------------------------------------------------------
 	//  Netty Options

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -73,16 +73,30 @@ public class NetworkBufferPool implements BufferPoolFactory, MemorySegmentProvid
 
 	private final int numberOfSegmentsToRequest;
 
+	private final long requestSegmentsTimeoutInMillis;
+
+	public NetworkBufferPool(int numberOfSegmentsToAllocate, int segmentSize, int numberOfSegmentsToRequest) {
+		this(numberOfSegmentsToAllocate, segmentSize, numberOfSegmentsToRequest, Long.MAX_VALUE);
+	}
+
 	/**
 	 * Allocates all {@link MemorySegment} instances managed by this pool.
 	 */
-	public NetworkBufferPool(int numberOfSegmentsToAllocate, int segmentSize, int numberOfSegmentsToRequest) {
+	public NetworkBufferPool(
+		int numberOfSegmentsToAllocate,
+		int segmentSize,
+		int numberOfSegmentsToRequest,
+		long requestSegmentsTimeoutInMillis) {
 
 		this.totalNumberOfMemorySegments = numberOfSegmentsToAllocate;
 		this.memorySegmentSize = segmentSize;
 
 		checkArgument(numberOfSegmentsToRequest > 0, "The number of required buffers should be larger than 0.");
 		this.numberOfSegmentsToRequest = numberOfSegmentsToRequest;
+
+		checkArgument(requestSegmentsTimeoutInMillis > 0,
+				"The timeout for requesting exclusive buffers should be larger than 0.");
+		this.requestSegmentsTimeoutInMillis = requestSegmentsTimeoutInMillis;
 
 		final long sizeInLong = (long) segmentSize;
 
@@ -172,6 +186,7 @@ public class NetworkBufferPool implements BufferPoolFactory, MemorySegmentProvid
 
 		final List<MemorySegment> segments = new ArrayList<>(numberOfSegmentsToRequest);
 		try {
+			long startTimeInNanos = System.nanoTime();
 			while (segments.size() < numberOfSegmentsToRequest) {
 				if (isDestroyed) {
 					throw new IllegalStateException("Buffer pool is destroyed.");
@@ -180,6 +195,19 @@ public class NetworkBufferPool implements BufferPoolFactory, MemorySegmentProvid
 				final MemorySegment segment = availableMemorySegments.poll(2, TimeUnit.SECONDS);
 				if (segment != null) {
 					segments.add(segment);
+				}
+
+				if ((System.nanoTime() - startTimeInNanos) / 1_000_000 >= requestSegmentsTimeoutInMillis &&
+						segments.size() < numberOfSegmentsToRequest) {
+					throw new IOException(String.format("Insufficient number of network buffers: " +
+									"requesting exclusive buffers timeout. The total number of network " +
+									"buffers is currently set to %d of %d bytes each. You can increase this " +
+									"number by setting the configuration keys '%s', '%s', and '%s'.",
+							totalNumberOfMemorySegments,
+							memorySegmentSize,
+							NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_FRACTION.key(),
+							NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_MIN.key(),
+							NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_MAX.key()));
 				}
 			}
 		} catch (Throwable e) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -56,6 +56,8 @@ public class NettyShuffleEnvironmentConfiguration {
 	/** Number of extra network buffers to use for each outgoing/incoming gate (result partition/input gate). */
 	private final int floatingNetworkBuffersPerGate;
 
+	private final long requestSegmentsTimeoutInMillis;
+
 	private final boolean isCreditBased;
 
 	private final boolean isNetworkDetailedMetrics;
@@ -69,6 +71,7 @@ public class NettyShuffleEnvironmentConfiguration {
 			int partitionRequestMaxBackoff,
 			int networkBuffersPerChannel,
 			int floatingNetworkBuffersPerGate,
+			long requestSegmentsTimeoutInMillis,
 			boolean isCreditBased,
 			boolean isNetworkDetailedMetrics,
 			@Nullable NettyConfig nettyConfig) {
@@ -79,6 +82,7 @@ public class NettyShuffleEnvironmentConfiguration {
 		this.partitionRequestMaxBackoff = partitionRequestMaxBackoff;
 		this.networkBuffersPerChannel = networkBuffersPerChannel;
 		this.floatingNetworkBuffersPerGate = floatingNetworkBuffersPerGate;
+		this.requestSegmentsTimeoutInMillis = requestSegmentsTimeoutInMillis;
 		this.isCreditBased = isCreditBased;
 		this.isNetworkDetailedMetrics = isNetworkDetailedMetrics;
 		this.nettyConfig = nettyConfig;
@@ -122,6 +126,10 @@ public class NettyShuffleEnvironmentConfiguration {
 		return isNetworkDetailedMetrics;
 	}
 
+	public long getRequestSegmentsTimeoutInMillis() {
+		return requestSegmentsTimeoutInMillis;
+	}
+
 	// ------------------------------------------------------------------------
 
 	/**
@@ -158,6 +166,9 @@ public class NettyShuffleEnvironmentConfiguration {
 
 		boolean isNetworkDetailedMetrics = configuration.getBoolean(NettyShuffleEnvironmentOptions.NETWORK_DETAILED_METRICS);
 
+		long requestSegmentsTimeoutInMillis = configuration.getLong(
+				NettyShuffleEnvironmentOptions.NETWORK_EXCLUSIVE_BUFFERS_REQUEST_TIMEOUT_MILLISECONDS);
+
 		return new NettyShuffleEnvironmentConfiguration(
 			numberOfNetworkBuffers,
 			pageSize,
@@ -165,6 +176,7 @@ public class NettyShuffleEnvironmentConfiguration {
 			maxRequestBackoff,
 			buffersPerChannel,
 			extraBuffersPerGate,
+			requestSegmentsTimeoutInMillis,
 			isCreditBased,
 			isNetworkDetailedMetrics,
 			nettyConfig);
@@ -465,6 +477,7 @@ public class NettyShuffleEnvironmentConfiguration {
 		result = 31 * result + partitionRequestMaxBackoff;
 		result = 31 * result + networkBuffersPerChannel;
 		result = 31 * result + floatingNetworkBuffersPerGate;
+		result = 31 * result + (int) requestSegmentsTimeoutInMillis;
 		result = 31 * result + (isCreditBased ? 1 : 0);
 		result = 31 * result + (nettyConfig != null ? nettyConfig.hashCode() : 0);
 		return result;
@@ -487,6 +500,7 @@ public class NettyShuffleEnvironmentConfiguration {
 					this.partitionRequestMaxBackoff == that.partitionRequestMaxBackoff &&
 					this.networkBuffersPerChannel == that.networkBuffersPerChannel &&
 					this.floatingNetworkBuffersPerGate == that.floatingNetworkBuffersPerGate &&
+					this.requestSegmentsTimeoutInMillis == that.requestSegmentsTimeoutInMillis &&
 					this.isCreditBased == that.isCreditBased &&
 					(nettyConfig != null ? nettyConfig.equals(that.nettyConfig) : that.nettyConfig == null);
 		}
@@ -501,6 +515,7 @@ public class NettyShuffleEnvironmentConfiguration {
 				", partitionRequestMaxBackoff=" + partitionRequestMaxBackoff +
 				", networkBuffersPerChannel=" + networkBuffersPerChannel +
 				", floatingNetworkBuffersPerGate=" + floatingNetworkBuffersPerGate +
+				", requestSegmentsTimeoutInMillis=" + requestSegmentsTimeoutInMillis +
 				", isCreditBased=" + isCreditBased +
 				", nettyConfig=" + nettyConfig +
 				'}';

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
@@ -43,6 +43,8 @@ public class NettyShuffleEnvironmentBuilder {
 
 	private int floatingNetworkBuffersPerGate = 8;
 
+	private long requestSegmentsTimeoutInMillis = 30000L;
+
 	private boolean isCreditBased = true;
 
 	private boolean isNetworkDetailedMetrics = false;
@@ -92,6 +94,10 @@ public class NettyShuffleEnvironmentBuilder {
 		return this;
 	}
 
+	public void setRequestSegmentsTimeoutInMillis(long requestSegmentsTimeoutInMillis) {
+		this.requestSegmentsTimeoutInMillis = requestSegmentsTimeoutInMillis;
+	}
+
 	public NettyShuffleEnvironmentBuilder setIsCreditBased(boolean isCreditBased) {
 		this.isCreditBased = isCreditBased;
 		return this;
@@ -126,6 +132,7 @@ public class NettyShuffleEnvironmentBuilder {
 				partitionRequestMaxBackoff,
 				networkBuffersPerChannel,
 				floatingNetworkBuffersPerGate,
+				requestSegmentsTimeoutInMillis,
 				isCreditBased,
 				isNetworkDetailedMetrics,
 				nettyConfig),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
@@ -477,4 +477,46 @@ public class NetworkBufferPoolTest extends TestLogger {
 			globalPool.destroy();
 		}
 	}
+
+	/**
+	 * Tests {@link NetworkBufferPool#requestMemorySegments()} and verifies it will end exceptionally
+	 * when failing to acquire all the segments in the specific timeout.
+	 */
+	@Test
+	public void testRequestMemorySegmentsTimeout() throws Exception {
+		final int numBuffers = 10;
+		final int numberOfSegmentsToRequest = 2;
+		final long requestSegmentsTimeoutInMillis = 1000L;
+
+		NetworkBufferPool globalPool = new NetworkBufferPool(
+				numBuffers,
+				128,
+				numberOfSegmentsToRequest,
+				requestSegmentsTimeoutInMillis);
+
+		BufferPool localBufferPool = globalPool.createBufferPool(0, numBuffers);
+		for (int i = 0; i < numBuffers; ++i) {
+			localBufferPool.requestBuffer();
+		}
+
+		assertEquals(0, globalPool.getNumberOfAvailableMemorySegments());
+
+		CheckedThread asyncRequest = new CheckedThread() {
+			@Override
+			public void go() throws Exception {
+				globalPool.requestMemorySegments();
+			}
+		};
+
+		asyncRequest.start();
+
+		try {
+			asyncRequest.trySync(requestSegmentsTimeoutInMillis * 10);
+			fail("Requesting exclusive buffer does not timeout and throw exception as expected.");
+		} catch (IOException ignored) {
+			// Expected exception
+		}  finally {
+			globalPool.destroy();
+		}
+	}
 }


### PR DESCRIPTION
Mirror of apache flink#8925
## What is the purpose of the change

This pull request tries to fix the deadlock problem during requesting exclusive buffers. Since currently the number of maximum buffers and the number of required buffers are not the same for local buffer pools, there may be cases that the local buffer pools of the upstream tasks occupy all the buffers while the downstream tasks fail to acquire exclusive buffers to make progress. Although this problem can be fixed by increasing the number of total buffers, the deadlock may not be acceptable. Therefore, this PR tries to failover the current execution when the deadlock occurs and tips users to increase the number of buffers in the exceptional message.

## Brief change log

The main changes include

1. Add an option for the timeout of `requestMemorySegment` for each channel. The default timeout is 30s. This option is marked as undocumented since it may be removed within the future implementation.
2. Transfer the timeout to `NetworkBufferPool`.
3. `requestMemorySegments` will throw `IOException("Insufficient buffer")`  if not all segments acquired after timeout.

## Verifying this change

1. Added test that validates `requestMemorySegments` end exceptionally if not all segments acquired after timeout.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**

