### PR TITLE
Mirror of apache flink#8902

### DIFF
--- a/docs/dev/connectors/streamfile_sink.md
+++ b/docs/dev/connectors/streamfile_sink.md
@@ -24,7 +24,7 @@ under the License.
 -->
 
 This connector provides a Sink that writes partitioned files to filesystems
-supported by the [Flink `FileSystem` abstraction]({{ site.baseurl}}/ops/filesystems.html).
+supported by the [Flink `FileSystem` abstraction]({{ site.baseurl}}/ops/filesystems/index.html).
 
 Since in streaming the input is potentially infinite, the streaming file sink writes data
 into buckets. The bucketing behaviour is configurable but a useful default is time-based

--- a/docs/dev/connectors/streamfile_sink.zh.md
+++ b/docs/dev/connectors/streamfile_sink.zh.md
@@ -24,7 +24,7 @@ under the License.
 -->
 
 This connector provides a Sink that writes partitioned files to filesystems
-supported by the [Flink `FileSystem` abstraction]({{ site.baseurl}}/ops/filesystems.html).
+supported by the [Flink `FileSystem` abstraction]({{ site.baseurl}}/ops/filesystems/index.html).
 
 Since in streaming the input is potentially infinite, the streaming file sink writes data
 into buckets. The bucketing behaviour is configurable but a useful default is time-based


### PR DESCRIPTION
Mirror of apache flink#8902

## What is the purpose of the change

 fix wrong link in streamfile_sink

## Brief change log

 fix wrong link in streamfile_sink， from {{ site.baseurl}}/ops/filesystems.html to {{ site.baseurl}}/ops/filesystems


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: ( no)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
