### PR TITLE
Mirror of apache flink#8910

### DIFF
--- a/flink-python/dev/pip_test_code.py
+++ b/flink-python/dev/pip_test_code.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 # test pyflink shell environment
-from pyflink.shell import bt_env, FileSystem, OldCsv, DataTypes, Schema
+from pyflink.shell import b_env, bt_env, FileSystem, OldCsv, DataTypes, Schema
 
 import tempfile
 import os
@@ -28,7 +28,7 @@ if os.path.exists(sink_path):
         os.remove(sink_path)
     else:
         shutil.rmtree(sink_path)
-bt_env.exec_env().set_parallelism(1)
+b_env.set_parallelism(1)
 t = bt_env.from_elements([(1, 'hi', 'hello'), (2, 'hi', 'hello')], ['a', 'b', 'c'])
 bt_env.connect(FileSystem().path(sink_path)) \
     .with_format(OldCsv()
@@ -44,7 +44,7 @@ bt_env.connect(FileSystem().path(sink_path)) \
 
 t.select("a + 1, b, c").insert_into("batch_sink")
 
-bt_env.exec_env().execute()
+b_env.execute()
 
 with open(sink_path, 'r') as f:
     lines = f.read()

--- a/flink-python/pyflink/dataset/tests/test_execution_environment.py
+++ b/flink-python/pyflink/dataset/tests/test_execution_environment.py
@@ -110,6 +110,6 @@ class ExecutionEnvironmentTests(PyFlinkTestCase):
             CsvTableSink(field_names, field_types, tmp_csv))
         t_env.scan("Orders").insert_into("Results")
 
-        plan = t_env.exec_env().get_execution_plan()
+        plan = self.env.get_execution_plan()
 
         json.loads(plan)

--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
@@ -187,6 +187,6 @@ class StreamExecutionEnvironmentTests(PyFlinkTestCase):
             CsvTableSink(field_names, field_types, tmp_csv))
         t_env.scan("Orders").insert_into("Results")
 
-        plan = t_env.exec_env().get_execution_plan()
+        plan = self.env.get_execution_plan()
 
         json.loads(plan)

--- a/flink-python/pyflink/shell.py
+++ b/flink-python/pyflink/shell.py
@@ -20,8 +20,9 @@ import codecs
 import platform
 import sys
 
-from pyflink.dataset import ExecutionEnvironment
-from pyflink.datastream import StreamExecutionEnvironment
+from pyflink.common import *
+from pyflink.dataset import *
+from pyflink.datastream import *
 from pyflink.table import *
 from pyflink.table.catalog import *
 from pyflink.table.descriptors import *

--- a/flink-python/pyflink/shell.py
+++ b/flink-python/pyflink/shell.py
@@ -94,16 +94,16 @@ NOTE: Use the prebound Table Environment to implement batch or streaming Table p
     *         shutil.rmtree(sink_path)
     * b_env.set_parallelism(1)
     * t = bt_env.from_elements([(1, 'hi', 'hello'), (2, 'hi', 'hello')], ['a', 'b', 'c'])
-    * bt_env.connect(FileSystem().path(sink_path))\
+    * bt_env.connect(FileSystem().path(sink_path)) \\
     *     .with_format(OldCsv()
     *                  .field_delimiter(',')
     *                  .field("a", DataTypes.BIGINT())
     *                  .field("b", DataTypes.STRING())
-    *                  .field("c", DataTypes.STRING()))\
+    *                  .field("c", DataTypes.STRING())) \\
     *     .with_schema(Schema()
     *                  .field("a", DataTypes.BIGINT())
     *                  .field("b", DataTypes.STRING())
-    *                  .field("c", DataTypes.STRING()))\
+    *                  .field("c", DataTypes.STRING())) \\
     *     .register_table_sink("batch_sink")
     *
     * t.select("a + 1, b, c").insert_into("batch_sink")
@@ -124,16 +124,16 @@ NOTE: Use the prebound Table Environment to implement batch or streaming Table p
     *         shutil.rmtree(sink_path)
     * s_env.set_parallelism(1)
     * t = st_env.from_elements([(1, 'hi', 'hello'), (2, 'hi', 'hello')], ['a', 'b', 'c'])
-    * st_env.connect(FileSystem().path(sink_path))\\
+    * st_env.connect(FileSystem().path(sink_path)) \\
     *     .with_format(OldCsv()
     *                  .field_delimiter(',')
     *                  .field("a", DataTypes.BIGINT())
     *                  .field("b", DataTypes.STRING())
-    *                  .field("c", DataTypes.STRING()))\\
+    *                  .field("c", DataTypes.STRING())) \\
     *     .with_schema(Schema()
     *                  .field("a", DataTypes.BIGINT())
     *                  .field("b", DataTypes.STRING())
-    *                  .field("c", DataTypes.STRING()))\\
+    *                  .field("c", DataTypes.STRING())) \\
     *     .register_table_sink("stream_sink")
     * 
     * t.select("a + 1, b, c").insert_into("stream_sink")

--- a/flink-python/pyflink/shell.py
+++ b/flink-python/pyflink/shell.py
@@ -92,7 +92,7 @@ NOTE: Use the prebound Table Environment to implement batch or streaming Table p
     *         os.remove(sink_path)
     *     else:
     *         shutil.rmtree(sink_path)
-    * bt_env.exec_env().set_parallelism(1)
+    * b_env.set_parallelism(1)
     * t = bt_env.from_elements([(1, 'hi', 'hello'), (2, 'hi', 'hello')], ['a', 'b', 'c'])
     * bt_env.connect(FileSystem().path(sink_path))\
     *     .with_format(OldCsv()
@@ -108,7 +108,7 @@ NOTE: Use the prebound Table Environment to implement batch or streaming Table p
     *
     * t.select("a + 1, b, c").insert_into("batch_sink")
     *
-    * bt_env.exec_env().execute()
+    * b_env.execute()
 
   Streaming - Use the 'st_env' variable
 
@@ -122,7 +122,7 @@ NOTE: Use the prebound Table Environment to implement batch or streaming Table p
     *         os.remove(sink_path)
     *     else:
     *         shutil.rmtree(sink_path)
-    * st_env.exec_env().set_parallelism(1)
+    * s_env.set_parallelism(1)
     * t = st_env.from_elements([(1, 'hi', 'hello'), (2, 'hi', 'hello')], ['a', 'b', 'c'])
     * st_env.connect(FileSystem().path(sink_path))\\
     *     .with_format(OldCsv()
@@ -138,10 +138,14 @@ NOTE: Use the prebound Table Environment to implement batch or streaming Table p
     * 
     * t.select("a + 1, b, c").insert_into("stream_sink")
     *
-    * st_env.exec_env().execute()
+    * s_env.execute()
 '''
 utf8_out.write(welcome_msg)
 
-bt_env = BatchTableEnvironment.create(ExecutionEnvironment.get_execution_environment())
+b_env = ExecutionEnvironment.get_execution_environment()
 
-st_env = StreamTableEnvironment.create(StreamExecutionEnvironment.get_execution_environment())
+bt_env = BatchTableEnvironment.create(b_env)
+
+s_env = StreamExecutionEnvironment.get_execution_environment()
+
+st_env = StreamTableEnvironment.create(s_env)

--- a/flink-python/pyflink/shell.py
+++ b/flink-python/pyflink/shell.py
@@ -80,7 +80,7 @@ welcome_msg = u'''
 
 NOTE: Use the prebound Table Environment to implement batch or streaming Table programs.
 
-  Batch - Use the 'bt_env' variable
+  Batch - Use 'b_env' and 'bt_env' variables
 
     *
     * import tempfile
@@ -110,7 +110,7 @@ NOTE: Use the prebound Table Environment to implement batch or streaming Table p
     *
     * b_env.execute()
 
-  Streaming - Use the 'st_env' variable
+  Streaming - Use 's_env' and 'st_env' variables
 
     *
     * import tempfile

--- a/flink-python/pyflink/table/examples/batch/word_count.py
+++ b/flink-python/pyflink/table/examples/batch/word_count.py
@@ -21,7 +21,8 @@ import shutil
 import sys
 import tempfile
 
-from pyflink.table import TableConfig, TableEnvironment
+from pyflink.dataset import ExecutionEnvironment
+from pyflink.table import BatchTableEnvironment, TableConfig
 from pyflink.table.descriptors import FileSystem, OldCsv, Schema
 from pyflink.table.types import DataTypes
 
@@ -35,8 +36,9 @@ def word_count():
               "License you may not use this file except in compliance " \
               "with the License"
 
-    t_config = TableConfig.Builder().as_batch_execution().build()
-    t_env = TableEnvironment.create(t_config)
+    t_config = TableConfig()
+    env = ExecutionEnvironment.get_execution_environment()
+    t_env = BatchTableEnvironment.create(env, t_config)
 
     # register Results table in table environment
     tmp_dir = tempfile.gettempdir()
@@ -68,7 +70,7 @@ def word_count():
          .select("word, count(1) as count") \
          .insert_into("Results")
 
-    t_env.exec_env().execute()
+    env.execute()
 
 
 if __name__ == '__main__':

--- a/flink-python/pyflink/table/table.py
+++ b/flink-python/pyflink/table/table.py
@@ -52,7 +52,7 @@ class Table(object):
         ...
         >>> t_env.register_table_sink("result", ...)
         >>> t.insert_into("result")
-        >>> t_env.exec_env().execute()
+        >>> env.execute()
 
     Operations such as :func:`~pyflink.table.Table.join`, :func:`~pyflink.table.Table.select`,
     :func:`~pyflink.table.Table.where` and :func:`~pyflink.table.Table.group_by`

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -19,11 +19,9 @@ import os
 import tempfile
 from abc import ABCMeta, abstractmethod
 
-from pyflink.dataset import ExecutionEnvironment
 from pyflink.serializers import BatchedSerializer, PickleSerializer
 from pyflink.table.catalog import Catalog
-from pyflink.datastream import StreamExecutionEnvironment
-from pyflink.table.query_config import StreamQueryConfig, BatchQueryConfig, QueryConfig
+from pyflink.table.query_config import QueryConfig
 from pyflink.table.table_config import TableConfig
 from pyflink.table.descriptors import (StreamTableDescriptor, ConnectorDescriptor,
                                        BatchTableDescriptor)
@@ -383,28 +381,11 @@ class TableEnvironment(object):
         self._j_tenv.useDatabase(database_name)
 
     @abstractmethod
-    def exec_env(self):
-        """
-        :return: The execution environment of this table environment.
-        """
-        pass
-
-    @abstractmethod
     def get_config(self):
         """
         Returns the table config to define the runtime behavior of the Table API.
 
         :return: Current :class:`TableConfig`.
-        """
-        pass
-
-    @abstractmethod
-    def query_config(self):
-        """
-        Returns a :class:`StreamQueryConfig` that holds parameters to configure the behavior of
-        streaming queries.
-
-        :return: A new :class:`StreamQueryConfig` or :class:`BatchQueryConfig`.
         """
         pass
 
@@ -548,15 +529,6 @@ class StreamTableEnvironment(TableEnvironment):
         table_config._j_table_config = self._j_tenv.getConfig()
         return table_config
 
-    def query_config(self):
-        """
-        Returns a :class:`StreamQueryConfig` that holds parameters to configure the behavior of
-        streaming queries.
-
-        :return: A new :class:`StreamQueryConfig`.
-        """
-        return StreamQueryConfig()
-
     def connect(self, connector_descriptor):
         """
         Creates a table source and/or table sink from a descriptor.
@@ -587,12 +559,6 @@ class StreamTableEnvironment(TableEnvironment):
         # type: (ConnectorDescriptor) -> StreamTableDescriptor
         return StreamTableDescriptor(
             self._j_tenv.connect(connector_descriptor._j_connector_descriptor))
-
-    def exec_env(self):
-        """
-        :return: The stream execution environment of this table environment.
-        """
-        return StreamExecutionEnvironment(self._j_tenv.execEnv())
 
     @classmethod
     def create(cls, stream_execution_environment, table_config=None):
@@ -630,15 +596,6 @@ class BatchTableEnvironment(TableEnvironment):
         table_config._j_table_config = self._j_tenv.getConfig()
         return table_config
 
-    def query_config(self):
-        """
-        Returns the :class:`BatchQueryConfig` that holds parameters to configure the behavior of
-        batch queries.
-
-        :return: A new :class:`BatchQueryConfig`.
-        """
-        return BatchQueryConfig()
-
     def connect(self, connector_descriptor):
         """
         Creates a table source and/or table sink from a descriptor.
@@ -669,12 +626,6 @@ class BatchTableEnvironment(TableEnvironment):
         # type: (ConnectorDescriptor) -> BatchTableDescriptor
         return BatchTableDescriptor(
             self._j_tenv.connect(connector_descriptor._j_connector_descriptor))
-
-    def exec_env(self):
-        """
-        :return: The stream execution environment of this table environment.
-        """
-        return ExecutionEnvironment(self._j_tenv.execEnv())
 
     @classmethod
     def create(cls, execution_environment, table_config=None):

--- a/flink-python/pyflink/table/tests/test_calc.py
+++ b/flink-python/pyflink/table/tests/test_calc.py
@@ -97,7 +97,7 @@ class StreamTableCalcTests(PyFlinkStreamTableTestCase):
               PythonOnlyPoint(3.0, 4.0))],
             schema)
         t.insert_into("Results")
-        t_env.exec_env().execute()
+        self.env.execute()
         actual = source_sink_utils.results()
 
         expected = ['1,1.0,hi,hello,1970-01-02,01:00:00,1970-01-02 00:00:00.0,'

--- a/flink-python/pyflink/table/tests/test_descriptor.py
+++ b/flink-python/pyflink/table/tests/test_descriptor.py
@@ -956,7 +956,7 @@ class AbstractTableDescriptorTests(object):
         t_env.scan("source") \
              .select("a + 1, b, c") \
              .insert_into("sink")
-        t_env.exec_env().execute()
+        self.env.execute()
 
         with open(sink_path, 'r') as f:
             lines = f.read()
@@ -998,7 +998,7 @@ class AbstractTableDescriptorTests(object):
         t_env.scan("source") \
              .select("a + 1, b, c") \
              .insert_into("sink")
-        t_env.exec_env().execute()
+        self.env.execute()
 
         with open(sink_path, 'r') as f:
             lines = f.read()

--- a/flink-python/pyflink/table/tests/test_shell_example.py
+++ b/flink-python/pyflink/table/tests/test_shell_example.py
@@ -24,7 +24,7 @@ class ShellExampleTests(PyFlinkTestCase):
     """
 
     def test_batch_case(self):
-        from pyflink.shell import bt_env, FileSystem, OldCsv, DataTypes, Schema
+        from pyflink.shell import b_env, bt_env, FileSystem, OldCsv, DataTypes, Schema
         # example begin
 
         import tempfile
@@ -36,7 +36,7 @@ class ShellExampleTests(PyFlinkTestCase):
                 os.remove(sink_path)
             else:
                 shutil.rmtree(sink_path)
-        bt_env.exec_env().set_parallelism(1)
+        b_env.set_parallelism(1)
         t = bt_env.from_elements([(1, 'hi', 'hello'), (2, 'hi', 'hello')], ['a', 'b', 'c'])
         bt_env.connect(FileSystem().path(sink_path))\
             .with_format(OldCsv()
@@ -52,7 +52,7 @@ class ShellExampleTests(PyFlinkTestCase):
 
         t.select("a + 1, b, c").insert_into("batch_sink")
 
-        bt_env.exec_env().execute()
+        b_env.execute()
 
         # verify code, do not copy these code to shell.py
         with open(sink_path, 'r') as f:
@@ -60,7 +60,7 @@ class ShellExampleTests(PyFlinkTestCase):
             self.assertEqual(lines, '2,hi,hello\n' + '3,hi,hello\n')
 
     def test_stream_case(self):
-        from pyflink.shell import st_env, FileSystem, OldCsv, DataTypes, Schema
+        from pyflink.shell import s_env, st_env, FileSystem, OldCsv, DataTypes, Schema
         # example begin
 
         import tempfile
@@ -72,7 +72,7 @@ class ShellExampleTests(PyFlinkTestCase):
                 os.remove(sink_path)
             else:
                 shutil.rmtree(sink_path)
-        st_env.exec_env().set_parallelism(1)
+        s_env.set_parallelism(1)
         t = st_env.from_elements([(1, 'hi', 'hello'), (2, 'hi', 'hello')], ['a', 'b', 'c'])
         st_env.connect(FileSystem().path(sink_path))\
             .with_format(OldCsv()
@@ -88,7 +88,7 @@ class ShellExampleTests(PyFlinkTestCase):
 
         t.select("a + 1, b, c").insert_into("stream_sink")
 
-        st_env.exec_env().execute()
+        s_env.execute()
 
         # verify code, do not copy these code to shell.py
         with open(sink_path, 'r') as f:

--- a/flink-python/tox.ini
+++ b/flink-python/tox.ini
@@ -39,4 +39,4 @@ commands =
 # up to 100 characters in length, not 79.
 ignore=E226,E241,E305,E402,E722,E731,E741,W503,W504
 max-line-length=100
-exclude=.tox/*,dev/*,lib/*,target/*,build/*,pyflink/shell.py
+exclude=.tox/*,dev/*,lib/*,target/*,build/*,dist/*,pyflink/shell.py


### PR DESCRIPTION
Mirror of apache flink#8910
## What is the purpose of the change

*This pull request aligns Python Table API with the Java Table API by removing methods exec_env() and query_config() in table_environment.py*

## Brief change log

  - *Removes methods exec_env() and query_config() in table_environment.py*


## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

