### PR TITLE
Mirror of apache flink#8909

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/harness/OverWindowHarnessTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/harness/OverWindowHarnessTest.scala
@@ -136,9 +136,9 @@ class OverWindowHarnessTest(mode: StateBackendMode) extends HarnessTestBase(mode
     expectedOutput.add(new StreamRecord(
       baserow(2L: JLong, "aaa", 9L: JLong, null, 8L: JLong, 9L: JLong)))
     expectedOutput.add(new StreamRecord(
-      baserow(2L: JLong, "aaa", 10L: JLong, null, 9L: JLong, 10L: JLong)))
+      baserow(2L: JLong, "aaa", 10L: JLong, null, 10L: JLong, 10L: JLong)))
     expectedOutput.add(new StreamRecord(
-      baserow(2L: JLong, "bbb", 40L: JLong, null, 30L: JLong, 40L: JLong)))
+      baserow(2L: JLong, "bbb", 40L: JLong, null, 40L: JLong, 40L: JLong)))
 
     assertor.assertOutputEqualsSorted("result mismatch", expectedOutput, result)
 
@@ -237,19 +237,19 @@ class OverWindowHarnessTest(mode: StateBackendMode) extends HarnessTestBase(mode
     expectedOutput.add(new StreamRecord(
       baserow(0L: JLong, "aaa", 2L: JLong, null, 1L: JLong, 2L: JLong)))
     expectedOutput.add(new StreamRecord(
-      baserow(0L: JLong, "aaa", 3L: JLong, null, 1L: JLong, 4L: JLong)))
+      baserow(0L: JLong, "aaa", 3L: JLong, null, 3L: JLong, 4L: JLong)))
     expectedOutput.add(new StreamRecord(
-      baserow(0L: JLong, "bbb", 20L: JLong, null, 10L: JLong, 20L: JLong)))
+      baserow(0L: JLong, "bbb", 20L: JLong, null, 20L: JLong, 20L: JLong)))
     expectedOutput.add(new StreamRecord(
-      baserow(0L: JLong, "aaa", 4L: JLong, null, 1L: JLong, 4L: JLong)))
+      baserow(0L: JLong, "aaa", 4L: JLong, null, 4L: JLong, 4L: JLong)))
     expectedOutput.add(new StreamRecord(
-      baserow(0L: JLong, "aaa", 5L: JLong, null, 3L: JLong, 6L: JLong)))
+      baserow(0L: JLong, "aaa", 5L: JLong, null, 5L: JLong, 6L: JLong)))
     expectedOutput.add(new StreamRecord(
-      baserow(0L: JLong, "aaa", 6L: JLong, null, 3L: JLong, 6L: JLong)))
+      baserow(0L: JLong, "aaa", 6L: JLong, null, 5L: JLong, 6L: JLong)))
     expectedOutput.add(new StreamRecord(
-      baserow(0L: JLong, "bbb", 30L: JLong, null, 20L: JLong, 30L: JLong)))
+      baserow(0L: JLong, "bbb", 30L: JLong, null, 30L: JLong, 30L: JLong)))
     expectedOutput.add(new StreamRecord(
-      baserow(0L: JLong, "aaa", 7L: JLong, null, 5L: JLong, 7L: JLong)))
+      baserow(0L: JLong, "aaa", 7L: JLong, null, 7L: JLong, 7L: JLong)))
     expectedOutput.add(new StreamRecord(
       baserow(0L: JLong, "aaa", 8L: JLong, null, 7L: JLong, 10L: JLong)))
     expectedOutput.add(new StreamRecord(
@@ -366,11 +366,11 @@ class OverWindowHarnessTest(mode: StateBackendMode) extends HarnessTestBase(mode
     expectedOutput.add(new StreamRecord(
       baserow(0L: JLong, "aaa", 8L: JLong, null, 1L: JLong, 8L: JLong)))
     expectedOutput.add(new StreamRecord(
-      baserow(0L: JLong, "aaa", 9L: JLong, null, 1L: JLong, 9L: JLong)))
+      baserow(0L: JLong, "aaa", 9L: JLong, null, 9L: JLong, 9L: JLong)))
     expectedOutput.add(new StreamRecord(
-      baserow(0L: JLong, "aaa", 10L: JLong, null, 1L: JLong, 10L: JLong)))
+      baserow(0L: JLong, "aaa", 10L: JLong, null, 9L: JLong, 10L: JLong)))
     expectedOutput.add(new StreamRecord(
-      baserow(0L: JLong, "bbb", 40L: JLong, null, 10L: JLong, 40L: JLong)))
+      baserow(0L: JLong, "bbb", 40L: JLong, null, 40L: JLong, 40L: JLong)))
 
     assertor.assertOutputEqualsSorted("result mismatch", expectedOutput, result)
     testHarness.close()
@@ -667,7 +667,7 @@ class OverWindowHarnessTest(mode: StateBackendMode) extends HarnessTestBase(mode
     expectedOutput.add(new StreamRecord(
       baserow(20002L: JLong, "ccc", 2L: JLong, 1L: JLong, 2L: JLong)))
     expectedOutput.add(new StreamRecord(
-      baserow(20011L: JLong, "ccc", 3L: JLong, 1L: JLong, 3L: JLong)))
+      baserow(20011L: JLong, "ccc", 3L: JLong, 3L: JLong, 3L: JLong)))
 
     assertor.assertOutputEqualsSorted("result mismatch", expectedOutput, result)
     testHarness.close()

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/harness/OverWindowHarnessTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/runtime/harness/OverWindowHarnessTest.scala
@@ -522,7 +522,7 @@ class OverWindowHarnessTest(mode: StateBackendMode) extends HarnessTestBase(mode
     expectedOutput.add(new StreamRecord(
       baserow(20002L: JLong, "ccc", 2L: JLong, 1L: JLong, 2L: JLong)))
     expectedOutput.add(new StreamRecord(
-      baserow(20011L: JLong, "ccc", 3L: JLong, 1L: JLong, 3L: JLong)))
+      baserow(20011L: JLong, "ccc", 3L: JLong, 3L: JLong, 3L: JLong)))
 
     assertor.assertOutputEqualsSorted("result mismatch", expectedOutput, result)
     testHarness.close()

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/KeyedProcessFunctionWithCleanupState.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/KeyedProcessFunctionWithCleanupState.java
@@ -85,7 +85,7 @@ public abstract class KeyedProcessFunctionWithCleanupState<K, IN, OUT>
 		if (stateCleaningEnabled) {
 			Long cleanupTime = cleanupTimeState.value();
 			// check that the triggered timer is the last registered processing time timer.
-			return null != cleanupTime && timestamp == cleanupTime;
+			return timestamp.equals(cleanupTime);
 		} else {
 			return false;
 		}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/AbstractRowTimeUnboundedPrecedingOver.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/AbstractRowTimeUnboundedPrecedingOver.java
@@ -154,7 +154,7 @@ public abstract class AbstractRowTimeUnboundedPrecedingOver<K> extends KeyedProc
 			KeyedProcessFunction<K, BaseRow, BaseRow>.OnTimerContext ctx,
 			Collector<BaseRow> out) throws Exception {
 		if (isProcessingTimeTimer(ctx)) {
-			if (needToCleanupState(timestamp)) {
+			if (stateCleaningEnabled) {
 
 				// we check whether there are still records which have not been processed yet
 				boolean noRecordsToProcess = !inputState.keys().iterator().hasNext();

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/AbstractRowTimeUnboundedPrecedingOver.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/AbstractRowTimeUnboundedPrecedingOver.java
@@ -157,7 +157,7 @@ public abstract class AbstractRowTimeUnboundedPrecedingOver<K> extends KeyedProc
 			if (needToCleanupState(timestamp)) {
 
 				// we check whether there are still records which have not been processed yet
-				boolean noRecordsToProcess = !inputState.contains(timestamp);
+				boolean noRecordsToProcess = !inputState.keys().iterator().hasNext();
 				if (noRecordsToProcess) {
 					// we clean the state
 					cleanupState(inputState, accState);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/ProcTimeRowsBoundedPrecedingFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/ProcTimeRowsBoundedPrecedingFunction.java
@@ -220,7 +220,7 @@ public class ProcTimeRowsBoundedPrecedingFunction<K> extends KeyedProcessFunctio
 			long timestamp,
 			KeyedProcessFunction<K, BaseRow, BaseRow>.OnTimerContext ctx,
 			Collector<BaseRow> out) throws Exception {
-		if (needToCleanupState(timestamp)) {
+		if (stateCleaningEnabled) {
 			cleanupState(inputState, accState, counterState, smallestTsState);
 			function.cleanup();
 		}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/ProcTimeUnboundedPrecedingFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/ProcTimeUnboundedPrecedingFunction.java
@@ -111,7 +111,7 @@ public class ProcTimeUnboundedPrecedingFunction<K> extends KeyedProcessFunctionW
 			long timestamp,
 			KeyedProcessFunction<K, BaseRow, BaseRow>.OnTimerContext ctx,
 			Collector<BaseRow> out) throws Exception {
-		if (needToCleanupState(timestamp)) {
+		if (stateCleaningEnabled) {
 			cleanupState(accState);
 			function.cleanup();
 		}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/RowTimeRangeBoundedPrecedingFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/RowTimeRangeBoundedPrecedingFunction.java
@@ -170,7 +170,7 @@ public class RowTimeRangeBoundedPrecedingFunction<K> extends KeyedProcessFunctio
 		registerProcessingCleanupTimer(ctx, ctx.timerService().currentProcessingTime());
 
 		if (isProcessingTimeTimer(ctx)) {
-			if (needToCleanupState(timestamp)) {
+			if (stateCleaningEnabled) {
 
 				Iterator<Long> keysIt = inputState.keys().iterator();
 				Long lastProcessedTime = lastTriggeringTsState.value();

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/RowTimeRowsBoundedPrecedingFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/over/RowTimeRowsBoundedPrecedingFunction.java
@@ -175,7 +175,7 @@ public class RowTimeRowsBoundedPrecedingFunction<K> extends KeyedProcessFunction
 			KeyedProcessFunction<K, BaseRow, BaseRow>.OnTimerContext ctx,
 			Collector<BaseRow> out) throws Exception {
 		if (isProcessingTimeTimer(ctx)) {
-			if (needToCleanupState(timestamp)) {
+			if (stateCleaningEnabled) {
 
 				Iterator<Long> keysIt = inputState.keys().iterator();
 				Long lastProcessedTime = lastTriggeringTsState.value();


### PR DESCRIPTION
Mirror of apache flink#8909
## What is the purpose of the change

Current implementation of `#needToCleanupState` in `KeyedProcessFunctionWithCleanupState` used incorrect way to judge whether the time should cleaned up. We should sue `equals` instead of `==` to compare wrapper type of Long. 

## Brief change log

  - Correct the logic of `#needToCleanupState` in `KeyedProcessFunctionWithCleanupState`.
  - Correct the check logic of  whether there are still records which have not been processed yet in `AbstractRowTimeUnboundedPrecedingOver`.


## Verifying this change

This change added tests and can be verified as follows:

  - Updated test of `OverWindowHarnessTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**

