### PR TITLE
Mirror of apache flink#9131

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacyScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacyScheduler.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
@@ -75,6 +76,7 @@ import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.WebMonitorUtils;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.function.FunctionUtils;
@@ -618,6 +620,13 @@ public class LegacyScheduler implements SchedulerNG {
 			.handle((completedCheckpoint, throwable) -> {
 				if (throwable != null) {
 					log.info("Failed during stopping job {} with a savepoint. Reason: {}", jobGraph.getJobID(), throwable.getMessage());
+					// it's possible this failure hasn't triggered a task failure, but rather the savepoint was aborted
+					// "softly" (for example on checkpoints barriers alignment, due to buffer limits).
+					// such situation may leave other tasks of the job in a blocking state.
+					// to workaround this, we fail the whole job.
+					if (isPotentiallyTaskLocalException(throwable)) {
+						executionGraph.failGlobal(throwable);
+					}
 					throw new CompletionException(throwable);
 				}
 				return completedCheckpoint.getExternalPointer();
@@ -648,5 +657,25 @@ public class LegacyScheduler implements SchedulerNG {
 			.map(Execution::getAssignedResourceLocation)
 			.map(TaskManagerLocation::toString)
 			.orElse("Unknown location");
+	}
+
+	private static boolean isPotentiallyTaskLocalException(Throwable throwable) {
+		return ExceptionUtils.findThrowable(throwable, CheckpointException.class)
+			.map(CheckpointException::getCheckpointFailureReason)
+			.map(reason -> {
+				switch (reason) {
+					case PERIODIC_SCHEDULER_SHUTDOWN:
+					case ALREADY_QUEUED:
+					case TOO_MANY_CONCURRENT_CHECKPOINTS:
+					case MINIMUM_TIME_BETWEEN_CHECKPOINTS:
+					case NOT_ALL_REQUIRED_TASKS_RUNNING:
+					case EXCEPTION:
+					case CHECKPOINT_COORDINATOR_SHUTDOWN:
+						return false;
+					default:
+						return true;
+				}
+			})
+			.orElse(true);
 	}
 }


### PR DESCRIPTION
Mirror of apache flink#9131
## What is the purpose of the change

This pull request is an attempt to address hanging Flink job when stop-with-savepoint fails due to decline of the savepoint by job's task. In such cases, the job manager would fail the whole execution graph (which may trigger a job restart).

## Brief change log

  - The `LegacyScheduler` is modified to track `CheckpointException`s in `stopWithSavepoint()` that originate from tasks and fails the execution graph for such exceptions.

## Verifying this change

This change was partially tested by manual e2e test:
 * configured Flink cluster with savepoints/checkpoints setup and `task.checkpoint.alignment.max-size: 64` set;
 * a test Flink job with two congested sources (joined in `map-1`) and events that exceed the configured limit (see execution graph below).

In the test job, the `map-1` with high probability rejects checkpoint/savepoints due to `checkpointSizeLimitExceeded`.

![job-graph](https://user-images.githubusercontent.com/488251/61300624-9b368600-a7e2-11e9-8d9c-62e936689a79.png)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

