### PR TITLE
Mirror of apache flink#9147

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -93,7 +93,8 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -125,7 +126,7 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 	private final Time rpcTimeout;
 
 	@GuardedBy("lock")
-	private final List<TaskExecutor> taskManagers;
+	private final Map<ResourceID, TaskExecutor> taskManagers;
 
 	private final TerminatingFatalErrorHandlerFactory taskManagerTerminatingFatalErrorHandlerFactory = new TerminatingFatalErrorHandlerFactory();
 
@@ -198,7 +199,7 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 		this.terminationFuture = CompletableFuture.completedFuture(null);
 		running = false;
 
-		this.taskManagers = new ArrayList<>(miniClusterConfiguration.getNumTaskManagers());
+		this.taskManagers = new HashMap<>(miniClusterConfiguration.getNumTaskManagers());
 	}
 
 	public CompletableFuture<URI> getRestAddress() {
@@ -228,6 +229,18 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 		synchronized (lock) {
 			return Collections.unmodifiableCollection(dispatcherResourceManagerComponents);
 		}
+	}
+
+	@VisibleForTesting
+	@Nonnull
+	protected Map<ResourceID, TaskExecutor> getTaskManagers() {
+		return taskManagers;
+	}
+
+	@VisibleForTesting
+	@Nonnull
+	protected Object getLock() {
+		return lock;
 	}
 
 	// ------------------------------------------------------------------------
@@ -489,19 +502,20 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 		synchronized (lock) {
 			final Configuration configuration = miniClusterConfiguration.getConfiguration();
 
+			final ResourceID resourceID = new ResourceID(UUID.randomUUID().toString());
 			final TaskExecutor taskExecutor = TaskManagerRunner.startTaskManager(
 				configuration,
-				new ResourceID(UUID.randomUUID().toString()),
+				resourceID,
 				taskManagerRpcServiceFactory.createRpcService(),
 				haServices,
 				heartbeatServices,
 				metricRegistry,
 				blobCacheService,
 				useLocalCommunication(),
-				taskManagerTerminatingFatalErrorHandlerFactory.create(taskManagers.size()));
+				taskManagerTerminatingFatalErrorHandlerFactory.create(resourceID));
 
+			taskManagers.put(resourceID, taskExecutor);
 			taskExecutor.start();
-			taskManagers.add(taskExecutor);
 		}
 	}
 
@@ -513,20 +527,12 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 	@GuardedBy("lock")
 	private Collection<? extends CompletableFuture<Void>> terminateTaskExecutors() {
 		final Collection<CompletableFuture<Void>> terminationFutures = new ArrayList<>(taskManagers.size());
-		for (int i = 0; i < taskManagers.size(); i++) {
-			terminationFutures.add(terminateTaskExecutor(i));
+		for (TaskExecutor taskExecutor : taskManagers.values()) {
+			terminationFutures.add(taskExecutor.closeAsync());
 		}
+		taskManagers.clear();
 
 		return terminationFutures;
-	}
-
-	@VisibleForTesting
-	@Nonnull
-	protected CompletableFuture<Void> terminateTaskExecutor(int index) {
-		synchronized (lock) {
-			final TaskExecutor taskExecutor = taskManagers.get(index);
-			return taskExecutor.closeAsync();
-		}
 	}
 
 	// ------------------------------------------------------------------------
@@ -744,6 +750,7 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 		for (DispatcherResourceManagerComponent<?> dispatcherResourceManagerComponent : dispatcherResourceManagerComponents) {
 			terminationFutures.add(dispatcherResourceManagerComponent.closeAsync());
 		}
+		dispatcherResourceManagerComponents.clear();
 
 		final FutureUtils.ConjunctFuture<Void> dispatcherTerminationFuture = FutureUtils.completeAll(terminationFutures);
 
@@ -921,20 +928,24 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 
 	private class TerminatingFatalErrorHandler implements FatalErrorHandler {
 
-		private final int index;
+		private final ResourceID resourceID;
 
-		private TerminatingFatalErrorHandler(int index) {
-			this.index = index;
+		private TerminatingFatalErrorHandler(ResourceID resourceID) {
+			this.resourceID = resourceID;
 		}
 
 		@Override
 		public void onFatalError(Throwable exception) {
 			// first check if we are still running
 			if (running) {
-				LOG.error("TaskManager #{} failed.", index, exception);
+				LOG.error("TaskManager {} failed.", resourceID, exception);
 
 				synchronized (lock) {
-					taskManagers.get(index).closeAsync();
+					final TaskExecutor taskExecutor = taskManagers.remove(resourceID);
+					if (taskExecutor != null) {
+						taskExecutor.closeAsync();
+					}
+					// else means task execution has already been shut down
 				}
 			}
 		}
@@ -953,14 +964,14 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 
 		/**
 		 * Create a new {@link TerminatingFatalErrorHandler} for the {@link TaskExecutor} with
-		 * the given index.
+		 * the given resource id.
 		 *
-		 * @param index into the {@link #taskManagers} collection to identify the correct {@link TaskExecutor}.
+		 * @param resourceID the unique id to identify the {@link TaskExecutor}.
 		 * @return {@link TerminatingFatalErrorHandler} for the given index
 		 */
 		@GuardedBy("lock")
-		private TerminatingFatalErrorHandler create(int index) {
-			return new TerminatingFatalErrorHandler(index);
+		private TerminatingFatalErrorHandler create(ResourceID resourceID) {
+			return new TerminatingFatalErrorHandler(resourceID);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
@@ -95,7 +95,7 @@ public class TaskExecutorITCase extends TestLogger {
 		final CompletableFuture<JobResult> jobResultFuture = submitJobAndWaitUntilRunning(jobGraph);
 
 		// kill one TaskExecutor which should fail the job execution
-		miniCluster.terminateTaskExecutor(0);
+		miniCluster.terminateTaskExecutorRandomly();
 
 		final JobResult jobResult = jobResultFuture.get();
 
@@ -122,7 +122,7 @@ public class TaskExecutorITCase extends TestLogger {
 		// start an additional TaskExecutor
 		miniCluster.startTaskExecutor();
 
-		miniCluster.terminateTaskExecutor(0).get(); // this should fail the job
+		miniCluster.terminateTaskExecutorRandomly().get(); // this should fail the job
 
 		BlockingOperator.unblock();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
@@ -47,6 +47,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
@@ -122,7 +123,12 @@ public class TaskExecutorITCase extends TestLogger {
 		// start an additional TaskExecutor
 		miniCluster.startTaskExecutor();
 
-		miniCluster.terminateTaskExecutorRandomly().get(); // this should fail the job
+		try {
+			miniCluster.terminateTaskExecutorRandomly().get(); // this should fail the job
+		} catch (ExecutionException e) {
+			// we need this catching till FLINK-11630 has been resolved
+			log.info("Terminate task executor randomly caused an exception, just ignore it", e);
+		}
 
 		BlockingOperator.unblock();
 


### PR DESCRIPTION
Mirror of apache flink#9147
## What is the purpose of the change

* Harden `TaskExecutorITCase#testJobReExecutionAfterTaskExecutorTermination`
* Harden `TastExecutorITCase#testJobRecoveryWithFailingTaskExecutor`

## Brief change log

* Improve `MiniCluster` by clearing terminated components in case of an reusing
* Use a map to keep task managers in `MiniCluster` instead of a list since the task managers might be mutable in some test cases
* `MiniCluster` exposes more components to `TestingMiniCluster` for enriching testing
* Replace `terminateTaskExecutor(index)` with `terminateTaskExecutorRandomly()` in `TestingMiniCluster`
* Add a try-catch for `TastExecutorITCase#testJobRecoveryWithFailingTaskExecutor` to avoid unexpected exception caused by terminating task executor

## Verifying this change

* This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

