### PR TITLE
Mirror of apache flink#8923

### DIFF
--- a/flink-connectors/flink-jdbc/pom.xml
+++ b/flink-connectors/flink-jdbc/pom.xml
@@ -67,5 +67,20 @@ under the License.
 			<version>10.14.2.0</version>
 			<scope>test</scope>
 		</dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-test-utils_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+        </dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCLookupFunction.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCLookupFunction.java
@@ -1,0 +1,340 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.jdbc;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.functions.TableFunction;
+import org.apache.flink.types.Row;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.api.java.io.jdbc.JDBCTypeUtil.getFieldFromResultSet;
+import static org.apache.flink.api.java.io.jdbc.JDBCTypeUtil.setFieldToStatement;
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link TableFunction} to query fields from JDBC by keys.
+ * The query template like:
+ * <PRE>
+ *   SELECT c, d, e, f from T where a = ? and b = ?
+ * </PRE>
+ *
+ * Support cache the result to avoid frequent accessing to remote databases.
+ * 1.The cacheMaxSize is -1 means not use cache.
+ * 2.For real-time data, you need to set the TTL of cache.
+ */
+public class JDBCLookupFunction extends TableFunction<Row> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(JDBCLookupFunction.class);
+
+	static final int DEFAULT_MAX_RETRY_TIMES = 3;
+
+	private final String query;
+	private final String drivername;
+	private final String dbURL;
+	private final String username;
+	private final String password;
+	private final TypeInformation[] keyTypes;
+	private final int[] keySqlTypes;
+	private final String[] fieldNames;
+	private final TypeInformation[] fieldTypes;
+	private final int[] outputSqlTypes;
+	private final long cacheMaxSize;
+	private final long cacheExpireMs;
+	private final int maxRetryTimes;
+
+	private transient Connection dbConn;
+	private transient PreparedStatement statement;
+	private transient Cache<Row, List<Row>> cache;
+
+	public JDBCLookupFunction(
+			String tableName, String username, String password, String drivername, String dbURL,
+			String[] fieldNames, TypeInformation[] fieldTypes, String[] keyNames,
+			String leftQuote, String rightQuote, long cacheMaxSize, long cacheExpireMs, int maxRetryTimes) {
+		this.drivername = drivername;
+		this.dbURL = dbURL;
+		this.username = username;
+		this.password = password;
+		this.fieldNames = fieldNames;
+		this.fieldTypes = fieldTypes;
+		List<String> nameList = Arrays.asList(fieldNames);
+		this.keyTypes = Arrays.stream(keyNames)
+				.map(s -> {
+					checkArgument(nameList.contains(s),
+							"keyName %s can't find in fieldNames %s.", s, nameList);
+					return fieldTypes[nameList.indexOf(s)];
+				})
+				.toArray(TypeInformation[]::new);
+		this.cacheMaxSize = cacheMaxSize;
+		this.cacheExpireMs = cacheExpireMs;
+		this.maxRetryTimes = maxRetryTimes;
+		this.keySqlTypes = Arrays.stream(keyTypes).mapToInt(JDBCTypeUtil::typeInformationToSqlType).toArray();
+		this.outputSqlTypes = Arrays.stream(fieldTypes).mapToInt(JDBCTypeUtil::typeInformationToSqlType).toArray();
+
+		String quoteTableName = leftQuote + tableName + rightQuote;
+		String selectFields = StringUtils.join(Arrays.stream(fieldNames)
+				.map(name -> leftQuote + name + rightQuote)
+				.toArray(String[]::new), ",");
+		String conditions = StringUtils.join(Arrays.stream(keyNames)
+				.map(name -> leftQuote + name + rightQuote + " = ?")
+				.toArray(String[]::new), " AND ");
+		this.query = "SELECT " + selectFields + " FROM " + quoteTableName + " WHERE " + conditions;
+	}
+
+	@Override
+	public void open(FunctionContext context) throws Exception {
+		try {
+			establishConnection();
+			statement = dbConn.prepareStatement(query);
+			this.cache = cacheMaxSize == -1 ? null : CacheBuilder.newBuilder()
+					.expireAfterWrite(cacheExpireMs, TimeUnit.MILLISECONDS)
+					.maximumSize(cacheMaxSize)
+					.build();
+		} catch (SQLException sqe) {
+			throw new IllegalArgumentException("open() failed.", sqe);
+		} catch (ClassNotFoundException cnfe) {
+			throw new IllegalArgumentException("JDBC driver class not found.", cnfe);
+		}
+	}
+
+	public void eval(Object... keys) {
+		Row keyRow = Row.of(keys);
+		if (cache != null) {
+			List<Row> cachedRows = cache.getIfPresent(keyRow);
+			if (cachedRows != null) {
+				for (Row cachedRow : cachedRows) {
+					collect(cachedRow);
+				}
+				return;
+			}
+		}
+
+		for (int retry = 1; retry <= maxRetryTimes; retry++) {
+			try {
+				statement.clearParameters();
+				for (int i = 0; i < keys.length; i++) {
+					setFieldToStatement(i, keySqlTypes[i], keys[i], statement);
+				}
+				try (ResultSet resultSet = statement.executeQuery()) {
+					if (cache == null) {
+						while (resultSet.next()) {
+							collect(convertToRowFromResultSet(resultSet));
+						}
+					} else {
+						ArrayList<Row> rows = new ArrayList<>();
+						while (resultSet.next()) {
+							Row row = convertToRowFromResultSet(resultSet);
+							rows.add(row);
+							collect(row);
+						}
+						rows.trimToSize();
+						cache.put(keyRow, rows);
+					}
+				}
+				break;
+			} catch (SQLException e) {
+				LOG.error(String.format("JDBC executeBatch error, retry times = %d", retry), e);
+				if (retry >= maxRetryTimes) {
+					throw new RuntimeException("Execution of JDBC statement failed.", e);
+				}
+
+				try {
+					Thread.sleep(1000 * retry);
+				} catch (InterruptedException e1) {
+					throw new RuntimeException(e1);
+				}
+			}
+		}
+	}
+
+	private Row convertToRowFromResultSet(ResultSet resultSet) throws SQLException {
+		Row row = new Row(outputSqlTypes.length);
+		for (int i = 0; i < outputSqlTypes.length; i++) {
+			row.setField(i, getFieldFromResultSet(i, outputSqlTypes[i], resultSet));
+		}
+		return row;
+	}
+
+	private void establishConnection() throws SQLException, ClassNotFoundException {
+		Class.forName(drivername);
+		if (username == null) {
+			dbConn = DriverManager.getConnection(dbURL);
+		} else {
+			dbConn = DriverManager.getConnection(dbURL, username, password);
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		if (statement != null) {
+			try {
+				statement.close();
+			} catch (SQLException e) {
+				LOG.info("JDBC statement could not be closed: " + e.getMessage());
+			} finally {
+				statement = null;
+			}
+		}
+
+		if (dbConn != null) {
+			try {
+				dbConn.close();
+			} catch (SQLException se) {
+				LOG.info("JDBC connection could not be closed: " + se.getMessage());
+			} finally {
+				dbConn = null;
+			}
+		}
+	}
+
+	@Override
+	public TypeInformation<Row> getResultType() {
+		return new RowTypeInfo(fieldTypes, fieldNames);
+	}
+
+	@Override
+	public TypeInformation<?>[] getParameterTypes(Class<?>[] signature) {
+		return keyTypes;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Builder for a {@link JDBCLookupFunction}.
+	 */
+	public static class Builder {
+		private String tableName;
+		private String username;
+		private String password;
+		private String drivername;
+		private String dbURL;
+		private String[] fieldNames;
+		private TypeInformation[] fieldTypes;
+		private String[] keyNames;
+		private String leftQuote = "";
+		private String rightQuote = "";
+		private long cacheMaxSize = -1;
+		private long cacheExpireMs = -1;
+		private int maxRetryTimes = DEFAULT_MAX_RETRY_TIMES;
+
+		public Builder setTableName(String tableName) {
+			this.tableName = tableName;
+			return this;
+		}
+
+		public Builder setUsername(String username) {
+			this.username = username;
+			return this;
+		}
+
+		public Builder setPassword(String password) {
+			this.password = password;
+			return this;
+		}
+
+		public Builder setDrivername(String drivername) {
+			this.drivername = drivername;
+			return this;
+		}
+
+		public Builder setDBUrl(String dbURL) {
+			this.dbURL = dbURL;
+			return this;
+		}
+
+		public Builder setFieldNames(String[] fieldNames) {
+			this.fieldNames = fieldNames;
+			return this;
+		}
+
+		public Builder setFieldTypes(TypeInformation[] fieldTypes) {
+			this.fieldTypes = fieldTypes;
+			return this;
+		}
+
+		public Builder setKeyNames(String[] keyNames) {
+			this.keyNames = keyNames;
+			return this;
+		}
+
+		public Builder setLeftQuote(String leftQuote) {
+			this.leftQuote = leftQuote;
+			return this;
+		}
+
+		public Builder setRightQuote(String rightQuote) {
+			this.rightQuote = rightQuote;
+			return this;
+		}
+
+		public Builder setCacheMaxSize(long cacheMaxSize) {
+			this.cacheMaxSize = cacheMaxSize;
+			return this;
+		}
+
+		public Builder setCacheExpireMs(long cacheExpireMs) {
+			this.cacheExpireMs = cacheExpireMs;
+			return this;
+		}
+
+		public Builder setMaxRetryTimes(int maxRetryTimes) {
+			this.maxRetryTimes = maxRetryTimes;
+			return this;
+		}
+
+		/**
+		 * Finalizes the configuration and checks validity.
+		 *
+		 * @return Configured JDBCLookupFunction
+		 */
+		public JDBCLookupFunction build() {
+			checkNotNull(tableName, "No tableName supplied.");
+			checkNotNull(drivername, "No driver supplied.");
+			checkNotNull(dbURL, "No database URL supplied.");
+			checkNotNull(fieldNames, "No fieldNames supplied.");
+			checkNotNull(fieldTypes, "No fieldTypes supplied.");
+			checkNotNull(keyNames, "No keyNames supplied.");
+
+			return new JDBCLookupFunction(
+					tableName, username, password, drivername, dbURL,
+					fieldNames, fieldTypes, keyNames,
+					leftQuote, rightQuote, cacheMaxSize, cacheExpireMs, maxRetryTimes);
+		}
+	}
+}

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCLookupTableSource.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCLookupTableSource.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.jdbc;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.functions.AsyncTableFunction;
+import org.apache.flink.table.functions.TableFunction;
+import org.apache.flink.table.sources.LookupableTableSource;
+import org.apache.flink.types.Row;
+
+import static org.apache.flink.api.java.io.jdbc.JDBCLookupFunction.DEFAULT_MAX_RETRY_TIMES;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * {@link LookupableTableSource} for JDBC.
+ */
+public class JDBCLookupTableSource implements LookupableTableSource<Row> {
+
+	private final String tableName;
+	private final String username;
+	private final String password;
+	private final String drivername;
+	private final String dbURL;
+	private final String[] fieldNames;
+	private final TypeInformation[] fieldTypes;
+	private final String leftQuote;
+	private final String rightQuote;
+	private final long cacheMaxSize;
+	private final long cacheExpireMs;
+	private final int maxRetryTimes;
+
+	public JDBCLookupTableSource(String tableName, String username, String password,
+			String drivername, String dbURL, String[] fieldNames, TypeInformation[] fieldTypes,
+			String leftQuote, String rightQuote, long cacheMaxSize, long cacheExpireMs,
+			int maxRetryTimes) {
+		this.tableName = tableName;
+		this.username = username;
+		this.password = password;
+		this.drivername = drivername;
+		this.dbURL = dbURL;
+		this.fieldNames = fieldNames;
+		this.fieldTypes = fieldTypes;
+		this.leftQuote = leftQuote;
+		this.rightQuote = rightQuote;
+		this.cacheMaxSize = cacheMaxSize;
+		this.cacheExpireMs = cacheExpireMs;
+		this.maxRetryTimes = maxRetryTimes;
+	}
+
+	@Override
+	public TableFunction<Row> getLookupFunction(String[] lookupKeys) {
+		return JDBCLookupFunction.builder()
+				.setTableName(tableName)
+				.setUsername(username)
+				.setPassword(password)
+				.setDrivername(drivername)
+				.setDBUrl(dbURL)
+				.setFieldNames(fieldNames)
+				.setFieldTypes(fieldTypes)
+				.setKeyNames(lookupKeys)
+				.setLeftQuote(leftQuote)
+				.setRightQuote(rightQuote)
+				.setCacheMaxSize(cacheMaxSize)
+				.setCacheExpireMs(cacheExpireMs)
+				.setMaxRetryTimes(maxRetryTimes).build();
+	}
+
+	@Override
+	public AsyncTableFunction<Row> getAsyncLookupFunction(String[] lookupKeys) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean isAsyncEnabled() {
+		return false;
+	}
+
+	@Override
+	public TableSchema getTableSchema() {
+		return new TableSchema(fieldNames, fieldTypes);
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Builder for a {@link JDBCLookupTableSource}.
+	 */
+	public static class Builder {
+		private String tableName;
+		private String username;
+		private String password;
+		private String drivername;
+		private String dbURL;
+		private String[] fieldNames;
+		private TypeInformation[] fieldTypes;
+		private String leftQuote = "";
+		private String rightQuote = "";
+		private long cacheMaxSize = -1;
+		private long cacheExpireMs = -1;
+		private int maxRetryTimes = DEFAULT_MAX_RETRY_TIMES;
+
+		public Builder setTableName(String tableName) {
+			this.tableName = tableName;
+			return this;
+		}
+
+		public Builder setUsername(String username) {
+			this.username = username;
+			return this;
+		}
+
+		public Builder setPassword(String password) {
+			this.password = password;
+			return this;
+		}
+
+		public Builder setDrivername(String drivername) {
+			this.drivername = drivername;
+			return this;
+		}
+
+		public Builder setDBUrl(String dbURL) {
+			this.dbURL = dbURL;
+			return this;
+		}
+
+		public Builder setFieldNames(String[] fieldNames) {
+			this.fieldNames = fieldNames;
+			return this;
+		}
+
+		public Builder setFieldTypes(TypeInformation[] fieldTypes) {
+			this.fieldTypes = fieldTypes;
+			return this;
+		}
+
+		public Builder setLeftQuote(String leftQuote) {
+			this.leftQuote = leftQuote;
+			return this;
+		}
+
+		public Builder setRightQuote(String rightQuote) {
+			this.rightQuote = rightQuote;
+			return this;
+		}
+
+		public Builder setCacheMaxSize(long cacheMaxSize) {
+			this.cacheMaxSize = cacheMaxSize;
+			return this;
+		}
+
+		public Builder setCacheExpireMs(long cacheExpireMs) {
+			this.cacheExpireMs = cacheExpireMs;
+			return this;
+		}
+
+		public Builder setMaxRetryTimes(int maxRetryTimes) {
+			this.maxRetryTimes = maxRetryTimes;
+			return this;
+		}
+
+		/**
+		 * Finalizes the configuration and checks validity.
+		 *
+		 * @return Configured JDBCLookupTableSource
+		 */
+		public JDBCLookupTableSource build() {
+			checkNotNull(tableName, "No tableName supplied.");
+			checkNotNull(drivername, "No driver supplied.");
+			checkNotNull(dbURL, "No database URL supplied.");
+			checkNotNull(fieldNames, "No fieldNames supplied.");
+			checkNotNull(fieldTypes, "No fieldTypes supplied.");
+
+			return new JDBCLookupTableSource(
+					tableName, username, password, drivername, dbURL,
+					fieldNames, fieldTypes, leftQuote, rightQuote,
+					cacheMaxSize, cacheExpireMs, maxRetryTimes);
+		}
+	}
+}

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCLookupFunctionITCase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCLookupFunctionITCase.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.jdbc;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.java.StreamTableEnvironment;
+import org.apache.flink.table.runtime.utils.StreamITCase;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.types.Row;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.apache.flink.api.java.io.jdbc.JDBCTestBase.DRIVER_CLASS;
+
+/**
+ * IT case for {@link JDBCLookupFunction}.
+ */
+@RunWith(Parameterized.class)
+public class JDBCLookupFunctionITCase extends AbstractTestBase {
+
+	public static final String DB_URL = "jdbc:derby:memory:lookup";
+	public static final String LOOKUP_TABLE = "lookup_table";
+
+	private final boolean useCache;
+
+	public JDBCLookupFunctionITCase(boolean useCache) {
+		this.useCache = useCache;
+	}
+
+	@Parameterized.Parameters(name = "Table config = {0}")
+	public static Collection<Boolean> parameters() {
+		return Arrays.asList(true, false);
+	}
+
+	@Before
+	public void before() throws ClassNotFoundException, SQLException {
+		System.setProperty("derby.stream.error.field", JDBCTestBase.class.getCanonicalName() + ".DEV_NULL");
+
+		Class.forName(DRIVER_CLASS);
+		try (
+			Connection conn = DriverManager.getConnection(DB_URL + ";create=true");
+			Statement stat = conn.createStatement()) {
+			stat.executeUpdate("CREATE TABLE " + LOOKUP_TABLE + " (" +
+					"id1 INT NOT NULL DEFAULT 0," +
+					"id2 INT NOT NULL DEFAULT 0," +
+					"comment1 VARCHAR(1000)," +
+					"comment2 VARCHAR(1000))");
+
+			Object[][] data = new Object[][] {
+					new Object[] {1, 1, "11-c1-v1", "11-c2-v1"},
+					new Object[] {1, 1, "11-c1-v2", "11-c2-v2"},
+					new Object[] {2, 3, "23-c1", "23-c2"},
+					new Object[] {2, 5, "25-c1", "25-c2"},
+					new Object[] {3, 8, "38-c1", "38-c2"}
+			};
+			StringBuilder sqlQueryBuilder = new StringBuilder(
+					"INSERT INTO " + LOOKUP_TABLE + " (id1, id2, comment1, comment2) VALUES ");
+			for (int i = 0; i < data.length; i++) {
+				sqlQueryBuilder.append("(")
+						.append(data[i][0]).append(",")
+						.append(data[i][1]).append(",'")
+						.append(data[i][2]).append("','")
+						.append(data[i][3]).append("')") ;
+				if (i < data.length - 1) {
+					sqlQueryBuilder.append(",");
+				}
+			}
+			stat.execute(sqlQueryBuilder.toString());
+		}
+	}
+
+	@After
+	public void clearOutputTable() throws Exception {
+		Class.forName(DRIVER_CLASS);
+		try (
+				Connection conn = DriverManager.getConnection(DB_URL);
+				Statement stat = conn.createStatement()) {
+			stat.execute("DROP TABLE " + LOOKUP_TABLE);
+		}
+	}
+
+	@Test
+	public void test() throws Exception {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+		StreamITCase.clear();
+
+		Table t = tEnv.fromDataStream(env.fromCollection(Arrays.asList(
+					new Tuple2<>(1, 1),
+					new Tuple2<>(1, 1),
+					new Tuple2<>(2, 3),
+					new Tuple2<>(2, 5),
+					new Tuple2<>(3, 5),
+					new Tuple2<>(3, 8)
+				)), "id1, id2");
+
+		tEnv.registerTable("T", t);
+
+		JDBCLookupTableSource.Builder builder = JDBCLookupTableSource.builder()
+				.setDrivername(DRIVER_CLASS).
+						setDBUrl(DB_URL)
+				.setTableName(LOOKUP_TABLE)
+				.setFieldNames(new String[]{"id1", "id2", "comment1", "comment2"})
+				.setFieldTypes(new TypeInformation[]{Types.INT, Types.INT, Types.STRING, Types.STRING});
+		if (useCache) {
+			builder.setCacheMaxSize(1000);
+			builder.setCacheExpireMs(1000 * 1000);
+		}
+		tEnv.registerFunction("jdbcLookup",
+				builder.build().getLookupFunction(t.getSchema().getFieldNames()));
+
+		String sqlQuery = "SELECT id1, id2, comment1, comment2 FROM T, " +
+				"LATERAL TABLE(jdbcLookup(id1, id2)) AS S(l_id1, l_id2, comment1, comment2)";
+		Table result = tEnv.sqlQuery(sqlQuery);
+
+		DataStream<Row> resultSet = tEnv.toAppendStream(result, Row.class);
+		resultSet.addSink(new StreamITCase.StringSink<>());
+		env.execute();
+
+		List<String> expected = new ArrayList<>();
+		expected.add("1,1,11-c1-v1,11-c2-v1");
+		expected.add("1,1,11-c1-v1,11-c2-v1");
+		expected.add("1,1,11-c1-v2,11-c2-v2");
+		expected.add("1,1,11-c1-v2,11-c2-v2");
+		expected.add("2,3,23-c1,23-c2");
+		expected.add("2,5,25-c1,25-c2");
+		expected.add("3,8,38-c1,38-c2");
+
+		StreamITCase.compareWithList(expected);
+	}
+}


### PR DESCRIPTION
Mirror of apache flink#8923

## What is the purpose of the change

It is very common to store dimension information in JDBC databases. It is very useful to support JDBCLookupFunction, user can use this to lookup dimension fields in his streaming job.
User can use JDBCLookupFunction to table function, or user can use JDBCLookupTableSource to blink planner temporal table join.

## Brief change log

1.Introduce JDBCLookupFunction
2.Introduce JDBCLookupTableSource

## Verifying this change

ut

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)

