### PR TITLE
Mirror of apache flink#9139

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/NestedRow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/NestedRow.java
@@ -25,8 +25,12 @@ import static org.apache.flink.table.dataformat.BinaryRow.calculateBitSetWidthIn
 import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
- * Its memory storage structure and {@link BinaryRow} exactly the same, the only different is it supports
- * all bytes in variable MemorySegments.
+ * Its memory storage structure is exactly the same with {@link BinaryRow}.
+ * The only different is that, as {@link NestedRow} is used
+ * to store row value in the variable-length part of {@link BinaryRow},
+ * every field (including both fixed-length part and variable-length part) of {@link NestedRow}
+ * has a possibility to cross the boundary of a segment, while the fixed-length part of {@link BinaryRow}
+ * must fir into its first memory segment.
  */
 public final class NestedRow extends BinaryFormat implements BaseRow {
 
@@ -219,7 +223,7 @@ public final class NestedRow extends BinaryFormat implements BaseRow {
 	public BinaryString getString(int pos) {
 		assertIndexIsValid(pos);
 		int fieldOffset = getFieldOffset(pos);
-		final long offsetAndLen = segments[0].getLong(fieldOffset);
+		final long offsetAndLen = SegmentsUtil.getLong(segments, fieldOffset);
 		return BinaryString.readBinaryStringFieldFromSegments(segments, offset, fieldOffset, offsetAndLen);
 	}
 
@@ -247,7 +251,7 @@ public final class NestedRow extends BinaryFormat implements BaseRow {
 	public byte[] getBinary(int pos) {
 		assertIndexIsValid(pos);
 		int fieldOffset = getFieldOffset(pos);
-		final long offsetAndLen = segments[0].getLong(fieldOffset);
+		final long offsetAndLen = SegmentsUtil.getLong(segments, fieldOffset);
 		return readBinaryFieldFromSegments(segments, offset, fieldOffset, offsetAndLen);
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/types/InternalSerializers.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/types/InternalSerializers.java
@@ -80,9 +80,9 @@ public class InternalSerializers {
 				return new BaseArraySerializer(((ArrayType) type).getElementType(), config);
 			case MAP:
 				MapType mapType = (MapType) type;
-				return new BaseMapSerializer(mapType.getKeyType(), mapType.getValueType());
+				return new BaseMapSerializer(mapType.getKeyType(), mapType.getValueType(), config);
 			case MULTISET:
-				return new BaseMapSerializer(((MultisetType) type).getElementType(), new IntType());
+				return new BaseMapSerializer(((MultisetType) type).getElementType(), new IntType(), config);
 			case ROW:
 				RowType rowType = (RowType) type;
 				return new BaseRowSerializer(config, rowType);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/typeutils/BaseMapSerializer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/typeutils/BaseMapSerializer.java
@@ -62,12 +62,22 @@ public class BaseMapSerializer extends TypeSerializer<BaseMap> {
 	private transient BinaryArrayWriter reuseKeyWriter;
 	private transient BinaryArrayWriter reuseValueWriter;
 
-	public BaseMapSerializer(LogicalType keyType, LogicalType valueType) {
+	public BaseMapSerializer(LogicalType keyType, LogicalType valueType, ExecutionConfig config) {
 		this.keyType = keyType;
 		this.valueType = valueType;
 
-		this.keySerializer = InternalSerializers.create(keyType, new ExecutionConfig());
-		this.valueSerializer = InternalSerializers.create(valueType, new ExecutionConfig());
+		this.keySerializer = InternalSerializers.create(keyType, config);
+		this.valueSerializer = InternalSerializers.create(valueType, config);
+	}
+
+	private BaseMapSerializer(
+			LogicalType keyType, LogicalType valueType,
+			TypeSerializer keySerializer, TypeSerializer valueSerializer) {
+		this.keyType = keyType;
+		this.valueType = valueType;
+
+		this.keySerializer = keySerializer;
+		this.valueSerializer = valueSerializer;
 	}
 
 	@Override
@@ -77,7 +87,7 @@ public class BaseMapSerializer extends TypeSerializer<BaseMap> {
 
 	@Override
 	public TypeSerializer<BaseMap> duplicate() {
-		return new BaseMapSerializer(keyType, valueType);
+		return new BaseMapSerializer(keyType, valueType, keySerializer.duplicate(), valueSerializer.duplicate());
 	}
 
 	@Override
@@ -264,7 +274,7 @@ public class BaseMapSerializer extends TypeSerializer<BaseMap> {
 
 		@Override
 		public TypeSerializer<BaseMap> restoreSerializer() {
-			return new BaseMapSerializer(previousKeyType, previousValueType);
+			return new BaseMapSerializer(previousKeyType, previousValueType, new ExecutionConfig());
 		}
 
 		@Override

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/BaseRowTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/BaseRowTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.table.dataformat;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.types.logical.IntType;
@@ -102,7 +103,8 @@ public class BaseRowTest {
 		writer.writeDecimal(10, decimal1, 5);
 		writer.writeDecimal(11, decimal2, 20);
 		writer.writeArray(12, array, new BaseArraySerializer(DataTypes.INT().getLogicalType(), null));
-		writer.writeMap(13, map, new BaseMapSerializer(DataTypes.INT().getLogicalType(), DataTypes.INT().getLogicalType()));
+		writer.writeMap(13, map, new BaseMapSerializer(
+			DataTypes.INT().getLogicalType(), DataTypes.INT().getLogicalType(), new ExecutionConfig()));
 		writer.writeRow(14, underRow, new BaseRowSerializer(null, RowType.of(new IntType(), new IntType())));
 		writer.writeBinary(15, bytes);
 		return row;

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/BinaryArrayTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/BinaryArrayTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.dataformat;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
@@ -101,17 +102,17 @@ public class BinaryArrayTest {
 			writer.complete();
 
 			assertTrue(array.isNullAt(0));
-			assertEquals(true, array.getBoolean(1));
+			assertTrue(array.getBoolean(1));
 			array.setBoolean(0, true);
-			assertEquals(true, array.getBoolean(0));
+			assertTrue(array.getBoolean(0));
 			array.setNullBoolean(0);
 			assertTrue(array.isNullAt(0));
 
 			BinaryArray newArray = splitArray(array);
 			assertTrue(newArray.isNullAt(0));
-			assertEquals(true, newArray.getBoolean(1));
+			assertTrue(newArray.getBoolean(1));
 			newArray.setBoolean(0, true);
-			assertEquals(true, newArray.getBoolean(0));
+			assertTrue(newArray.getBoolean(0));
 			newArray.setNullBoolean(0);
 			assertTrue(newArray.isNullAt(0));
 
@@ -236,17 +237,17 @@ public class BinaryArrayTest {
 			writer.complete();
 
 			assertTrue(array.isNullAt(0));
-			assertTrue(25 == array.getFloat(1));
+			assertEquals(25, array.getFloat(1), 0.0);
 			array.setFloat(0, 5);
-			assertTrue(5 == array.getFloat(0));
+			assertEquals(5, array.getFloat(0), 0.0);
 			array.setNullFloat(0);
 			assertTrue(array.isNullAt(0));
 
 			BinaryArray newArray = splitArray(array);
 			assertTrue(newArray.isNullAt(0));
-			assertTrue(25 == newArray.getFloat(1));
+			assertEquals(25, newArray.getFloat(1), 0.0);
 			newArray.setFloat(0, 5);
-			assertTrue(5 == newArray.getFloat(0));
+			assertEquals(5, newArray.getFloat(0), 0.0);
 			newArray.setNullFloat(0);
 			assertTrue(newArray.isNullAt(0));
 
@@ -263,17 +264,17 @@ public class BinaryArrayTest {
 			writer.complete();
 
 			assertTrue(array.isNullAt(0));
-			assertTrue(25 == array.getDouble(1));
+			assertEquals(25, array.getDouble(1), 0.0);
 			array.setDouble(0, 5);
-			assertTrue(5 == array.getDouble(0));
+			assertEquals(5, array.getDouble(0), 0.0);
 			array.setNullDouble(0);
 			assertTrue(array.isNullAt(0));
 
 			BinaryArray newArray = splitArray(array);
 			assertTrue(newArray.isNullAt(0));
-			assertTrue(25 == newArray.getDouble(1));
+			assertEquals(25, newArray.getDouble(1), 0.0);
 			newArray.setDouble(0, 5);
-			assertTrue(5 == newArray.getDouble(0));
+			assertEquals(5, newArray.getDouble(0), 0.0);
 			newArray.setNullDouble(0);
 			assertTrue(newArray.isNullAt(0));
 
@@ -325,7 +326,8 @@ public class BinaryArrayTest {
 			BinaryArrayWriter writer = new BinaryArrayWriter(array, 2, 8);
 			writer.setNullAt(0);
 			writer.writeMap(1, BinaryMap.valueOf(subArray, subArray),
-					new BaseMapSerializer(DataTypes.INT().getLogicalType(), DataTypes.INT().getLogicalType()));
+				new BaseMapSerializer(
+					DataTypes.INT().getLogicalType(), DataTypes.INT().getLogicalType(), new ExecutionConfig()));
 			writer.complete();
 
 			assertTrue(array.isNullAt(0));
@@ -358,7 +360,8 @@ public class BinaryArrayTest {
 		BinaryRow row = new BinaryRow(1);
 		BinaryRowWriter rowWriter = new BinaryRowWriter(row);
 		rowWriter.writeMap(0, binaryMap,
-				new BaseMapSerializer(DataTypes.INT().getLogicalType(), DataTypes.INT().getLogicalType()));
+			new BaseMapSerializer(
+				DataTypes.INT().getLogicalType(), DataTypes.INT().getLogicalType(), new ExecutionConfig()));
 		rowWriter.complete();
 
 		BinaryMap map = (BinaryMap) row.getMap(0);

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/ComplexTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/ComplexTest.java
@@ -1,0 +1,317 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.dataformat;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.typeutils.GenericTypeInfo;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.dataformat.BinaryRowTest.MyObj;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.typeutils.BaseArraySerializer;
+import org.apache.flink.table.typeutils.BaseMapSerializer;
+import org.apache.flink.table.typeutils.BaseRowSerializer;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for nestedRow, array, map.
+ */
+public class ComplexTest {
+
+	@Test
+	public void testNestedRow() {
+		BinaryRow row = new BinaryRow(1);
+		BinaryRowWriter writer = new BinaryRowWriter(row);
+
+		GenericTypeInfo<MyObj> info = new GenericTypeInfo<>(MyObj.class);
+		TypeSerializer<MyObj> genericSerializer = info.createSerializer(new ExecutionConfig());
+		GenericRow gRow = new GenericRow(5);
+		gRow.setField(0, 1);
+		gRow.setField(1, 5L);
+		gRow.setField(2, BinaryString.fromString("12345678"));
+		gRow.setField(3, null);
+		gRow.setField(4, new BinaryGeneric<>(new MyObj(15, 5), genericSerializer));
+
+		BaseRowSerializer serializer = new BaseRowSerializer(
+			new LogicalType[]{
+				DataTypes.INT().getLogicalType(),
+				DataTypes.BIGINT().getLogicalType(),
+				DataTypes.STRING().getLogicalType(),
+				DataTypes.STRING().getLogicalType(),
+				DataTypes.ANY(info).getLogicalType()
+			},
+			new TypeSerializer[]{
+				IntSerializer.INSTANCE,
+				LongSerializer.INSTANCE,
+				StringSerializer.INSTANCE,
+				StringSerializer.INSTANCE,
+				genericSerializer
+			});
+		writer.writeRow(0, gRow, serializer);
+		writer.complete();
+
+		{
+			BaseRow nestedRow = row.getRow(0, 5);
+			assertEquals(nestedRow.getInt(0), 1);
+			assertEquals(nestedRow.getLong(1), 5L);
+			assertEquals(nestedRow.getString(2), BinaryString.fromString("12345678"));
+			assertTrue(nestedRow.isNullAt(3));
+			assertEquals(new MyObj(15, 5),
+				BinaryGeneric.getJavaObjectFromBinaryGeneric(nestedRow.getGeneric(4), genericSerializer));
+		}
+
+		MemorySegment[] segments = splitBytes(row.getSegments()[0].getHeapMemory(), 3);
+		row.pointTo(segments, 3, row.getSizeInBytes());
+		{
+			BaseRow nestedRow = row.getRow(0, 5);
+			assertEquals(nestedRow.getInt(0), 1);
+			assertEquals(nestedRow.getLong(1), 5L);
+			assertEquals(nestedRow.getString(2), BinaryString.fromString("12345678"));
+			assertTrue(nestedRow.isNullAt(3));
+			assertEquals(new MyObj(15, 5),
+				BinaryGeneric.getJavaObjectFromBinaryGeneric(nestedRow.getGeneric(4), genericSerializer));
+		}
+	}
+
+	@Test
+	public void testNestInNestedRow() {
+		//1.layer1
+		GenericRow gRow = new GenericRow(4);
+		gRow.setField(0, 1);
+		gRow.setField(1, 5L);
+		gRow.setField(2, BinaryString.fromString("12345678"));
+		gRow.setField(3, null);
+
+		//2.layer2
+		BaseRowSerializer serializer = new BaseRowSerializer(
+			new LogicalType[]{
+				DataTypes.INT().getLogicalType(),
+				DataTypes.BIGINT().getLogicalType(),
+				DataTypes.STRING().getLogicalType(),
+				DataTypes.STRING().getLogicalType()
+			},
+			new TypeSerializer[]{
+				IntSerializer.INSTANCE,
+				LongSerializer.INSTANCE,
+				StringSerializer.INSTANCE,
+				StringSerializer.INSTANCE
+			});
+		BinaryRow row = new BinaryRow(2);
+		BinaryRowWriter writer = new BinaryRowWriter(row);
+		writer.writeString(0, BinaryString.fromString("hahahahafff"));
+		writer.writeRow(1, gRow, serializer);
+		writer.complete();
+
+		//3.layer3
+		BinaryRow row2 = new BinaryRow(1);
+		BinaryRowWriter writer2 = new BinaryRowWriter(row2);
+		writer2.writeRow(0, row, null);
+		writer2.complete();
+
+		// verify
+		{
+			NestedRow nestedRow = (NestedRow) row2.getRow(0, 2);
+			BinaryRow binaryRow = new BinaryRow(2);
+			binaryRow.pointTo(nestedRow.getSegments(), nestedRow.getOffset(),
+				nestedRow.getSizeInBytes());
+			assertEquals(binaryRow, row);
+		}
+
+		assertEquals(row2.getRow(0, 2).getString(0), BinaryString.fromString("hahahahafff"));
+		BaseRow nestedRow = row2.getRow(0, 2).getRow(1, 4);
+		assertEquals(nestedRow.getInt(0), 1);
+		assertEquals(nestedRow.getLong(1), 5L);
+		assertEquals(nestedRow.getString(2), BinaryString.fromString("12345678"));
+		assertTrue(nestedRow.isNullAt(3));
+	}
+
+	@Test
+	public void testGenericArray() {
+		// 1. array test
+		Integer[] javaArray = {6, null, 666};
+		GenericArray array = new GenericArray(javaArray, 3, false);
+
+		assertEquals(array.getInt(0), 6);
+		assertTrue(array.isNullAt(1));
+		assertEquals(array.getInt(2), 666);
+
+		// 2. test write array to binary row.
+		BinaryRow row2 = new BinaryRow(1);
+		BinaryRowWriter writer2 = new BinaryRowWriter(row2);
+		BaseArraySerializer serializer = new BaseArraySerializer(
+			DataTypes.INT().getLogicalType(), new ExecutionConfig());
+		writer2.writeArray(0, array, serializer);
+		writer2.complete();
+
+		BaseArray array2 = row2.getArray(0);
+		assertEquals(6, array2.getInt(0));
+		assertTrue(array2.isNullAt(1));
+		assertEquals(666, array2.getInt(2));
+	}
+
+	@Test
+	public void testBinaryArray() {
+		// 1. array test
+		BinaryArray array = new BinaryArray();
+		BinaryArrayWriter writer = new BinaryArrayWriter(
+			array, 3, BinaryArray.calculateFixLengthPartSize(DataTypes.INT().getLogicalType()));
+
+		writer.writeInt(0, 6);
+		writer.setNullInt(1);
+		writer.writeInt(2, 666);
+		writer.complete();
+
+		assertEquals(array.getInt(0), 6);
+		assertTrue(array.isNullAt(1));
+		assertEquals(array.getInt(2), 666);
+
+		// 2. test write array to binary row.
+		BinaryRow row2 = new BinaryRow(1);
+		BinaryRowWriter writer2 = new BinaryRowWriter(row2);
+		BaseArraySerializer serializer = new BaseArraySerializer(
+			DataTypes.INT().getLogicalType(), new ExecutionConfig());
+		writer2.writeArray(0, array, serializer);
+		writer2.complete();
+
+		BinaryArray array2 = (BinaryArray) row2.getArray(0);
+		assertEquals(array, array2);
+		assertEquals(6, array2.getInt(0));
+		assertTrue(array2.isNullAt(1));
+		assertEquals(666, array2.getInt(2));
+	}
+
+	@Test
+	public void testGenericMap() {
+		Map javaMap = new HashMap();
+		javaMap.put(6, BinaryString.fromString("6"));
+		javaMap.put(5, BinaryString.fromString("5"));
+		javaMap.put(666, BinaryString.fromString("666"));
+		javaMap.put(0, null);
+
+		GenericMap genericMap = new GenericMap(javaMap);
+
+		BinaryRow row = new BinaryRow(1);
+		BinaryRowWriter rowWriter = new BinaryRowWriter(row);
+		BaseMapSerializer serializer = new BaseMapSerializer(
+			DataTypes.INT().getLogicalType(),
+			DataTypes.STRING().getLogicalType(),
+			new ExecutionConfig());
+		rowWriter.writeMap(0, genericMap, serializer);
+		rowWriter.complete();
+
+		Map map = row.getMap(0).toJavaMap(DataTypes.INT().getLogicalType(), DataTypes.STRING().getLogicalType());
+		assertEquals(BinaryString.fromString("6"), map.get(6));
+		assertEquals(BinaryString.fromString("5"), map.get(5));
+		assertEquals(BinaryString.fromString("666"), map.get(666));
+		assertTrue(map.containsKey(0));
+		assertNull(map.get(0));
+	}
+
+	@Test
+	public void testBinaryMap() {
+		BinaryArray array1 = new BinaryArray();
+		BinaryArrayWriter writer1 = new BinaryArrayWriter(
+			array1, 4, BinaryArray.calculateFixLengthPartSize(DataTypes.INT().getLogicalType()));
+		writer1.writeInt(0, 6);
+		writer1.writeInt(1, 5);
+		writer1.writeInt(2, 666);
+		writer1.writeInt(3, 0);
+		writer1.complete();
+
+		BinaryArray array2 = new BinaryArray();
+		BinaryArrayWriter writer2 = new BinaryArrayWriter(
+			array2, 4, BinaryArray.calculateFixLengthPartSize(DataTypes.STRING().getLogicalType()));
+		writer2.writeString(0, BinaryString.fromString("6"));
+		writer2.writeString(1, BinaryString.fromString("5"));
+		writer2.writeString(2, BinaryString.fromString("666"));
+		writer2.setNullAt(3, DataTypes.STRING().getLogicalType());
+		writer2.complete();
+
+		BinaryMap binaryMap = BinaryMap.valueOf(array1, array2);
+
+		BinaryRow row = new BinaryRow(1);
+		BinaryRowWriter rowWriter = new BinaryRowWriter(row);
+		BaseMapSerializer serializer = new BaseMapSerializer(
+			DataTypes.STRING().getLogicalType(),
+			DataTypes.INT().getLogicalType(),
+			new ExecutionConfig());
+		rowWriter.writeMap(0, binaryMap, serializer);
+		rowWriter.complete();
+
+		BinaryMap map = (BinaryMap) row.getMap(0);
+		BinaryArray key = map.keyArray();
+		BinaryArray value = map.valueArray();
+
+		assertEquals(binaryMap, map);
+		assertEquals(array1, key);
+		assertEquals(array2, value);
+
+		assertEquals(5, key.getInt(1));
+		assertEquals(BinaryString.fromString("5"), value.getString(1));
+		assertEquals(0, key.getInt(3));
+		assertTrue(value.isNullAt(3));
+	}
+
+	public static MemorySegment[] splitBytes(byte[] bytes, int baseOffset) {
+		int newSize = (bytes.length + 1) / 2 + baseOffset;
+		MemorySegment[] ret = new MemorySegment[2];
+		ret[0] = MemorySegmentFactory.wrap(new byte[newSize]);
+		ret[1] = MemorySegmentFactory.wrap(new byte[newSize]);
+
+		ret[0].put(baseOffset, bytes, 0, newSize - baseOffset);
+		ret[1].put(0, bytes, newSize - baseOffset, bytes.length - (newSize - baseOffset));
+		return ret;
+	}
+
+	@Test
+	public void testToArray() {
+		BinaryArray array = new BinaryArray();
+		BinaryArrayWriter writer = new BinaryArrayWriter(
+			array, 3, BinaryArray.calculateFixLengthPartSize(DataTypes.SMALLINT().getLogicalType()));
+		writer.writeShort(0, (short) 5);
+		writer.writeShort(1, (short) 10);
+		writer.writeShort(2, (short) 15);
+		writer.complete();
+
+		short[] shorts = array.toShortArray();
+		assertEquals(5, shorts[0]);
+		assertEquals(10, shorts[1]);
+		assertEquals(15, shorts[2]);
+
+		MemorySegment[] segments = splitBytes(writer.segment.getHeapMemory(), 3);
+		array.pointTo(segments, 3, array.getSizeInBytes());
+		short[] shorts2 = array.toShortArray();
+		assertEquals(5, shorts2[0]);
+		assertEquals(10, shorts2[1]);
+		assertEquals(15, shorts2[2]);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/DecimalTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/DecimalTest.java
@@ -23,6 +23,8 @@ import org.junit.Test;
 
 import java.math.BigDecimal;
 
+import static org.junit.Assert.assertEquals;
+
 /**
  * Test for {@link Decimal}.
  */
@@ -113,5 +115,13 @@ public class DecimalTest {
 		Assert.assertNull(Decimal.fromBigDecimal(new BigDecimal(Long.MAX_VALUE), 5, 0));
 		Assert.assertEquals(0, Decimal.zero(20, 2).toBigDecimal().intValue());
 		Assert.assertEquals(0, Decimal.zero(20, 2).toBigDecimal().intValue());
+	}
+
+	@Test
+	public void testToString() {
+		String val = "0.0000000000000000001";
+		assertEquals(val, Decimal.castFrom(val, 39, val.length() - 2).toString());
+		val = "123456789012345678901234567890123456789";
+		assertEquals(val, Decimal.castFrom(val, 39, 0).toString());
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/typeutils/BaseMapSerializerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/typeutils/BaseMapSerializerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.typeutils;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.dataformat.BaseMap;
@@ -56,7 +57,7 @@ public class BaseMapSerializerTest extends SerializerTestBase<BaseMap> {
 	}
 
 	private static BaseMapSerializer newSer() {
-		return new BaseMapSerializer(INT, STRING);
+		return new BaseMapSerializer(INT, STRING, new ExecutionConfig());
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/util/BoundaryTestUtil.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/util/BoundaryTestUtil.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.util;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.table.dataformat.BinaryRow;
+import org.apache.flink.table.dataformat.BinaryRowWriter;
+import org.apache.flink.table.dataformat.BinaryString;
+
+import org.apache.commons.lang3.RandomStringUtils;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Utils to generate specific length binary rows
+ * to test the reading and writing on the boundary of some binary structures.
+ */
+public class BoundaryTestUtil {
+	public static BinaryRow get24BytesBinaryRow() {
+		BinaryRow row = new BinaryRow(2);
+		BinaryRowWriter writer = new BinaryRowWriter(row);
+		writer.writeString(0, BinaryString.fromString(RandomStringUtils.randomNumeric(2)));
+		writer.writeString(1, BinaryString.fromString(RandomStringUtils.randomNumeric(2)));
+		writer.complete();
+		return row;
+	}
+
+	public static BinaryRow get160BytesBinaryRow() {
+		BinaryRow row = new BinaryRow(2);
+		BinaryRowWriter writer = new BinaryRowWriter(row);
+		writer.writeString(0, BinaryString.fromString(RandomStringUtils.randomNumeric(72)));
+		writer.writeString(1, BinaryString.fromString(RandomStringUtils.randomNumeric(64)));
+		writer.complete();
+		return row;
+	}
+
+	public static BinaryRow getVarSeg160BytesBinaryRow(BinaryRow row160) {
+		BinaryRow varSegRow160 = new BinaryRow(2);
+		MemorySegment[] segments = new MemorySegment[6];
+		int baseOffset = 8;
+		int posInSeg = baseOffset;
+		int remainSize = 160;
+		for (int i = 0; i < segments.length; i++) {
+			segments[i] = MemorySegmentFactory.wrap(new byte[32]);
+			int copy = Math.min(32 - posInSeg, remainSize);
+			row160.getSegments()[0].copyTo(160 - remainSize, segments[i], posInSeg, copy);
+			remainSize -= copy;
+			posInSeg = 0;
+		}
+		varSegRow160.pointTo(segments, baseOffset, 160);
+		assertEquals(row160, varSegRow160);
+		return varSegRow160;
+	}
+
+	public static BinaryRow getVarSeg160BytesInOneSegRow(BinaryRow row160) {
+		MemorySegment[] segments = new MemorySegment[2];
+		segments[0] = row160.getSegments()[0];
+		segments[1] = MemorySegmentFactory.wrap(new byte[row160.getSegments()[0].size()]);
+		row160.pointTo(segments, 0, row160.getSizeInBytes());
+		return row160;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/util/SegmentsUtilTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/util/SegmentsUtilTest.java
@@ -19,10 +19,18 @@ package org.apache.flink.table.util;
 
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.table.dataformat.BinaryRow;
 import org.apache.flink.table.dataformat.BinaryRowTest;
+import org.apache.flink.table.dataformat.util.BinaryRowUtil;
 
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.apache.flink.table.dataformat.util.BinaryRowUtil.BYTE_ARRAY_BASE_OFFSET;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test for {@link SegmentsUtil}, most is covered by {@link BinaryRowTest},
@@ -59,4 +67,135 @@ public class SegmentsUtilTest {
 		Assert.assertFalse(SegmentsUtil.equals(segments1, 0, segments2, 1, 7));
 	}
 
+	@Test
+	public void testBoundaryByteArrayEquals() {
+		byte[] bytes1 = new byte[5];
+		bytes1[3] = 81;
+		byte[] bytes2 = new byte[100];
+		bytes2[3] = 81;
+		bytes2[4] = 81;
+
+		assertTrue(BinaryRowUtil.byteArrayEquals(bytes1, bytes2, 4));
+		assertFalse(BinaryRowUtil.byteArrayEquals(bytes1, bytes2, 5));
+		assertTrue(BinaryRowUtil.byteArrayEquals(bytes1, bytes2, 0));
+	}
+
+	@Test
+	public void testBoundaryEquals() {
+		BinaryRow row24 = BoundaryTestUtil.get24BytesBinaryRow();
+		BinaryRow row160 = BoundaryTestUtil.get160BytesBinaryRow();
+		BinaryRow varRow160 = BoundaryTestUtil.getVarSeg160BytesBinaryRow(row160);
+		BinaryRow varRow160InOne = BoundaryTestUtil.getVarSeg160BytesInOneSegRow(row160);
+
+		assertEquals(row160, varRow160InOne);
+		assertEquals(varRow160, varRow160InOne);
+		assertEquals(row160, varRow160);
+		assertEquals(varRow160InOne, varRow160);
+
+		assertNotEquals(row24, row160);
+		assertNotEquals(row24, varRow160);
+		assertNotEquals(row24, varRow160InOne);
+
+		assertTrue(SegmentsUtil.equals(row24.getSegments(), 0, row160.getSegments(), 0, 0));
+		assertTrue(SegmentsUtil.equals(row24.getSegments(), 0, varRow160.getSegments(), 0, 0));
+
+		// test var segs
+		MemorySegment[] segments1 = new MemorySegment[2];
+		segments1[0] = MemorySegmentFactory.wrap(new byte[32]);
+		segments1[1] = MemorySegmentFactory.wrap(new byte[32]);
+		MemorySegment[] segments2 = new MemorySegment[3];
+		segments2[0] = MemorySegmentFactory.wrap(new byte[16]);
+		segments2[1] = MemorySegmentFactory.wrap(new byte[16]);
+		segments2[2] = MemorySegmentFactory.wrap(new byte[16]);
+
+		segments1[0].put(9, (byte) 1);
+		assertFalse(SegmentsUtil.equals(segments1, 0, segments2, 14, 14));
+		segments2[1].put(7, (byte) 1);
+		assertTrue(SegmentsUtil.equals(segments1, 0, segments2, 14, 14));
+		assertTrue(SegmentsUtil.equals(segments1, 2, segments2, 16, 14));
+		assertTrue(SegmentsUtil.equals(segments1, 2, segments2, 16, 16));
+
+		segments2[2].put(7, (byte) 1);
+		assertTrue(SegmentsUtil.equals(segments1, 2, segments2, 32, 14));
+	}
+
+	@Test
+	public void testBoundaryCopy() {
+		MemorySegment[] segments1 = new MemorySegment[2];
+		segments1[0] = MemorySegmentFactory.wrap(new byte[32]);
+		segments1[1] = MemorySegmentFactory.wrap(new byte[32]);
+		segments1[0].put(15, (byte) 5);
+		segments1[1].put(15, (byte) 6);
+
+		{
+			byte[] bytes = new byte[64];
+			MemorySegment[] segments2 = new MemorySegment[]{MemorySegmentFactory.wrap(bytes)};
+
+			SegmentsUtil.copyToBytes(segments1, 0, bytes, 0, 64);
+			assertTrue(SegmentsUtil.equals(segments1, 0, segments2, 0, 64));
+		}
+
+		{
+			byte[] bytes = new byte[64];
+			MemorySegment[] segments2 = new MemorySegment[]{MemorySegmentFactory.wrap(bytes)};
+
+			SegmentsUtil.copyToBytes(segments1, 32, bytes, 0, 14);
+			assertTrue(SegmentsUtil.equals(segments1, 32, segments2, 0, 14));
+		}
+
+		{
+			byte[] bytes = new byte[64];
+			MemorySegment[] segments2 = new MemorySegment[]{MemorySegmentFactory.wrap(bytes)};
+
+			SegmentsUtil.copyToBytes(segments1, 34, bytes, 0, 14);
+			assertTrue(SegmentsUtil.equals(segments1, 34, segments2, 0, 14));
+		}
+	}
+
+	@Test
+	public void testCopyToUnsafe() {
+		MemorySegment[] segments1 = new MemorySegment[2];
+		segments1[0] = MemorySegmentFactory.wrap(new byte[32]);
+		segments1[1] = MemorySegmentFactory.wrap(new byte[32]);
+		segments1[0].put(15, (byte) 5);
+		segments1[1].put(15, (byte) 6);
+
+		{
+			byte[] bytes = new byte[64];
+			MemorySegment[] segments2 = new MemorySegment[]{MemorySegmentFactory.wrap(bytes)};
+
+			SegmentsUtil.copyToUnsafe(segments1, 0, bytes, BYTE_ARRAY_BASE_OFFSET, 64);
+			assertTrue(SegmentsUtil.equals(segments1, 0, segments2, 0, 64));
+		}
+
+		{
+			byte[] bytes = new byte[64];
+			MemorySegment[] segments2 = new MemorySegment[]{MemorySegmentFactory.wrap(bytes)};
+
+			SegmentsUtil.copyToUnsafe(segments1, 32, bytes, BYTE_ARRAY_BASE_OFFSET, 14);
+			assertTrue(SegmentsUtil.equals(segments1, 32, segments2, 0, 14));
+		}
+
+		{
+			byte[] bytes = new byte[64];
+			MemorySegment[] segments2 = new MemorySegment[]{MemorySegmentFactory.wrap(bytes)};
+
+			SegmentsUtil.copyToUnsafe(segments1, 34, bytes, BYTE_ARRAY_BASE_OFFSET, 14);
+			assertTrue(SegmentsUtil.equals(segments1, 34, segments2, 0, 14));
+		}
+	}
+
+	@Test
+	public void testFind() {
+		MemorySegment[] segments1 = new MemorySegment[2];
+		segments1[0] = MemorySegmentFactory.wrap(new byte[32]);
+		segments1[1] = MemorySegmentFactory.wrap(new byte[32]);
+		MemorySegment[] segments2 = new MemorySegment[3];
+		segments2[0] = MemorySegmentFactory.wrap(new byte[16]);
+		segments2[1] = MemorySegmentFactory.wrap(new byte[16]);
+		segments2[2] = MemorySegmentFactory.wrap(new byte[16]);
+
+		assertEquals(34, SegmentsUtil.find(segments1, 34, 0, segments2, 0, 0));
+		assertEquals(-1, SegmentsUtil.find(segments1, 34, 0, segments2, 0, 15));
+	}
 }


### PR DESCRIPTION
Mirror of apache flink#9139
## What is the purpose of the change

The `getString` and `getBinary` methods are not implemented correctly in `NestedRow`. This PR fixes the implementation and adds test cases for complex data formats.

## Brief change log

 - Fix implementation of `getString` and `getBinary` in `NestedRow`.
 - Add tests for complex data formats.

## Verifying this change

This change added tests and can be verified as follows: run the newly added `ComplexTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

