### PR TITLE
Mirror of apache flink#9132

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
@@ -138,9 +138,7 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
 		}
 
 		for (NetworkSequenceViewReader reader : allReaders.values()) {
-			reader.notifySubpartitionConsumed();
-			reader.releaseAllResources();
-			markAsReleased(reader.getReceiverId());
+			releaseViewReader(reader, true);
 		}
 		allReaders.clear();
 	}
@@ -307,8 +305,7 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
 	private void releaseAllResources() throws IOException {
 		// note: this is only ever executed by one thread: the Netty IO thread!
 		for (NetworkSequenceViewReader reader : allReaders.values()) {
-			reader.releaseAllResources();
-			markAsReleased(reader.getReceiverId());
+			releaseViewReader(reader, false);
 		}
 
 		availableReaders.clear();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
@@ -109,7 +109,7 @@ public class CancelPartitionRequestTest {
 			}
 
 			verify(view, times(1)).releaseAllResources();
-			verify(view, times(0)).notifySubpartitionConsumed();
+			verify(view, times(1)).notifySubpartitionConsumed();
 		}
 		finally {
 			shutdown(serverAndClient);
@@ -168,7 +168,7 @@ public class CancelPartitionRequestTest {
 			NettyTestUtil.awaitClose(ch);
 
 			verify(view, times(1)).releaseAllResources();
-			verify(view, times(0)).notifySubpartitionConsumed();
+			verify(view, times(1)).notifySubpartitionConsumed();
 		}
 		finally {
 			shutdown(serverAndClient);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.util.EnumSet;
 import java.util.Optional;
 
+import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.createFilledBufferConsumer;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -157,5 +158,12 @@ public class PartitionTestUtils {
 			1,
 			true,
 			releaseType);
+	}
+
+	public static void writeBuffers(ResultPartition partition, int numberOfBuffers, int bufferSize) throws IOException {
+		for (int i = 0; i < numberOfBuffers; i++) {
+			partition.addBufferConsumer(createFilledBufferConsumer(bufferSize, bufferSize), 0);
+		}
+		partition.finish();
 	}
 }


### PR DESCRIPTION
Mirror of apache flink#9132
## What is the purpose of the change

*On producer side the netty handler receives the `CancelPartitionRequest` for releasing the `ResultSubpartitionView` resource. In previous implementation we try to find the corresponding view via available queue in `PartitionRequestQueue`. But in reality the view is not always available to stay in this queue, then the view would never be released.*

*Furthermore the release of `ResultPartition/ResultSubpartitions` is based on the reference counter in `ReleaseOnConsumptionResultPartition`, but while handling the `CancelPartitionRequest` in `PartitionRequestQueue`, the `ReleaseOnConsum#ptionResultPartition` is never notified of consumed subpartition. That means the reference counter would never decrease to 0 to trigger partition release, which would bring file resource leak in the case of `BoundedBlockingSubpartition`.*
    
*In order to fix above two issues, the corresponding view is released via all reader queue instead, and then it would call `ReleaseOnConsumptionResultPartition#onConsumedSubpartition` meanwhile to solve this bug.*

## Brief change log

  - *Fix the logic in handling `CancelPartitionRequest` in `PartitionRequestQueue`*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit tests for verifying the partition and view are both released while receiving `CancelPartitionRequest` for the case of available/unavailable view.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
