### PR TITLE
Mirror of apache flink#9141

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/calcite/sql/fun/SqlWindowAvgAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/calcite/sql/fun/SqlWindowAvgAggFunction.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.fun;
+
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.apache.calcite.util.Optionality;
+
+/**
+ * <code>Avg</code> is an aggregator which returns the average of the values which go into it.
+ *
+ * <p>This class is similar to {@link SqlAvgAggFunction}. The difference is
+ * {@link SqlWindowAvgAggFunction} contains a self defined {@link SqlReturnTypeInference}, e.g,
+ * WINDOW_AVG_AGG_FUNCTION, which will not change return type to nullable even if the call occurs
+ * within a "GROUP BY ()" for window aggregates.
+ *
+ * <p>See more details in {@link ReturnTypes#AVG_AGG_FUNCTION}.
+ */
+public class SqlWindowAvgAggFunction extends SqlAggFunction {
+
+	//~ Constructors -----------------------------------------------------------
+
+	/**
+	 * Creates a SqlWindowAvgAggFunction.
+	 */
+	public SqlWindowAvgAggFunction() {
+		super("WINDOW_AVG",
+			null,
+			SqlKind.AVG,
+			WINDOW_AVG_AGG_FUNCTION,
+			null,
+			OperandTypes.NUMERIC,
+			SqlFunctionCategory.NUMERIC,
+			false,
+			false,
+			Optionality.FORBIDDEN);
+	}
+
+	//~ Methods ----------------------------------------------------------------
+
+	/**
+	 * Returns the specific function, e.g. AVG.
+	 *
+	 * @return Subtype
+	 */
+	@Deprecated // to be removed before 2.0
+	public Subtype getSubtype() {
+		return Subtype.valueOf(kind.name());
+	}
+
+	/** Sub-type of aggregate function. */
+	@Deprecated // to be removed before 2.0
+	public enum Subtype {
+		AVG,
+		STDDEV_POP,
+		STDDEV_SAMP,
+		VAR_POP,
+		VAR_SAMP
+	}
+
+	private static final SqlReturnTypeInference WINDOW_AVG_AGG_FUNCTION = opBinding -> {
+		RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
+		return typeFactory.getTypeSystem().deriveAvgAggType(typeFactory,
+			opBinding.getOperandType(0));
+	};
+}
+
+// End SqlWindowAvgAggFunction.java

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/calcite/sql/fun/SqlWindowSumAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/calcite/sql/fun/SqlWindowSumAggFunction.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.sql.fun;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlSplittableAggFunction;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.apache.calcite.util.Optionality;
+
+import java.util.List;
+
+/**
+ * <code>Sum</code> is an aggregator which returns the sum of the values which go into it.
+ *
+ * <p>Similar to {@link SqlSumAggFunction}. The difference is {@link SqlWindowSumAggFunction}
+ * contains a self defined {@link SqlReturnTypeInference}, e.g, WINDOW_AGG_SUM, which will not
+ * change return type to nullable even if the call occurs within a "GROUP BY ()" for window
+ * aggregates.
+ *
+ * <p>See more details in {@link ReturnTypes#AGG_SUM}.
+ */
+public class SqlWindowSumAggFunction extends SqlAggFunction {
+
+	//~ Instance fields --------------------------------------------------------
+
+	@Deprecated // to be removed before 2.0
+	private final RelDataType type;
+
+	//~ Constructors -----------------------------------------------------------
+
+	public SqlWindowSumAggFunction(RelDataType type) {
+		super(
+			"WINDOW_SUM",
+			null,
+			SqlKind.SUM,
+			WINDOW_AGG_SUM,
+			null,
+			OperandTypes.NUMERIC,
+			SqlFunctionCategory.NUMERIC,
+			false,
+			false,
+			Optionality.FORBIDDEN);
+		this.type = type;
+	}
+
+	//~ Methods ----------------------------------------------------------------
+
+	@SuppressWarnings("deprecation")
+	public List<RelDataType> getParameterTypes(RelDataTypeFactory typeFactory) {
+		return ImmutableList.of(type);
+	}
+
+	@Deprecated // to be removed before 2.0
+	public RelDataType getType() {
+		return type;
+	}
+
+	@SuppressWarnings("deprecation")
+	public RelDataType getReturnType(RelDataTypeFactory typeFactory) {
+		return type;
+	}
+
+	@Override public <T> T unwrap(Class<T> clazz) {
+		if (clazz == SqlSplittableAggFunction.class) {
+			return clazz.cast(SqlSplittableAggFunction.SumSplitter.INSTANCE);
+		}
+		return super.unwrap(clazz);
+	}
+
+	private static final SqlReturnTypeInference WINDOW_AGG_SUM = opBinding -> {
+		RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
+		return typeFactory.getTypeSystem()
+			.deriveSumType(typeFactory, opBinding.getOperandType(0));
+	};
+}
+
+// End SqlWindowSumAggFunction.java

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/plan/rules/logical/ReplaceWindowAggregateFunctionRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/plan/rules/logical/ReplaceWindowAggregateFunctionRule.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.logical;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptRuleOperand;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlAvgAggFunction;
+import org.apache.calcite.sql.fun.SqlSumAggFunction;
+import org.apache.calcite.sql.fun.SqlWindowAvgAggFunction;
+import org.apache.calcite.sql.fun.SqlWindowSumAggFunction;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Replace a {@link SqlSumAggFunction} to a {@link SqlWindowSumAggFunction} or replace a
+ * {@link SqlAvgAggFunction} to a {@link SqlWindowAvgAggFunction} when it is a group window
+ * aggregate.
+ *
+ * <p>This rule should be called before the window rules to replace the corresponding
+ * {@link SqlAggFunction}.
+ */
+public class ReplaceWindowAggregateFunctionRule extends RelOptRule {
+
+	public static final ReplaceWindowAggregateFunctionRule INSTANCE =
+		new ReplaceWindowAggregateFunctionRule(
+			operand(LogicalAggregate.class,
+				operand(LogicalProject.class, any())),
+			"ReplaceWindowAggregateFunctionRule");
+
+	public ReplaceWindowAggregateFunctionRule(RelOptRuleOperand operand, String description) {
+		super(operand, description);
+	}
+
+	@Override
+	public boolean matches(RelOptRuleCall call) {
+		LogicalAggregate agg = call.rel(0);
+		LogicalProject project = call.rel(1);
+		return isWindowAggregate(agg, project);
+	}
+
+	@Override
+	public void onMatch(RelOptRuleCall call) {
+		LogicalAggregate agg = call.rel(0);
+
+		// Replace SqlReturnTypeInference for sum and avg.
+		List<AggregateCall> newAggCalls = replaceAggCalls(agg.getAggCallList());
+		LogicalAggregate newAgg = LogicalAggregate.create(
+			agg.getInput(),
+			agg.getGroupSet(),
+			agg.getGroupSets(),
+			newAggCalls);
+
+		call.transformTo(newAgg);
+	}
+
+	/**
+	 * Replace a {@link SqlSumAggFunction} to a {@link SqlWindowSumAggFunction} or replace a
+	 * {@link SqlAvgAggFunction} to a {@link SqlWindowAvgAggFunction}.
+	 */
+	private List<AggregateCall> replaceAggCalls(List<AggregateCall> origAggCalls) {
+		List<AggregateCall> newAggCalls = new LinkedList<>();
+		for (int i = 0; i < origAggCalls.size(); ++i) {
+			AggregateCall aggregateCall = origAggCalls.get(i);
+			// replace
+			SqlAggFunction finalSqlAggFunction = aggregateCall.getAggregation();
+			if (SqlKind.SUM == aggregateCall.getAggregation().kind) {
+				finalSqlAggFunction = new SqlWindowSumAggFunction(aggregateCall.getType());
+			} else if (SqlKind.AVG == aggregateCall.getAggregation().kind) {
+				finalSqlAggFunction = new SqlWindowAvgAggFunction();
+			}
+			AggregateCall newAggCall = AggregateCall.create(
+				finalSqlAggFunction,
+				aggregateCall.isDistinct(),
+				aggregateCall.isApproximate(),
+				aggregateCall.ignoreNulls(),
+				aggregateCall.getArgList(),
+				aggregateCall.filterArg,
+				aggregateCall.collation,
+				aggregateCall.type,
+				aggregateCall.name);
+			newAggCalls.add(newAggCall);
+		}
+		return newAggCalls;
+	}
+
+	private boolean isWindowAggregate(LogicalAggregate agg, LogicalProject project) {
+		List<Integer> groupKeys = agg.getGroupSet().toList();
+
+		List<RexNode> groupExpr = new LinkedList<>();
+		for (int i = 0; i < project.getProjects().size(); ++i) {
+			if (groupKeys.contains(i)) {
+				groupExpr.add(project.getProjects().get(i));
+			}
+		}
+
+		List<RexCall> windowExprs = groupExpr.stream().filter(p -> p instanceof RexCall)
+			.map(p -> (RexCall) p)
+			.filter(p -> {
+				if ((SqlKind.TUMBLE == p.getOperator().getKind()) ||
+					(SqlKind.SESSION == p.getOperator().getKind())) {
+					return 2 == p.getOperands().size();
+				} else if (SqlKind.HOP == p.getOperator().getKind()) {
+					return 3 == p.getOperands().size();
+				} else {
+					return false;
+				}
+			}).collect(Collectors.toList());
+
+		return 1 == windowExprs.size();
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/FlinkBatchRuleSets.scala
@@ -109,6 +109,7 @@ object FlinkBatchRuleSets {
       REDUCE_EXPRESSION_RULES.asScala ++
       List(
         // Transform window to LogicalWindowAggregate
+        ReplaceWindowAggregateFunctionRule.INSTANCE,
         BatchLogicalWindowAggregateRule.INSTANCE,
         WindowPropertiesRules.WINDOW_PROPERTIES_RULE,
         WindowPropertiesRules.WINDOW_PROPERTIES_HAVING_RULE,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/FlinkStreamRuleSets.scala
@@ -109,6 +109,7 @@ object FlinkStreamRuleSets {
       REWRITE_COALESCE_RULES.asScala ++
       REDUCE_EXPRESSION_RULES.asScala ++
       List(
+        ReplaceWindowAggregateFunctionRule.INSTANCE,
         StreamLogicalWindowAggregateRule.INSTANCE,
         // slices a project into sections which contain window agg functions
         // and sections which do not.

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/AggFunctionFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/AggFunctionFactory.scala
@@ -69,9 +69,11 @@ class AggFunctionFactory(
       .toArray
 
     call.getAggregation match {
-      case a: SqlAvgAggFunction if a.kind == SqlKind.AVG => createAvgAggFunction(argTypes)
+      case _: SqlWindowAvgAggFunction | _: SqlAvgAggFunction
+        if call.getAggregation.kind == SqlKind.AVG => createAvgAggFunction(argTypes)
 
-      case _: SqlSumAggFunction => createSumAggFunction(argTypes, index)
+      case _: SqlSumAggFunction | _: SqlWindowSumAggFunction =>
+        createSumAggFunction(argTypes, index)
 
       case _: SqlSumEmptyIsZeroAggFunction => createSum0AggFunction(argTypes)
 

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/agg/WindowAggregateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/agg/WindowAggregateTest.xml
@@ -1409,4 +1409,111 @@ Calc(select=[w$end AS EXPR$0])
 ]]>
     </Resource>
   </TestCase>
+    <TestCase name="testReturnTypeInferenceForWindowAgg[aggStrategy=AUTO]">
+        <Resource name="sql">
+            <![CDATA[
+SELECT
+  SUM(correct) AS s,
+  AVG(correct) AS a,
+  TUMBLE_START(b, INTERVAL '15' MINUTE) AS wStart
+FROM (
+  SELECT CASE a
+      WHEN 1 THEN 1
+      ELSE 99
+    END AS correct, b
+  FROM MyTable
+)
+GROUP BY TUMBLE(b, INTERVAL '15' MINUTE)
+      ]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(s=[$1], a=[$2], wStart=[TUMBLE_START($0)])
++- LogicalAggregate(group=[{0}], s=[SUM($1)], a=[AVG($1)])
+   +- LogicalProject($f0=[TUMBLE($1, 900000:INTERVAL MINUTE)], correct=[CASE(=($0, 1), 1, 99)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+Calc(select=[s, CAST(/(CAST(CASE(=($f1, 0), null:INTEGER, s)), $f1)) AS a, w$start AS wStart])
++- HashWindowAggregate(window=[TumblingGroupWindow], properties=[w$start, w$end, w$rowtime], select=[Final_$SUM0(sum$0) AS s, Final_COUNT(count1$1) AS $f1])
+   +- Exchange(distribution=[single])
+      +- LocalHashWindowAggregate(window=[TumblingGroupWindow], properties=[w$start, w$end, w$rowtime], select=[Partial_$SUM0($f1) AS sum$0, Partial_COUNT(*) AS count1$1])
+         +- Calc(select=[b, CASE(=(a, 1), 1, 99) AS $f1])
+            +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testReturnTypeInferenceForWindowAgg[aggStrategy=ONE_PHASE]">
+        <Resource name="sql">
+            <![CDATA[
+SELECT
+  SUM(correct) AS s,
+  AVG(correct) AS a,
+  TUMBLE_START(b, INTERVAL '15' MINUTE) AS wStart
+FROM (
+  SELECT CASE a
+      WHEN 1 THEN 1
+      ELSE 99
+    END AS correct, b
+  FROM MyTable
+)
+GROUP BY TUMBLE(b, INTERVAL '15' MINUTE)
+      ]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(s=[$1], a=[$2], wStart=[TUMBLE_START($0)])
++- LogicalAggregate(group=[{0}], s=[SUM($1)], a=[AVG($1)])
+   +- LogicalProject($f0=[TUMBLE($1, 900000:INTERVAL MINUTE)], correct=[CASE(=($0, 1), 1, 99)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+Calc(select=[s, CAST(/(CAST(CASE(=($f1, 0), null:INTEGER, s)), $f1)) AS a, w$start AS wStart])
++- HashWindowAggregate(window=[TumblingGroupWindow], properties=[w$start, w$end, w$rowtime], select=[$SUM0($f1) AS s, COUNT(*) AS $f1])
+   +- Exchange(distribution=[single])
+      +- Calc(select=[b, CASE(=(a, 1), 1, 99) AS $f1])
+         +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="testReturnTypeInferenceForWindowAgg[aggStrategy=TWO_PHASE]">
+        <Resource name="sql">
+            <![CDATA[
+SELECT
+  SUM(correct) AS s,
+  AVG(correct) AS a,
+  TUMBLE_START(b, INTERVAL '15' MINUTE) AS wStart
+FROM (
+  SELECT CASE a
+      WHEN 1 THEN 1
+      ELSE 99
+    END AS correct, b
+  FROM MyTable
+)
+GROUP BY TUMBLE(b, INTERVAL '15' MINUTE)
+      ]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(s=[$1], a=[$2], wStart=[TUMBLE_START($0)])
++- LogicalAggregate(group=[{0}], s=[SUM($1)], a=[AVG($1)])
+   +- LogicalProject($f0=[TUMBLE($1, 900000:INTERVAL MINUTE)], correct=[CASE(=($0, 1), 1, 99)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+Calc(select=[s, CAST(/(CAST(CASE(=($f1, 0), null:INTEGER, s)), $f1)) AS a, w$start AS wStart])
++- HashWindowAggregate(window=[TumblingGroupWindow], properties=[w$start, w$end, w$rowtime], select=[Final_$SUM0(sum$0) AS s, Final_COUNT(count1$1) AS $f1])
+   +- Exchange(distribution=[single])
+      +- LocalHashWindowAggregate(window=[TumblingGroupWindow], properties=[w$start, w$end, w$rowtime], select=[Partial_$SUM0($f1) AS sum$0, Partial_COUNT(*) AS count1$1])
+         +- Calc(select=[b, CASE(=(a, 1), 1, 99) AS $f1])
+            +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+        </Resource>
+    </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/rules/logical/AggregateReduceGroupingRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/rules/logical/AggregateReduceGroupingRuleTest.xml
@@ -349,7 +349,7 @@ LogicalProject(a4=[$0], c4=[$1], EXPR$2=[$3], EXPR$3=[$4])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-FlinkLogicalWindowAggregate(group=[{0}], c4=[AUXILIARY_GROUP($2)], EXPR$2=[COUNT($1)], EXPR$3=[AVG($1)], window=[TumblingGroupWindow], properties=[])
+FlinkLogicalWindowAggregate(group=[{0}], c4=[AUXILIARY_GROUP($2)], EXPR$2=[COUNT($1)], EXPR$3=[WINDOW_AVG($1)], window=[TumblingGroupWindow], properties=[])
 +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, T4, source: [TestTableSource(a4, b4, c4, d4)]]], fields=[a4, b4, c4, d4])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/stream/sql/agg/WindowAggregateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/stream/sql/agg/WindowAggregateTest.xml
@@ -467,4 +467,39 @@ Calc(select=[EXPR$0, wAvg, w$start AS EXPR$2, w$end AS EXPR$3])
 ]]>
     </Resource>
   </TestCase>
+    <TestCase name="testReturnTypeInferenceForWindowAgg">
+        <Resource name="sql">
+            <![CDATA[
+SELECT
+  SUM(correct) AS s,
+  AVG(correct) AS a,
+  TUMBLE_START(rowtime, INTERVAL '15' MINUTE) AS wStart
+FROM (
+  SELECT CASE a
+      WHEN 1 THEN 1
+      ELSE 99
+    END AS correct, rowtime
+  FROM MyTable
+)
+GROUP BY TUMBLE(rowtime, INTERVAL '15' MINUTE)
+      ]]>
+        </Resource>
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(s=[$1], a=[$2], wStart=[TUMBLE_START($0)])
++- LogicalAggregate(group=[{0}], s=[SUM($1)], a=[AVG($1)])
+   +- LogicalProject($f0=[TUMBLE($4, 900000:INTERVAL MINUTE)], correct=[CASE(=($0, 1), 1, 99)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+Calc(select=[s, CAST(/(CAST(CASE(=($f1, 0), null:INTEGER, s)), $f1)) AS a, w$start AS wStart])
++- GroupWindowAggregate(window=[TumblingGroupWindow], properties=[w$start, w$end, w$rowtime, w$proctime], select=[$SUM0($f1) AS s, COUNT(*) AS $f1, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])
+   +- Exchange(distribution=[single])
+      +- Calc(select=[rowtime, CASE(=(a, 1), 1, 99) AS $f1])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+        </Resource>
+    </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/agg/WindowAggregateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/agg/WindowAggregateTest.scala
@@ -299,6 +299,28 @@ class WindowAggregateTest(aggStrategy: AggregatePhaseStrategy) extends TableTest
       """.stripMargin
     util.verifyPlan(sql)
   }
+
+  @Test
+  def testReturnTypeInferenceForWindowAgg() = {
+
+    val sql =
+      """
+        |SELECT
+        |  SUM(correct) AS s,
+        |  AVG(correct) AS a,
+        |  TUMBLE_START(b, INTERVAL '15' MINUTE) AS wStart
+        |FROM (
+        |  SELECT CASE a
+        |      WHEN 1 THEN 1
+        |      ELSE 99
+        |    END AS correct, b
+        |  FROM MyTable
+        |)
+        |GROUP BY TUMBLE(b, INTERVAL '15' MINUTE)
+      """.stripMargin
+
+    util.verifyPlan(sql)
+  }
 }
 
 object WindowAggregateTest {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stream/sql/agg/WindowAggregateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stream/sql/agg/WindowAggregateTest.scala
@@ -295,4 +295,25 @@ class WindowAggregateTest extends TableTestBase {
     util.verifyPlan(sql)
   }
 
+  @Test
+  def testReturnTypeInferenceForWindowAgg() = {
+
+    val sql =
+      """
+        |SELECT
+        |  SUM(correct) AS s,
+        |  AVG(correct) AS a,
+        |  TUMBLE_START(rowtime, INTERVAL '15' MINUTE) AS wStart
+        |FROM (
+        |  SELECT CASE a
+        |      WHEN 1 THEN 1
+        |      ELSE 99
+        |    END AS correct, rowtime
+        |  FROM MyTable
+        |)
+        |GROUP BY TUMBLE(rowtime, INTERVAL '15' MINUTE)
+      """.stripMargin
+
+    util.verifyPlan(sql)
+  }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/fun/SqlWindowAvgAggFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/fun/SqlWindowAvgAggFunction.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.fun;
+
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.apache.calcite.util.Optionality;
+
+/**
+ * <code>Avg</code> is an aggregator which returns the average of the values which go into it.
+ *
+ * <p>This class is similar to {@link SqlAvgAggFunction}. The difference is
+ * {@link SqlWindowAvgAggFunction} contains a self defined {@link SqlReturnTypeInference}, e.g,
+ * WINDOW_AVG_AGG_FUNCTION, which will not change return type to nullable even if the call occurs
+ * within a "GROUP BY ()" for window aggregates.
+ *
+ * <p>See more details in {@link ReturnTypes#AVG_AGG_FUNCTION}.
+ */
+public class SqlWindowAvgAggFunction extends SqlAggFunction {
+
+	//~ Constructors -----------------------------------------------------------
+
+	/**
+	 * Creates a SqlWindowAvgAggFunction.
+	 */
+	public SqlWindowAvgAggFunction() {
+		super("WINDOW_AVG",
+			null,
+			SqlKind.AVG,
+			WINDOW_AVG_AGG_FUNCTION,
+			null,
+			OperandTypes.NUMERIC,
+			SqlFunctionCategory.NUMERIC,
+			false,
+			false,
+			Optionality.FORBIDDEN);
+	}
+
+	//~ Methods ----------------------------------------------------------------
+
+	/**
+	 * Returns the specific function, e.g. AVG.
+	 *
+	 * @return Subtype
+	 */
+	@Deprecated // to be removed before 2.0
+	public Subtype getSubtype() {
+		return Subtype.valueOf(kind.name());
+	}
+
+	/** Sub-type of aggregate function. */
+	@Deprecated // to be removed before 2.0
+	public enum Subtype {
+		AVG,
+		STDDEV_POP,
+		STDDEV_SAMP,
+		VAR_POP,
+		VAR_SAMP
+	}
+
+	private static final SqlReturnTypeInference WINDOW_AVG_AGG_FUNCTION = opBinding -> {
+		RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
+		return typeFactory.getTypeSystem().deriveAvgAggType(typeFactory,
+			opBinding.getOperandType(0));
+	};
+}
+
+// End SqlWindowAvgAggFunction.java

--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/fun/SqlWindowSumAggFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/fun/SqlWindowSumAggFunction.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.sql.fun;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlSplittableAggFunction;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.apache.calcite.util.Optionality;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+/**
+ * <code>Sum</code> is an aggregator which returns the sum of the values which go into it.
+ *
+ * <p>Similar to {@link SqlSumAggFunction}. The difference is {@link SqlWindowSumAggFunction}
+ * contains a self defined {@link SqlReturnTypeInference}, e.g, WINDOW_AGG_SUM, which will not
+ * change return type to nullable even if the call occurs within a "GROUP BY ()" for window
+ * aggregates.
+ *
+ * <p>See more details in {@link ReturnTypes#AGG_SUM}.
+ */
+public class SqlWindowSumAggFunction extends SqlAggFunction {
+
+	//~ Instance fields --------------------------------------------------------
+
+	@Deprecated // to be removed before 2.0
+	private final RelDataType type;
+
+	//~ Constructors -----------------------------------------------------------
+
+	public SqlWindowSumAggFunction(RelDataType type) {
+		super(
+			"WINDOW_SUM",
+			null,
+			SqlKind.SUM,
+			WINDOW_AGG_SUM,
+			null,
+			OperandTypes.NUMERIC,
+			SqlFunctionCategory.NUMERIC,
+			false,
+			false,
+			Optionality.FORBIDDEN);
+		this.type = type;
+	}
+
+	//~ Methods ----------------------------------------------------------------
+
+	@SuppressWarnings("deprecation")
+	public List<RelDataType> getParameterTypes(RelDataTypeFactory typeFactory) {
+		return ImmutableList.of(type);
+	}
+
+	@Deprecated // to be removed before 2.0
+	public RelDataType getType() {
+		return type;
+	}
+
+	@SuppressWarnings("deprecation")
+	public RelDataType getReturnType(RelDataTypeFactory typeFactory) {
+		return type;
+	}
+
+	@Override public <T> T unwrap(Class<T> clazz) {
+		if (clazz == SqlSplittableAggFunction.class) {
+			return clazz.cast(SqlSplittableAggFunction.SumSplitter.INSTANCE);
+		}
+		return super.unwrap(clazz);
+	}
+
+	private static final SqlReturnTypeInference WINDOW_AGG_SUM = opBinding -> {
+		RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
+		return typeFactory.getTypeSystem()
+			.deriveSumType(typeFactory, opBinding.getOperandType(0));
+	};
+}
+
+// End SqlWindowSumAggFunction.java

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/rules/logical/ReplaceWindowAggregateFunctionRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/rules/logical/ReplaceWindowAggregateFunctionRule.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.logical;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptRuleOperand;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlAvgAggFunction;
+import org.apache.calcite.sql.fun.SqlSumAggFunction;
+import org.apache.calcite.sql.fun.SqlWindowAvgAggFunction;
+import org.apache.calcite.sql.fun.SqlWindowSumAggFunction;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Replace a {@link SqlSumAggFunction} to a {@link SqlWindowSumAggFunction} or replace a
+ * {@link SqlAvgAggFunction} to a {@link SqlWindowAvgAggFunction} when it is a group window
+ * aggregate.
+ *
+ * <p>This rule should be called before the window rules to replace the corresponding
+ * {@link SqlAggFunction}.
+ */
+public class ReplaceWindowAggregateFunctionRule extends RelOptRule {
+
+	public static final ReplaceWindowAggregateFunctionRule INSTANCE =
+		new ReplaceWindowAggregateFunctionRule(
+			operand(LogicalAggregate.class,
+				operand(LogicalProject.class, any())),
+			"ReplaceWindowAggregateFunctionRule");
+
+	public ReplaceWindowAggregateFunctionRule(RelOptRuleOperand operand, String description) {
+		super(operand, description);
+	}
+
+	@Override
+	public boolean matches(RelOptRuleCall call) {
+		LogicalAggregate agg = call.rel(0);
+		LogicalProject project = call.rel(1);
+		return isWindowAggregate(agg, project);
+	}
+
+	@Override
+	public void onMatch(RelOptRuleCall call) {
+		LogicalAggregate agg = call.rel(0);
+
+		// Replace SqlReturnTypeInference for sum and avg.
+		List<AggregateCall> newAggCalls = replaceAggCalls(agg.getAggCallList());
+		LogicalAggregate newAgg = LogicalAggregate.create(
+			agg.getInput(),
+			agg.getGroupSet(),
+			agg.getGroupSets(),
+			newAggCalls);
+
+		call.transformTo(newAgg);
+	}
+
+	/**
+	 * Replace a {@link SqlSumAggFunction} to a {@link SqlWindowSumAggFunction} or replace a
+	 * {@link SqlAvgAggFunction} to a {@link SqlWindowAvgAggFunction}.
+	 */
+	private List<AggregateCall> replaceAggCalls(List<AggregateCall> origAggCalls) {
+		List<AggregateCall> newAggCalls = new LinkedList<>();
+		for (int i = 0; i < origAggCalls.size(); ++i) {
+			AggregateCall aggregateCall = origAggCalls.get(i);
+			// replace
+			SqlAggFunction finalSqlAggFunction = aggregateCall.getAggregation();
+			if (SqlKind.SUM == aggregateCall.getAggregation().kind) {
+				finalSqlAggFunction = new SqlWindowSumAggFunction(aggregateCall.getType());
+			} else if (SqlKind.AVG == aggregateCall.getAggregation().kind) {
+				finalSqlAggFunction = new SqlWindowAvgAggFunction();
+			}
+			AggregateCall newAggCall = AggregateCall.create(
+				finalSqlAggFunction,
+				aggregateCall.isDistinct(),
+				aggregateCall.isApproximate(),
+				aggregateCall.ignoreNulls(),
+				aggregateCall.getArgList(),
+				aggregateCall.filterArg,
+				aggregateCall.collation,
+				aggregateCall.type,
+				aggregateCall.name);
+			newAggCalls.add(newAggCall);
+		}
+		return newAggCalls;
+	}
+
+	private boolean isWindowAggregate(LogicalAggregate agg, LogicalProject project) {
+		List<Integer> groupKeys = agg.getGroupSet().toList();
+
+		List<RexNode> groupExpr = new LinkedList<>();
+		for (int i = 0; i < project.getProjects().size(); ++i) {
+			if (groupKeys.contains(i)) {
+				groupExpr.add(project.getProjects().get(i));
+			}
+		}
+
+		List<RexCall> windowExprs = groupExpr.stream().filter(p -> p instanceof RexCall)
+			.map(p -> (RexCall) p)
+			.filter(p -> {
+				if ((SqlKind.TUMBLE == p.getOperator().getKind()) ||
+					(SqlKind.SESSION == p.getOperator().getKind())) {
+					return 2 == p.getOperands().size();
+				} else if (SqlKind.HOP == p.getOperator().getKind()) {
+					return 3 == p.getOperands().size();
+				} else {
+					return false;
+				}
+			}).collect(Collectors.toList());
+
+		return 1 == windowExprs.size();
+	}
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
@@ -152,6 +152,7 @@ object FlinkRuleSets {
     // Transform grouping sets
     DecomposeGroupingSetRule.INSTANCE,
     // Transform window to LogicalWindowAggregate
+    ReplaceWindowAggregateFunctionRule.INSTANCE,
     DataSetLogicalWindowAggregateRule.INSTANCE,
     WindowPropertiesRule.INSTANCE,
     WindowPropertiesHavingRule.INSTANCE,
@@ -197,6 +198,7 @@ object FlinkRuleSets {
     */
   val DATASTREAM_NORM_RULES: RuleSet = RuleSets.ofList(
     // Transform window to LogicalWindowAggregate
+    ReplaceWindowAggregateFunctionRule.INSTANCE,
     DataStreamLogicalWindowAggregateRule.INSTANCE,
     WindowPropertiesRule.INSTANCE,
     WindowPropertiesHavingRule.INSTANCE,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
@@ -1559,7 +1559,7 @@ object AggregateUtil {
       case _: SqlCountAggFunction =>
         new CountAggFunction
 
-      case _: SqlSumAggFunction =>
+      case _: SqlSumAggFunction | _: SqlWindowSumAggFunction =>
         if (needRetraction) {
           outputTypeName match {
             case TINYINT =>
@@ -1641,7 +1641,7 @@ object AggregateUtil {
           }
         }
 
-      case a: SqlAvgAggFunction if a.kind == SqlKind.AVG =>
+      case _:SqlWindowAvgAggFunction | _:SqlAvgAggFunction if aggFunc.kind == SqlKind.AVG =>
         outputTypeName match {
           case TINYINT =>
             new ByteAvgAggFunction

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/sql/GroupWindowTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/sql/GroupWindowTest.scala
@@ -346,4 +346,45 @@ class GroupWindowTest extends TableTestBase {
 
     util.verifySql(sql, expected)
   }
+
+  @Test
+  def testReturnTypeInferenceForWindowAgg(): Unit = {
+    val util = batchTestUtil()
+    val table = util.addTable[(Int, Long, String, Timestamp)]("MyTable", 'a, 'b, 'c, 'rowtime)
+
+    val innerQuery =
+      """
+        |SELECT
+        | CASE a WHEN 1 THEN 1 ELSE 99 END AS correct,
+        | rowtime
+        |FROM MyTable
+      """.stripMargin
+
+    val sqlQuery =
+      "SELECT " +
+        "  sum(correct) as s, " +
+        "  avg(correct) as a, " +
+        "  TUMBLE_START(rowtime, INTERVAL '15' MINUTE) as wStart " +
+        s"FROM ($innerQuery) " +
+        "GROUP BY TUMBLE(rowtime, INTERVAL '15' MINUTE)"
+
+    val expected =
+      unaryNode(
+        "DataSetCalc",
+        unaryNode(
+          "DataSetWindowAggregate",
+          unaryNode(
+            "DataSetCalc",
+            batchTableNode(table),
+            term("select", "CASE(=(a, 1), 1, 99) AS correct, rowtime")
+          ),
+          term("window", "TumblingGroupWindow('w$, 'rowtime, 900000.millis)"),
+          term("select", "SUM(correct) AS s, AVG(correct) AS a, start('w$) AS w$start," +
+            " end('w$) AS w$end, rowtime('w$) AS w$rowtime")
+        ),
+        term("select", "s, a, CAST(w$start) AS wStart")
+      )
+
+    util.verifySql(sqlQuery, expected)
+  }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/GroupWindowTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/GroupWindowTest.scala
@@ -301,4 +301,47 @@ class GroupWindowTest extends TableTestBase {
       )
     streamUtil.verifySql(sql, expected)
   }
+
+  @Test
+  def testReturnTypeInferenceForWindowAgg() = {
+
+    val innerQuery =
+      """
+        |SELECT
+        | CASE a WHEN 1 THEN 1 ELSE 99 END AS correct,
+        | rowtime
+        |FROM MyTable
+      """.stripMargin
+
+    val sql =
+      "SELECT " +
+        "  sum(correct) as s, " +
+        "  avg(correct) as a, " +
+        "  TUMBLE_START(rowtime, INTERVAL '15' MINUTE) as wStart " +
+        s"FROM ($innerQuery) " +
+        "GROUP BY TUMBLE(rowtime, INTERVAL '15' MINUTE)"
+
+    val expected =
+      unaryNode(
+        "DataStreamCalc",
+        unaryNode(
+          "DataStreamGroupWindowAggregate",
+          unaryNode(
+            "DataStreamCalc",
+            streamTableNode(table),
+            term("select", "CASE(=(a, 1), 1, 99) AS correct", "rowtime")
+          ),
+          term("window", "TumblingGroupWindow('w$, 'rowtime, 900000.millis)"),
+          term("select",
+            "SUM(correct) AS s",
+            "AVG(correct) AS a",
+            "start('w$) AS w$start",
+            "end('w$) AS w$end",
+            "rowtime('w$) AS w$rowtime",
+            "proctime('w$) AS w$proctime")
+        ),
+        term("select", "s", "a", "w$start AS wStart")
+      )
+    streamUtil.verifySql(sql, expected)
+  }
 }


### PR DESCRIPTION
Mirror of apache flink#9141
## What is the purpose of the change

This pull request fixes type equivalence check problems for Window Aggregates

### background

Creating Aggregate node fails in rules: LogicalWindowAggregateRule and ExtendedAggregateExtractProjectRule if the only grouping expression is a window and
we compute aggregation on NON NULLABLE field.

The root cause for that, is how return type inference strategies in calcite work and how we handle window aggregates. Take org.apache.calcite.sql.type.ReturnTypes#AGG_SUM as an example, based on groupCount it adjusts type nullability based on groupCount.

### analysis
There is no problem for non-window aggregate that return type turn to nullable if the call occurs within a "GROUP BY ()" query, e.g. in "select sum(x) as s from empty", s may be null. 
This is also the behavior of common databases, such as mysql. The result of query "select sum(x) as s from empty" is a null output.

However, for window aggregate, there is no way to output null, as we don't know which window the null belongs to, so the result should be an empty result which means the result type is also not null.

### solution
To fix this problem we can replace the current sum/avg SqlAggFunction to a self-defined one which avoids turning the "not null" to "nullable" for window aggregate. We can simply use a Rule to archive this.

## Brief change log

  - Add a self-defined sum and avg SqlAggFunction which will not change return type to nullable even if the call occurs within a "GROUP BY ()" for window aggregates.
  - Add a Rule(`ReplaceWindowAggregateFunctionRule`) to change the sum/avg to the self-defined sum/avg(`SqlWindowAvgAggFunction` and `SqlWindowSumAggFunction`).
  - Add `getSqlAggFunctionString` in `CommonAggregate`. This method makes sure that the new self-defined sum/avg returns same string with sum/agg.
  - Add tests.

## Verifying this change

This change added tests and can be verified as follows:

  - Added plan tests for flink, blink.
  - Added plan tests for batch, streaming.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

