### PR TITLE
Mirror of apache flink#9140

### DIFF
--- a/flink-python/dev/lint-python.sh
+++ b/flink-python/dev/lint-python.sh
@@ -213,9 +213,9 @@ function install_tox() {
         fi
     fi
 
-    # virtualenv in conda-forge is not compatible with py27 and py34, so we install it from the
-    # default repository.
-    $CONDA_PATH install -p $CONDA_HOME virtualenv -y -q 2>&1 >/dev/null
+    # virtualenv 16.6.2 released in 2019-07-14 is incompatible with py27 and py34,
+    # force install an older version(16.0.0) to avoid this problem.
+    $CONDA_PATH install -p $CONDA_HOME -c conda-forge virtualenv=16.0.0 -y -q 2>&1 >/dev/null
     
     $CONDA_PATH install -p $CONDA_HOME -c conda-forge tox -y -q 2>&1 >/dev/null
     if [ $? -ne 0 ]; then

--- a/flink-python/dev/lint-python.sh
+++ b/flink-python/dev/lint-python.sh
@@ -215,9 +215,7 @@ function install_tox() {
 
     # virtualenv 16.6.2 released in 2019-07-14 is incompatible with py27 and py34,
     # force install an older version(16.0.0) to avoid this problem.
-    $CONDA_PATH install -p $CONDA_HOME -c conda-forge virtualenv=16.0.0 -y -q 2>&1 >/dev/null
-    
-    $CONDA_PATH install -p $CONDA_HOME -c conda-forge tox -y -q 2>&1 >/dev/null
+    $CONDA_PATH install -p $CONDA_HOME -c conda-forge virtualenv=16.0.0 tox -y -q 2>&1 >/dev/null
     if [ $? -ne 0 ]; then
         echo "conda install tox failed \
         please try to exec the script again.\

--- a/flink-python/dev/lint-python.sh
+++ b/flink-python/dev/lint-python.sh
@@ -213,6 +213,10 @@ function install_tox() {
         fi
     fi
 
+    # virtualenv in conda-forge is not compatible with py27 and py34, so we install it from the
+    # default repository.
+    $CONDA_PATH install -p $CONDA_HOME virtualenv -y -q 2>&1 >/dev/null
+    
     $CONDA_PATH install -p $CONDA_HOME -c conda-forge tox -y -q 2>&1 >/dev/null
     if [ $? -ne 0 ]; then
         echo "conda install tox failed \


### PR DESCRIPTION
Mirror of apache flink#9140
## What is the purpose of the change

*This pull request fixes a travis CI failure caused by an incompatible python virtualenv module.*


## Brief change log

  - *install the compatible virtualenv manually.*


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

