### PR TITLE
Mirror of apache flink#8912

### DIFF
--- a/docs/_includes/generated/blob_server_configuration.html
+++ b/docs/_includes/generated/blob_server_configuration.html
@@ -8,14 +8,14 @@
     </thead>
     <tbody>
         <tr>
-            <td><h5>blob.client.socket.timeout</h5></td>
-            <td style="word-wrap: break-word;">300000</td>
-            <td>The socket timeout in milliseconds for the blob client.</td>
-        </tr>
-        <tr>
             <td><h5>blob.client.connect.timeout</h5></td>
             <td style="word-wrap: break-word;">0</td>
             <td>The connection timeout in milliseconds for the blob client.</td>
+        </tr>
+        <tr>
+            <td><h5>blob.client.socket.timeout</h5></td>
+            <td style="word-wrap: break-word;">300000</td>
+            <td>The socket timeout in milliseconds for the blob client.</td>
         </tr>
         <tr>
             <td><h5>blob.fetch.backlog</h5></td>

--- a/docs/_includes/generated/netty_shuffle_environment_configuration.html
+++ b/docs/_includes/generated/netty_shuffle_environment_configuration.html
@@ -1,0 +1,61 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>taskmanager.data.port</h5></td>
+            <td style="word-wrap: break-word;">0</td>
+            <td>The task manager’s port used for data exchange operations.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.data.ssl.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Enable SSL support for the taskmanager data transport. This is applicable only when the global flag for internal SSL (security.ssl.internal.enabled) is set to true</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.detailed-metrics</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean flag to enable/disable more detailed metrics about inbound/outbound network queue lengths.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.memory.buffers-per-channel</h5></td>
+            <td style="word-wrap: break-word;">2</td>
+            <td>Maximum number of network buffers to use for each outgoing/incoming channel (subpartition/input channel).In credit-based flow control mode, this indicates how many credits are exclusive in each input channel. It should be configured at least 2 for good performance. 1 buffer is for receiving in-flight data in the subpartition and 1 buffer is for parallel serialization.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.memory.floating-buffers-per-gate</h5></td>
+            <td style="word-wrap: break-word;">8</td>
+            <td>Number of extra network buffers to use for each outgoing/incoming gate (result partition/input gate). In credit-based flow control mode, this indicates how many floating credits are shared among all the input channels. The floating buffers are distributed based on backlog (real-time output buffers in the subpartition) feedback, and can help relieve back-pressure caused by unbalanced data distribution among the subpartitions. This value should be increased in case of higher round trip times between nodes and/or larger number of machines in the cluster.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.memory.fraction</h5></td>
+            <td style="word-wrap: break-word;">0.1</td>
+            <td>Fraction of JVM memory to use for network buffers. This determines how many streaming data exchange channels a TaskManager can have at the same time and how well buffered the channels are. If a job is rejected or you get a warning that the system has not enough buffers available, increase this value or the min/max values below. Also note, that "taskmanager.network.memory.min"` and "taskmanager.network.memory.max" may override this fraction.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.memory.max</h5></td>
+            <td style="word-wrap: break-word;">"1gb"</td>
+            <td>Maximum memory size for network buffers.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.memory.min</h5></td>
+            <td style="word-wrap: break-word;">"64mb"</td>
+            <td>Minimum memory size for network buffers.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.request-backoff.initial</h5></td>
+            <td style="word-wrap: break-word;">100</td>
+            <td>Minimum backoff in milliseconds for partition requests of input channels.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.request-backoff.max</h5></td>
+            <td style="word-wrap: break-word;">10000</td>
+            <td>Maximum backoff in milliseconds for partition requests of input channels.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/_includes/generated/restart_backoff_time_strategy_configuration.html
+++ b/docs/_includes/generated/restart_backoff_time_strategy_configuration.html
@@ -8,6 +8,11 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>restart-backoff-time-strategy.class-name</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Class name of the RestartBackoffTimeStrategy implementation to use.</td>
+        </tr>
+        <tr>
             <td><h5>restart-backoff-time-strategy.failure-rate.backoff-time</h5></td>
             <td style="word-wrap: break-word;">0</td>
             <td>Backoff time in milliseconds between two consecutive restart attempts.</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestartBackoffTimeStrategyOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestartBackoffTimeStrategyOptions.java
@@ -25,6 +25,16 @@ import org.apache.flink.annotation.PublicEvolving;
  */
 @PublicEvolving
 public class RestartBackoffTimeStrategyOptions {
+
+	/**
+	 * Class name of the RestartBackoffTimeStrategy implementation to use.
+	 */
+	@PublicEvolving
+	public static final ConfigOption<String> RESTART_BACKOFF_TIME_STRATEGY_CLASS_NAME = ConfigOptions
+		.key("restart-backoff-time-strategy.class-name")
+		.noDefaultValue()
+		.withDescription("Class name of the RestartBackoffTimeStrategy implementation to use.");
+
 	/**
 	 * Maximum number of failures in given time interval {@link #RESTART_BACKOFF_TIME_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL}
 	 * before failing a job in FailureRateRestartBackoffTimeStrategy.
@@ -36,7 +46,8 @@ public class RestartBackoffTimeStrategyOptions {
 		.withDescription("Maximum number of failures in given time interval before failing a job.");
 
 	/**
-	 * Time interval in which greater amount of failures than {@link #RESTART_BACKOFF_TIME_STRATEGY_FAILURE_RATE_MAX_FAILURES_PER_INTERVAL}
+	 * Time interval (milli-seconds) in which greater amount of failures than
+	 * {@link #RESTART_BACKOFF_TIME_STRATEGY_FAILURE_RATE_MAX_FAILURES_PER_INTERVAL}
 	 * causes job fail in FailureRateRestartBackoffTimeStrategy.
 	 */
 	@PublicEvolving
@@ -46,7 +57,7 @@ public class RestartBackoffTimeStrategyOptions {
 		.withDescription("Time interval in milliseconds for measuring failure rate.");
 
 	/**
-	 * Backoff time between two consecutive restart attempts in FailureRateRestartBackoffTimeStrategy.
+	 * Backoff time (milli-seconds) between two consecutive restart attempts in FailureRateRestartBackoffTimeStrategy.
 	 */
 	@PublicEvolving
 	public static final ConfigOption<Long> RESTART_BACKOFF_TIME_STRATEGY_FAILURE_RATE_FAILURE_RATE_BACKOFF_TIME = ConfigOptions
@@ -64,7 +75,7 @@ public class RestartBackoffTimeStrategyOptions {
 		.withDescription("Maximum number of attempts the fixed delay restart strategy will try before failing a job.");
 
 	/**
-	 * Backoff time between two consecutive restart attempts in FixedDelayRestartBackoffTimeStrategy.
+	 * Backoff time (milli-seconds) between two consecutive restart attempts in FixedDelayRestartBackoffTimeStrategy.
 	 */
 	@PublicEvolving
 	public static final ConfigOption<Long> RESTART_BACKOFF_TIME_STRATEGY_FIXED_DELAY_BACKOFF_TIME = ConfigOptions

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/NoRestartBackoffTimeStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/NoRestartBackoffTimeStrategy.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.failover.flip1;
+
+import org.apache.flink.configuration.Configuration;
+
+/**
+ * Restart strategy which does not restart tasks when tasks fail.
+ */
+public class NoRestartBackoffTimeStrategy implements RestartBackoffTimeStrategy {
+
+	@Override
+	public boolean canRestart() {
+		return false;
+	}
+
+	@Override
+	public long getBackoffTime() {
+		return 0L;
+	}
+
+	@Override
+	public void notifyFailure(final Throwable cause) {
+		// nothing to do
+	}
+
+	@Override
+	public String toString() {
+		return "NoRestartBackoffTimeStrategy";
+	}
+
+	public static NoRestartBackoffTimeStrategyFactory createFactory(final Configuration configuration) {
+		return new NoRestartBackoffTimeStrategyFactory();
+	}
+
+	/**
+	 * The factory for creating {@link NoRestartBackoffTimeStrategy}.
+	 */
+	public static class NoRestartBackoffTimeStrategyFactory implements Factory {
+
+		@Override
+		public RestartBackoffTimeStrategy create() {
+			return new NoRestartBackoffTimeStrategy();
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartBackoffTimeStrategyFactoryLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartBackoffTimeStrategyFactoryLoader.java
@@ -1,0 +1,398 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.failover.flip1;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.configuration.AkkaOptions;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestartBackoffTimeStrategyOptions;
+import org.apache.flink.runtime.executiongraph.restart.FixedDelayRestartStrategy;
+import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+
+import scala.concurrent.duration.Duration;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A utility class to load {@link RestartBackoffTimeStrategy.Factory} from the configuration.
+ */
+public class RestartBackoffTimeStrategyFactoryLoader {
+
+	private static final Logger LOG = LoggerFactory.getLogger(RestartBackoffTimeStrategyFactoryLoader.class);
+
+	private static final String CREATE_METHOD = "createFactory";
+
+	/**
+	 * Creates proper {@link RestartBackoffTimeStrategy.Factory}.
+	 * If new version restart strategy is specified, will directly use it.
+	 * Otherwise will decide based on legacy restart strategy configs.
+	 *
+	 * @param jobRestartStrategyConfiguration restart configuration given within the job graph
+	 * @param clusterConfiguration cluster(server-side) configuration, usually represented as jobmanager config
+	 * @param isCheckpointingEnabled if checkpointing was enabled for the job
+	 * @return new version restart strategy factory
+	 */
+	public static RestartBackoffTimeStrategy.Factory createRestartStrategyFactory(
+		final RestartStrategies.RestartStrategyConfiguration jobRestartStrategyConfiguration,
+		final Configuration clusterConfiguration,
+		final boolean isCheckpointingEnabled) throws Exception {
+
+		checkNotNull(jobRestartStrategyConfiguration);
+		checkNotNull(clusterConfiguration);
+
+		final String restartStrategyClassName = clusterConfiguration.getString(
+			RestartBackoffTimeStrategyOptions.RESTART_BACKOFF_TIME_STRATEGY_CLASS_NAME);
+
+		if (restartStrategyClassName != null) {
+			// create new restart strategy directly if it is specified in cluster config
+			return createRestartStrategyFactoryInternal(clusterConfiguration);
+		} else {
+			// adapt the legacy restart strategy configs as new restart strategy configs
+			final Configuration adaptedConfiguration = getAdaptedConfiguration(
+				jobRestartStrategyConfiguration,
+				clusterConfiguration,
+				isCheckpointingEnabled);
+
+			// create new restart strategy from the adapted config
+			return createRestartStrategyFactoryInternal(adaptedConfiguration);
+		}
+	}
+
+	/**
+	 * Decides the {@link RestartBackoffTimeStrategy} to use and its params based on legacy configs,
+	 * and records its class name and the params into a adapted configuration.
+	 *
+	 * <p>The decision making is as follows:
+	 * <ol>
+	 *     <li>Use strategy of {@link RestartStrategies.RestartStrategyConfiguration}, unless it's a
+	 * {@link RestartStrategies.FallbackRestartStrategyConfiguration} or not valid.</li>
+	 *     <li>If strategy is not decided, use legacy strategy specified in cluster(server-side) config,
+	 * unless it is not set or not valid</li>
+	 *     <li>If strategy is not decided, use {@link FixedDelayRestartStrategy} if checkpointing is
+	 * enabled. Otherwise use {@link NoRestartStrategy}</li>
+	 * </ol>
+	 *
+	 * @param jobRestartStrategyConfiguration restart configuration given within the job graph
+	 * @param clusterConfiguration cluster(server-side) configuration, usually represented as jobmanager config
+	 * @param isCheckpointingEnabled if checkpointing was enabled for the job
+	 * @return adapted configuration
+	 */
+	private static Configuration getAdaptedConfiguration(
+		final RestartStrategies.RestartStrategyConfiguration jobRestartStrategyConfiguration,
+		final Configuration clusterConfiguration,
+		final boolean isCheckpointingEnabled) throws Exception {
+
+		// clone a new config to not modify existing one
+		final Configuration adaptedConfiguration = new Configuration();
+
+		// try determining restart strategy based on job restart strategy config first
+		if (!tryAdaptingJobRestartStrategyConfiguration(jobRestartStrategyConfiguration, adaptedConfiguration)) {
+
+			// if job restart strategy config does not help
+			// try determining restart strategy based on cluster config as fallback
+			if (!tryAdaptingClusterRestartStrategyConfiguration(clusterConfiguration, adaptedConfiguration)) {
+
+				// if the restart strategy is not decided yet
+				// determine the strategy based on whether checkpointing is enabled
+				setDefaultRestartStrategyToConfiguration(isCheckpointingEnabled, adaptedConfiguration);
+			}
+		}
+
+		return adaptedConfiguration;
+	}
+
+	private static RestartBackoffTimeStrategy.Factory createRestartStrategyFactoryInternal(
+		final Configuration configuration) {
+
+		final String restartStrategyClassName = configuration.getString(
+			RestartBackoffTimeStrategyOptions.RESTART_BACKOFF_TIME_STRATEGY_CLASS_NAME);
+
+		if (restartStrategyClassName == null) {
+			LOG.info("No restart strategy is configured. Using no restart strategy.");
+			return new NoRestartBackoffTimeStrategy.NoRestartBackoffTimeStrategyFactory();
+		}
+
+		try {
+			final Class<?> clazz = Class.forName(restartStrategyClassName);
+			if (clazz != null && RestartBackoffTimeStrategy.class.isAssignableFrom(clazz)) {
+				final Method method = clazz.getMethod(CREATE_METHOD, Configuration.class);
+				if (method != null) {
+					final Object result = method.invoke(null, configuration);
+
+					if (result != null) {
+						return (RestartBackoffTimeStrategy.Factory) result;
+					}
+				}
+			}
+		} catch (ClassNotFoundException cnfe) {
+			LOG.warn("Could not find restart strategy class {}.", restartStrategyClassName);
+		} catch (NoSuchMethodException nsme) {
+			LOG.warn("Class {} does not has static method {}.", restartStrategyClassName, CREATE_METHOD);
+		} catch (InvocationTargetException ite) {
+			LOG.warn("Cannot call static method {} from class {}.", CREATE_METHOD, restartStrategyClassName);
+		} catch (IllegalAccessException iae) {
+			LOG.warn("Illegal access while calling method {} from class {}.", CREATE_METHOD, restartStrategyClassName);
+		}
+
+		// fallback in case of an error
+		LOG.info("Configured restart strategy {} is not valid. Fall back to no restart strategy.",
+			restartStrategyClassName);
+		return new NoRestartBackoffTimeStrategy.NoRestartBackoffTimeStrategyFactory();
+	}
+
+	private static boolean tryAdaptingJobRestartStrategyConfiguration(
+		final RestartStrategies.RestartStrategyConfiguration restartStrategyConfiguration,
+		final Configuration adaptedConfiguration) throws Exception {
+
+		if (restartStrategyConfiguration instanceof RestartStrategies.NoRestartStrategyConfiguration) {
+			setNoRestartStrategyToConfiguration(adaptedConfiguration);
+
+			return true;
+		} else if (restartStrategyConfiguration instanceof RestartStrategies.FixedDelayRestartStrategyConfiguration) {
+			final RestartStrategies.FixedDelayRestartStrategyConfiguration fixedDelayConfig =
+				(RestartStrategies.FixedDelayRestartStrategyConfiguration) restartStrategyConfiguration;
+
+			setFixedDelayRestartStrategyToConfiguration(
+				adaptedConfiguration,
+				fixedDelayConfig.getDelayBetweenAttemptsInterval().toMilliseconds(),
+				fixedDelayConfig.getRestartAttempts());
+
+			return true;
+		} else if (restartStrategyConfiguration instanceof RestartStrategies.FailureRateRestartStrategyConfiguration) {
+			final RestartStrategies.FailureRateRestartStrategyConfiguration failureRateConfig =
+				(RestartStrategies.FailureRateRestartStrategyConfiguration) restartStrategyConfiguration;
+
+			setFailureRateRestartStrategyToConfiguration(
+				adaptedConfiguration,
+				failureRateConfig.getDelayBetweenAttemptsInterval().toMilliseconds(),
+				failureRateConfig.getFailureInterval().toMilliseconds(),
+				failureRateConfig.getMaxFailureRate());
+
+			return true;
+		} else if (restartStrategyConfiguration instanceof RestartStrategies.FallbackRestartStrategyConfiguration) {
+			return false;
+		} else {
+			throw new IllegalArgumentException("Unknown restart strategy configuration " +
+				restartStrategyConfiguration + ".");
+		}
+	}
+
+	private static boolean tryAdaptingClusterRestartStrategyConfiguration(
+		final Configuration clusterConfiguration,
+		final Configuration adaptedConfiguration) throws Exception {
+
+		final String restartStrategyName = clusterConfiguration.getString(ConfigConstants.RESTART_STRATEGY, null);
+		if (restartStrategyName == null) {
+			return tryAdaptingClusterConfigurationOfDeprecatedValues(clusterConfiguration, adaptedConfiguration);
+		}
+
+		switch (restartStrategyName.toLowerCase()) {
+			case "none":
+			case "off":
+			case "disable":
+				setNoRestartStrategyToConfiguration(adaptedConfiguration);
+				return true;
+			case "fixeddelay":
+			case "fixed-delay":
+				adaptClusterConfigurationOfFixedDelayRestartStrategy(
+					clusterConfiguration,
+					adaptedConfiguration);
+				return true;
+			case "failurerate":
+			case "failure-rate":
+				adaptClusterConfigurationOfFailureRateRestartStrategy(
+					clusterConfiguration,
+					adaptedConfiguration);
+				return true;
+			default:
+				return false;
+		}
+	}
+
+	private static boolean tryAdaptingClusterConfigurationOfDeprecatedValues(
+		final Configuration clusterConfiguration,
+		final Configuration adaptedConfiguration) throws Exception {
+
+		// support deprecated ConfigConstants values
+		final int maxAttempts = clusterConfiguration.getInteger(
+			ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS,
+			ConfigConstants.DEFAULT_EXECUTION_RETRIES);
+		final String pauseString = clusterConfiguration.getString(
+			AkkaOptions.WATCH_HEARTBEAT_PAUSE);
+		final String delayString = clusterConfiguration.getString(
+			ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY,
+			pauseString);
+
+		final long delay;
+		try {
+			delay = Duration.apply(delayString).toMillis();
+		} catch (NumberFormatException nfe) {
+			if (delayString.equals(pauseString)) {
+				throw new Exception("Invalid config value for " +
+					AkkaOptions.WATCH_HEARTBEAT_PAUSE.key() + ": " + pauseString +
+					". Value must be a valid duration (such as '10 s' or '1 min')");
+			} else {
+				throw new Exception("Invalid config value for " +
+					ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY + ": " + delayString +
+					". Value must be a valid duration (such as '100 milli' or '10 s')");
+			}
+		}
+
+		if (maxAttempts > 0 && delay >= 0) {
+			setFixedDelayRestartStrategyToConfiguration(adaptedConfiguration, delay, maxAttempts);
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	private static void adaptClusterConfigurationOfFixedDelayRestartStrategy(
+		final Configuration clusterConfiguration,
+		final Configuration adaptedConfiguration) throws Exception {
+
+		final int maxAttempts = clusterConfiguration.getInteger(
+			ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS,
+			1);
+		final String delayString = clusterConfiguration.getString(
+			ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY);
+
+		final long delay;
+		try {
+			delay = Duration.apply(delayString).toMillis();
+		} catch (NumberFormatException nfe) {
+			throw new Exception("Invalid config value for " +
+				ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY + ": " + delayString +
+				". Value must be a valid duration (such as '100 milli' or '10 s')");
+		}
+
+		setFixedDelayRestartStrategyToConfiguration(adaptedConfiguration, delay, maxAttempts);
+	}
+
+	private static void adaptClusterConfigurationOfFailureRateRestartStrategy(
+		final Configuration clusterConfiguration,
+		final Configuration adaptedConfiguration) throws Exception {
+
+		final int maxFailuresPerInterval = clusterConfiguration.getInteger(
+			ConfigConstants.RESTART_STRATEGY_FAILURE_RATE_MAX_FAILURES_PER_INTERVAL,
+			1);
+		final String failuresIntervalString = clusterConfiguration.getString(
+			ConfigConstants.RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL,
+			Duration.apply(1, TimeUnit.MINUTES).toString()
+		);
+		final String timeoutString = clusterConfiguration.getString(
+			AkkaOptions.WATCH_HEARTBEAT_INTERVAL);
+		final String delayString = clusterConfiguration.getString(
+			ConfigConstants.RESTART_STRATEGY_FAILURE_RATE_DELAY, timeoutString);
+
+		final long failuresInterval;
+		try {
+			failuresInterval = Duration.apply(failuresIntervalString).toMillis();
+		} catch (NumberFormatException nfe) {
+			throw new Exception("Invalid config value for " +
+				ConfigConstants.RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL + ": "
+				+ failuresIntervalString + ". Value must be a valid duration (such as '100 milli' or '10 s')");
+		}
+		final long delay;
+		try {
+			delay = Duration.apply(delayString).toMillis();
+		} catch (NumberFormatException nfe) {
+			throw new Exception("Invalid config value for " +
+				ConfigConstants.RESTART_STRATEGY_FAILURE_RATE_DELAY + ": " + delayString +
+				". Value must be a valid duration (such as '100 milli' or '10 s')");
+		}
+
+		setFailureRateRestartStrategyToConfiguration(adaptedConfiguration, delay, failuresInterval, maxFailuresPerInterval);
+	}
+
+	private static void setDefaultRestartStrategyToConfiguration(
+		final boolean isCheckpointingEnabled,
+		final Configuration configuration) {
+
+		if (isCheckpointingEnabled) {
+			// fixed delay restart strategy with default params
+			setFixedDelayRestartStrategyToConfiguration(configuration, 0L, Integer.MAX_VALUE);
+		} else {
+			// no restart strategy
+			setNoRestartStrategyToConfiguration(configuration);
+		}
+	}
+
+	private static void setNoRestartStrategyToConfiguration(final Configuration configuration) {
+		setRestartBackoffTimeStrategyToConfiguration(
+			NoRestartBackoffTimeStrategy.class,
+			configuration);
+	}
+
+	private static void setFixedDelayRestartStrategyToConfiguration(
+		final Configuration configuration,
+		final long backoffTime,
+		final int maxAttempts) {
+
+		setRestartBackoffTimeStrategyToConfiguration(
+			FixedDelayRestartBackoffTimeStrategy.class,
+			configuration);
+		configuration.setLong(
+			RestartBackoffTimeStrategyOptions.RESTART_BACKOFF_TIME_STRATEGY_FIXED_DELAY_BACKOFF_TIME,
+			backoffTime);
+		configuration.setInteger(
+			RestartBackoffTimeStrategyOptions.RESTART_BACKOFF_TIME_STRATEGY_FIXED_DELAY_ATTEMPTS,
+			maxAttempts);
+	}
+
+	private static void setFailureRateRestartStrategyToConfiguration(
+		final Configuration configuration,
+		final long backoffTime,
+		final long failuresInterval,
+		final int maxFailuresPerInterval) {
+
+		setRestartBackoffTimeStrategyToConfiguration(
+			FailureRateRestartBackoffTimeStrategy.class,
+			configuration);
+		configuration.setLong(
+			RestartBackoffTimeStrategyOptions.RESTART_BACKOFF_TIME_STRATEGY_FAILURE_RATE_FAILURE_RATE_BACKOFF_TIME,
+			backoffTime);
+		configuration.setLong(
+			RestartBackoffTimeStrategyOptions.RESTART_BACKOFF_TIME_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL,
+			failuresInterval);
+		configuration.setInteger(
+			RestartBackoffTimeStrategyOptions.RESTART_BACKOFF_TIME_STRATEGY_FAILURE_RATE_MAX_FAILURES_PER_INTERVAL,
+			maxFailuresPerInterval);
+	}
+
+	private static void setRestartBackoffTimeStrategyToConfiguration(
+		final Class<?> strategyClass,
+		final Configuration configuration) {
+
+		checkArgument(RestartBackoffTimeStrategy.class.isAssignableFrom(strategyClass),
+			strategyClass + " is not a valid RestartBackoffTimeStrategy implementation.");
+
+		configuration.setString(
+			RestartBackoffTimeStrategyOptions.RESTART_BACKOFF_TIME_STRATEGY_CLASS_NAME,
+			strategyClass.getName());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartBackoffTimeStrategyFactoryLoaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartBackoffTimeStrategyFactoryLoaderTest.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.failover.flip1;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestartBackoffTimeStrategyOptions;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+
+/**
+ * Unit tests for {@link RestartBackoffTimeStrategyFactoryLoader}.
+ */
+public class RestartBackoffTimeStrategyFactoryLoaderTest extends TestLogger {
+
+	private static final RestartStrategies.RestartStrategyConfiguration DEFAULT_RESTART_STRATEGY_CONFIGURATION =
+		new RestartStrategies.FallbackRestartStrategyConfiguration();
+
+	@Test
+	public void testNewStrategySpecified() throws Exception {
+		// specify RestartBackoffTimeStrategy directly in cluster config
+		final Configuration conf = new Configuration();
+		conf.setString(
+			RestartBackoffTimeStrategyOptions.RESTART_BACKOFF_TIME_STRATEGY_CLASS_NAME,
+			TestRestartBackoffTimeStrategy.class.getName());
+
+		// the RestartStrategyConfiguration should not take effect as the loader will
+		// directly create the factory from the config of the new version strategy
+		final RestartBackoffTimeStrategy.Factory factory =
+			RestartBackoffTimeStrategyFactoryLoader.createRestartStrategyFactory(
+				new RestartStrategies.FailureRateRestartStrategyConfiguration(
+					1,
+					Time.milliseconds(1000),
+					Time.milliseconds(1000)),
+				conf,
+				true);
+
+		assertThat(
+			factory,
+			instanceOf(TestRestartBackoffTimeStrategy.TestRestartBackoffTimeStrategyFactory.class));
+	}
+
+	@Test
+	public void testInvalidNewStrategySpecified() throws Exception {
+		final Configuration conf = new Configuration();
+		conf.setString(
+			RestartBackoffTimeStrategyOptions.RESTART_BACKOFF_TIME_STRATEGY_CLASS_NAME,
+			InvalidTestRestartBackoffTimeStrategy.class.getName());
+
+		final RestartBackoffTimeStrategy.Factory factory =
+			RestartBackoffTimeStrategyFactoryLoader.createRestartStrategyFactory(
+				DEFAULT_RESTART_STRATEGY_CONFIGURATION,
+				conf,
+				true);
+
+		assertThat(
+			factory,
+			instanceOf(NoRestartBackoffTimeStrategy.NoRestartBackoffTimeStrategyFactory.class));
+	}
+
+	@Test
+	public void testNoStrategySpecifiedWhenCheckpointingEnabled() throws Exception {
+		final RestartBackoffTimeStrategy.Factory factory =
+			RestartBackoffTimeStrategyFactoryLoader.createRestartStrategyFactory(
+				DEFAULT_RESTART_STRATEGY_CONFIGURATION,
+				new Configuration(),
+				true);
+
+		assertThat(
+			factory,
+			instanceOf(FixedDelayRestartBackoffTimeStrategy.FixedDelayRestartBackoffTimeStrategyFactory.class));
+	}
+
+	@Test
+	public void testNoStrategySpecifiedWhenCheckpointingDisabled() throws Exception {
+		final RestartBackoffTimeStrategy.Factory factory =
+			RestartBackoffTimeStrategyFactoryLoader.createRestartStrategyFactory(
+				DEFAULT_RESTART_STRATEGY_CONFIGURATION,
+				new Configuration(),
+				false);
+
+		assertThat(
+			factory,
+			instanceOf(NoRestartBackoffTimeStrategy.NoRestartBackoffTimeStrategyFactory.class));
+	}
+
+	@Test
+	public void testLegacyStrategySpecifiedInJobConfig() throws Exception {
+		// the fixed delay strategy config in cluster config should not take effect
+		// as it will be overridden by the failure rate strategy config in job config
+		final Configuration conf = new Configuration();
+		conf.setString(ConfigConstants.RESTART_STRATEGY, "fixed-delay");
+
+		final RestartBackoffTimeStrategy.Factory factory =
+			RestartBackoffTimeStrategyFactoryLoader.createRestartStrategyFactory(
+				new RestartStrategies.FailureRateRestartStrategyConfiguration(
+					1,
+					Time.milliseconds(1000),
+					Time.milliseconds(1000)),
+				conf,
+				false);
+
+		assertThat(
+			factory,
+			instanceOf(FailureRateRestartBackoffTimeStrategy.FailureRateRestartBackoffTimeStrategyFactory.class));
+	}
+
+	@Test
+	public void testLegacyStrategySpecifiedInClusterConfig() throws Exception {
+		// the fixed delay strategy config in cluster config should not take effect
+		// as it will be overridden by the failure rate strategy config in job config
+		final Configuration conf = new Configuration();
+		conf.setString(ConfigConstants.RESTART_STRATEGY, "fixed-delay");
+
+		final RestartBackoffTimeStrategy.Factory factory =
+			RestartBackoffTimeStrategyFactoryLoader.createRestartStrategyFactory(
+				DEFAULT_RESTART_STRATEGY_CONFIGURATION,
+				conf,
+				false);
+
+		assertThat(
+			factory,
+			instanceOf(FixedDelayRestartBackoffTimeStrategy.FixedDelayRestartBackoffTimeStrategyFactory.class));
+	}
+
+	@Test
+	public void testDeprecatedValuesSpecifiedInClusterConfig() throws Exception {
+		// the fixed delay strategy config in cluster config should not take effect
+		// as it will be overridden by the failure rate strategy config in job config
+		final Configuration conf = new Configuration();
+		conf.setInteger(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1);
+
+		final RestartBackoffTimeStrategy.Factory factory =
+			RestartBackoffTimeStrategyFactoryLoader.createRestartStrategyFactory(
+				DEFAULT_RESTART_STRATEGY_CONFIGURATION,
+				conf,
+				false);
+
+		assertThat(
+			factory,
+			instanceOf(FixedDelayRestartBackoffTimeStrategy.FixedDelayRestartBackoffTimeStrategyFactory.class));
+	}
+
+	// ------------------------------------------------------------------------
+	//  utilities
+	// ------------------------------------------------------------------------
+
+	/**
+	 * A test implementation of {@link RestartBackoffTimeStrategy}.
+	 */
+	private static class TestRestartBackoffTimeStrategy implements RestartBackoffTimeStrategy {
+
+		@Override
+		public boolean canRestart() {
+			return false;
+		}
+
+		@Override
+		public long getBackoffTime() {
+			return 0;
+		}
+
+		@Override
+		public void notifyFailure(Throwable cause) {
+
+		}
+
+		public static TestRestartBackoffTimeStrategyFactory createFactory(final Configuration configuration) {
+			return new TestRestartBackoffTimeStrategyFactory();
+		}
+
+		/**
+		 * The factory for creating {@link TestRestartBackoffTimeStrategy}.
+		 */
+		private static class TestRestartBackoffTimeStrategyFactory implements Factory {
+
+			@Override
+			public RestartBackoffTimeStrategy create() {
+				return new TestRestartBackoffTimeStrategy();
+			}
+		}
+	}
+
+	/**
+	 * A test class that has not implemented {@link RestartBackoffTimeStrategy}.
+	 */
+	private static class InvalidTestRestartBackoffTimeStrategy {}
+}


### PR DESCRIPTION
Mirror of apache flink#8912
… restart strategy configs

## What is the purpose of the change

*A loader is need to load factories of RestartBackoffTimeStrategy. In order to be backwards compatible, the loader should respect legacy RestartStrategy configurations. The legacy configuration can be in cluster config format (https://ci.apache.org/projects/flink/flink-docs-stable/dev/restart_strategies.html) or in RestartStrategies.RestartStrategyConfiguration format.*


## Brief change log

  - *The loader coverts legacy configuration into new generation format*
  - *The loader creates RestartBackoffTimeStrategy factory from new format configs*

## Verifying this change

  - *Added unit tests RestartBackoffTimeStrategyFactoryLoader*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)

