### PR TITLE
Mirror of apache flink#9148

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ flink-runtime-web/web-dashboard/web/
 flink-python/dist/
 flink-python/build/
 flink-python/pyflink.egg-info/
+flink-python/apache_flink.egg-info/
 flink-python/docs/_build
 flink-python/.tox/
 flink-python/dev/download

--- a/flink-container/docker/Dockerfile
+++ b/flink-container/docker/Dockerfile
@@ -52,7 +52,7 @@ ADD $job_artifacts/* $FLINK_JOB_ARTIFACTS_DIR/
 RUN set -x && \
   ln -s $FLINK_INSTALL_PATH/flink-[0-9]* $FLINK_HOME && \
   for jar in $FLINK_JOB_ARTIFACTS_DIR/*.jar; do [ -f "$jar" ] || continue; ln -s $jar $FLINK_LIB_DIR; done && \
-  if [ -n "$python_version" ]; then ln -s $FLINK_OPT_DIR/flink-python-*-java-binding.jar $FLINK_LIB_DIR; fi && \
+  if [ -n "$python_version" ]; then ln -s $FLINK_OPT_DIR/flink-python*.jar $FLINK_LIB_DIR; fi && \
   if [ -f ${FLINK_INSTALL_PATH}/flink-shaded-hadoop* ]; then ln -s ${FLINK_INSTALL_PATH}/flink-shaded-hadoop* $FLINK_LIB_DIR; fi && \
   addgroup -S flink && adduser -D -S -H -G flink -h $FLINK_HOME flink && \
   chown -R flink:flink ${FLINK_INSTALL_PATH}/flink-* && \

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -351,7 +351,6 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-python_${scala.binary.version}</artifactId>
-			<classifier>java-binding</classifier>
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>

--- a/flink-dist/src/main/assemblies/opt.xml
+++ b/flink-dist/src/main/assemblies/opt.xml
@@ -163,9 +163,9 @@
 
 		<!-- Python -->
 		<file>
-			<source>../flink-python/target/flink-python_${scala.binary.version}-${project.version}-java-binding.jar</source>
+			<source>../flink-python/target/flink-python_${scala.binary.version}-${project.version}.jar</source>
 			<outputDirectory>opt</outputDirectory>
-			<destName>flink-python-${project.version}-java-binding.jar</destName>
+			<destName>flink-python_${scala.binary.version}-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
 		</file>
 	</files>

--- a/flink-dist/src/main/flink-bin/bin/pyflink-gateway-server.sh
+++ b/flink-dist/src/main/flink-bin/bin/pyflink-gateway-server.sh
@@ -51,7 +51,7 @@ log=$FLINK_LOG_DIR/flink-$FLINK_IDENT_STRING-python-$HOSTNAME.log
 log_setting=(-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4j-cli.properties -Dlogback.configurationFile=file:"$FLINK_CONF_DIR"/logback.xml)
 
 TABLE_JAR_PATH=`echo "$FLINK_HOME"/opt/flink-table*.jar`
-PYTHON_JAR_PATH=`echo "$FLINK_HOME"/opt/flink-python*java-binding.jar`
+PYTHON_JAR_PATH=`echo "$FLINK_HOME"/opt/flink-python*.jar`
 
 FLINK_TEST_CLASSPATH=""
 if [[ -n "$FLINK_TESTING" ]]; then

--- a/flink-dist/src/main/flink-bin/bin/pyflink-shell.sh
+++ b/flink-dist/src/main/flink-bin/bin/pyflink-shell.sh
@@ -25,7 +25,7 @@ _FLINK_HOME_DETERMINED=1
 . "$FLINK_HOME"/bin/config.sh
 
 FLINK_CLASSPATH=`constructFlinkClassPath`
-PYTHON_JAR_PATH=`echo "$FLINK_OPT_DIR"/flink-python*java-binding.jar`
+PYTHON_JAR_PATH=`echo "$FLINK_OPT_DIR"/flink-python*.jar`
 
 
 PYFLINK_PYTHON="${PYFLINK_PYTHON:-"python"}"

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -135,17 +135,18 @@ under the License.
 				<executions>
 					<execution>
 						<id>shade-flink</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
 						<configuration>
-							<shadeTestJar>false</shadeTestJar>
-							<shadedArtifactAttached>true</shadedArtifactAttached>
-							<shadedClassifierName>java-binding</shadedClassifierName>
 							<artifactSet>
 								<includes combine.children="append">
 									<include>net.razorvine:*</include>
 									<include>net.sf.py4j:*</include>
 								</includes>
 							</artifactSet>
-							<relocations>
+							<relocations combine.children="append">
 								<relocation>
 									<pattern>py4j</pattern>
 									<shadedPattern>org.apache.flink.api.python.shaded.py4j</shadedPattern>

--- a/tools/travis_controller.sh
+++ b/tools/travis_controller.sh
@@ -146,7 +146,7 @@ if [ $STAGE == "$STAGE_COMPILE" ]; then
             ! -path "$CACHE_FLINK_DIR/flink-streaming-java/target/flink-streaming-java*tests.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/lib/flink-dist*.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/opt/flink-table*.jar" \
-            ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/opt/flink-python*java-binding.jar" \
+            ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/opt/flink-python*.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-connectors/flink-connector-elasticsearch-base/target/flink-*.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-connectors/flink-connector-kafka-base/target/flink-*.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-table/flink-table-planner/target/flink-table-planner*tests.jar" | xargs rm -rf


### PR DESCRIPTION
Mirror of apache flink#9148
## What is the purpose of the change

*This pull request removes the classifier of java-binding from the flink-python jar*

## Brief change log

  - *Removes the java-binding classifier*

## Verifying this change

This change is a code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

