### PR TITLE
Mirror of apache flink#9128

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/AdaptedRestartPipelinedRegionStrategyNG.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/AdaptedRestartPipelinedRegionStrategyNG.java
@@ -192,7 +192,7 @@ public class AdaptedRestartPipelinedRegionStrategyNG extends FailoverStrategy {
 			// abort pending checkpoints to
 			// i) enable new checkpoint triggering without waiting for last checkpoint expired.
 			// ii) ensure the EXACTLY_ONCE semantics if needed.
-			executionGraph.getCheckpointCoordinator().abortPendingCheckpoints(
+			executionGraph.getCheckpointCoordinator().abortPendingCheckpointsWithTriggerValidation(
 				new CheckpointException(CheckpointFailureReason.JOB_FAILOVER_REGION));
 
 			final Map<JobVertexID, ExecutionJobVertex> involvedExecutionJobVertices =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/AdaptedRestartPipelinedRegionStrategyNG.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/AdaptedRestartPipelinedRegionStrategyNG.java
@@ -192,7 +192,7 @@ public class AdaptedRestartPipelinedRegionStrategyNG extends FailoverStrategy {
 			// abort pending checkpoints to
 			// i) enable new checkpoint triggering without waiting for last checkpoint expired.
 			// ii) ensure the EXACTLY_ONCE semantics if needed.
-			executionGraph.getCheckpointCoordinator().abortPendingCheckpointsWithTriggerValidation(
+			executionGraph.getCheckpointCoordinator().abortPendingCheckpoints(
 				new CheckpointException(CheckpointFailureReason.JOB_FAILOVER_REGION));
 
 			final Map<JobVertexID, ExecutionJobVertex> involvedExecutionJobVertices =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailoverRegion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailoverRegion.java
@@ -209,10 +209,10 @@ public class FailoverRegion {
 			if (transitionState(JobStatus.CREATED, JobStatus.RUNNING)) {
 				// if we have checkpointed state, reload it into the executions
 				if (executionGraph.getCheckpointCoordinator() != null) {
-					// we restart the checkpoint scheduler for
+					// we abort pending checkpoints for
 					// i) enable new checkpoint could be triggered without waiting for last checkpoint expired.
 					// ii) ensure the EXACTLY_ONCE semantics if needed.
-					executionGraph.getCheckpointCoordinator().abortPendingCheckpoints(
+					executionGraph.getCheckpointCoordinator().abortPendingCheckpointsWithTriggerValidation(
 						new CheckpointException(CheckpointFailureReason.JOB_FAILOVER_REGION));
 
 					executionGraph.getCheckpointCoordinator().restoreLatestCheckpointedState(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailoverRegion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailoverRegion.java
@@ -212,7 +212,7 @@ public class FailoverRegion {
 					// we abort pending checkpoints for
 					// i) enable new checkpoint could be triggered without waiting for last checkpoint expired.
 					// ii) ensure the EXACTLY_ONCE semantics if needed.
-					executionGraph.getCheckpointCoordinator().abortPendingCheckpointsWithTriggerValidation(
+					executionGraph.getCheckpointCoordinator().abortPendingCheckpoints(
 						new CheckpointException(CheckpointFailureReason.JOB_FAILOVER_REGION));
 
 					executionGraph.getCheckpointCoordinator().restoreLatestCheckpointedState(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/FailoverStrategyCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/FailoverStrategyCheckpointCoordinatorTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.failover.AdaptedRestartPipelinedRegionStrategyNG;
+import org.apache.flink.runtime.executiongraph.failover.FailoverRegion;
+import org.apache.flink.runtime.executiongraph.failover.FailoverStrategy;
+import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
+import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+/**
+ * Tests for the interaction between the {@link FailoverStrategy} and the {@link CheckpointCoordinator}.
+ */
+public class FailoverStrategyCheckpointCoordinatorTest extends TestLogger {
+
+	/**
+	 * Tests that {@link CheckpointCoordinator#abortPendingCheckpointsWithTriggerValidation(CheckpointException)}
+	 * called by {@link AdaptedRestartPipelinedRegionStrategyNG} or {@link FailoverRegion} could handle
+	 * the {@code currentPeriodicTrigger} null situation well.
+	 */
+	@Test
+	public void testAbortPendingCheckpointsWithTriggerValidation() {
+		ExecutionVertex executionVertex = mockExecutionVertex();
+		CheckpointCoordinatorConfiguration checkpointCoordinatorConfiguration = new CheckpointCoordinatorConfiguration(
+			Integer.MAX_VALUE,
+			Integer.MAX_VALUE,
+			0,
+			1,
+			CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
+			true,
+			false,
+			0);
+		CheckpointCoordinator checkpointCoordinator = new CheckpointCoordinator(
+			new JobID(),
+			checkpointCoordinatorConfiguration,
+			new ExecutionVertex[] { executionVertex },
+			new ExecutionVertex[] { executionVertex },
+			new ExecutionVertex[] { executionVertex },
+			new StandaloneCheckpointIDCounter(),
+			new StandaloneCompletedCheckpointStore(1),
+			new MemoryStateBackend(),
+			Executors.directExecutor(),
+			SharedStateRegistry.DEFAULT_FACTORY,
+			mock(CheckpointFailureManager.class));
+
+		// switch current execution's state to running to allow checkpoint could be triggered.
+		mockExecutionRunning(executionVertex);
+
+		checkpointCoordinator.startCheckpointScheduler();
+		checkpointCoordinator.triggerCheckpoint(System.currentTimeMillis(), false);
+		assertTrue(checkpointCoordinator.isCurrentPeriodicTriggerAvailable());
+		checkpointCoordinator.triggerCheckpoint(System.currentTimeMillis() + 1, false);
+		// as we only support single concurrent checkpoint, after twice checkpoint trigger,
+		// the currentPeriodicTrigger would been assigned as null.
+		assertFalse(checkpointCoordinator.isCurrentPeriodicTriggerAvailable());
+		assertFalse(checkpointCoordinator.getPendingCheckpoints().isEmpty());
+
+		checkpointCoordinator.abortPendingCheckpointsWithTriggerValidation(
+			new CheckpointException(CheckpointFailureReason.JOB_FAILOVER_REGION));
+		// after aborting checkpoints, we ensure currentPeriodicTrigger still available.
+		assertTrue(checkpointCoordinator.isCurrentPeriodicTriggerAvailable());
+		assertTrue(checkpointCoordinator.getPendingCheckpoints().isEmpty());
+	}
+
+	private ExecutionVertex mockExecutionVertex() {
+		ExecutionAttemptID executionAttemptID = new ExecutionAttemptID();
+		ExecutionVertex executionVertex = mock(ExecutionVertex.class);
+		Execution execution = Mockito.mock(Execution.class);
+		when(execution.getAttemptId()).thenReturn(executionAttemptID);
+		when(executionVertex.getCurrentExecutionAttempt()).thenReturn(execution);
+		return executionVertex;
+	}
+
+	private void mockExecutionRunning(ExecutionVertex executionVertex) {
+		when(executionVertex.getCurrentExecutionAttempt().getState()).thenReturn(ExecutionState.RUNNING);
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/FailoverStrategyCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/FailoverStrategyCheckpointCoordinatorTest.java
@@ -19,7 +19,10 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.mock.Whitebox;
 import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
+import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -31,10 +34,19 @@ import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguratio
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.NeverCompleteFuture;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -44,20 +56,27 @@ import static org.powermock.api.mockito.PowerMockito.when;
  * Tests for the interaction between the {@link FailoverStrategy} and the {@link CheckpointCoordinator}.
  */
 public class FailoverStrategyCheckpointCoordinatorTest extends TestLogger {
+	private ManuallyTriggeredScheduledExecutor manualThreadExecutor;
+
+	@Before
+	public void setUp() {
+		manualThreadExecutor = new ManuallyTriggeredScheduledExecutor();
+	}
 
 	/**
-	 * Tests that {@link CheckpointCoordinator#abortPendingCheckpointsWithTriggerValidation(CheckpointException)}
+	 * Tests that {@link CheckpointCoordinator#abortPendingCheckpoints(CheckpointException)}
 	 * called by {@link AdaptedRestartPipelinedRegionStrategyNG} or {@link FailoverRegion} could handle
 	 * the {@code currentPeriodicTrigger} null situation well.
 	 */
 	@Test
 	public void testAbortPendingCheckpointsWithTriggerValidation() {
+		final int maxConcurrentCheckpoints = ThreadLocalRandom.current().nextInt(10) + 1;
 		ExecutionVertex executionVertex = mockExecutionVertex();
 		CheckpointCoordinatorConfiguration checkpointCoordinatorConfiguration = new CheckpointCoordinatorConfiguration(
 			Integer.MAX_VALUE,
 			Integer.MAX_VALUE,
 			0,
-			1,
+			maxConcurrentCheckpoints,
 			CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
 			true,
 			false,
@@ -78,20 +97,36 @@ public class FailoverStrategyCheckpointCoordinatorTest extends TestLogger {
 		// switch current execution's state to running to allow checkpoint could be triggered.
 		mockExecutionRunning(executionVertex);
 
-		checkpointCoordinator.startCheckpointScheduler();
-		checkpointCoordinator.triggerCheckpoint(System.currentTimeMillis(), false);
-		assertTrue(checkpointCoordinator.isCurrentPeriodicTriggerAvailable());
-		checkpointCoordinator.triggerCheckpoint(System.currentTimeMillis() + 1, false);
-		// as we only support single concurrent checkpoint, after twice checkpoint trigger,
-		// the currentPeriodicTrigger would been assigned as null.
-		assertFalse(checkpointCoordinator.isCurrentPeriodicTriggerAvailable());
-		assertFalse(checkpointCoordinator.getPendingCheckpoints().isEmpty());
+		// use manual checkpoint timer to trigger period checkpoints as we expect.
+		ManualCheckpointTimer manualCheckpointTimer = new ManualCheckpointTimer(manualThreadExecutor);
+		// set the init delay as 0 to ensure first checkpoint could be triggered once we trigger the manual executor
+		// this is used to avoid the randomness of when to trigger the first checkpoint (introduced via FLINK-9352)
+		manualCheckpointTimer.setManualDelay(0L);
+		Whitebox.setInternalState(checkpointCoordinator, "timer", manualCheckpointTimer);
 
-		checkpointCoordinator.abortPendingCheckpointsWithTriggerValidation(
+		checkpointCoordinator.startCheckpointScheduler();
+		assertTrue(checkpointCoordinator.isCurrentPeriodicTriggerAvailable());
+		manualThreadExecutor.triggerAll();
+		manualThreadExecutor.triggerScheduledTasks();
+		assertEquals(1, checkpointCoordinator.getNumberOfPendingCheckpoints());
+
+		for (int i = 1; i < maxConcurrentCheckpoints; i++) {
+			checkpointCoordinator.triggerCheckpoint(System.currentTimeMillis(), false);
+			assertEquals(i + 1, checkpointCoordinator.getNumberOfPendingCheckpoints());
+			assertTrue(checkpointCoordinator.isCurrentPeriodicTriggerAvailable());
+		}
+
+		// as we only support limited concurrent checkpoints, after checkpoint triggered more than the limits,
+		// the currentPeriodicTrigger would been assigned as null.
+		checkpointCoordinator.triggerCheckpoint(System.currentTimeMillis(), false);
+		assertFalse(checkpointCoordinator.isCurrentPeriodicTriggerAvailable());
+		assertEquals(maxConcurrentCheckpoints, checkpointCoordinator.getNumberOfPendingCheckpoints());
+
+		checkpointCoordinator.abortPendingCheckpoints(
 			new CheckpointException(CheckpointFailureReason.JOB_FAILOVER_REGION));
 		// after aborting checkpoints, we ensure currentPeriodicTrigger still available.
 		assertTrue(checkpointCoordinator.isCurrentPeriodicTriggerAvailable());
-		assertTrue(checkpointCoordinator.getPendingCheckpoints().isEmpty());
+		assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
 	}
 
 	private ExecutionVertex mockExecutionVertex() {
@@ -107,4 +142,45 @@ public class FailoverStrategyCheckpointCoordinatorTest extends TestLogger {
 		when(executionVertex.getCurrentExecutionAttempt().getState()).thenReturn(ExecutionState.RUNNING);
 	}
 
+	public static class ManualCheckpointTimer extends ScheduledThreadPoolExecutor {
+		private final ScheduledExecutor scheduledExecutor;
+		private long manualDelay = 0;
+
+		ManualCheckpointTimer(final ScheduledExecutor scheduledExecutor) {
+			super(0);
+			this.scheduledExecutor = scheduledExecutor;
+		}
+
+		void setManualDelay(long manualDelay) {
+			this.manualDelay = manualDelay;
+		}
+
+		@Override
+		public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+			// used as checkpoint canceller, as we don't want pending checkpoint cancelled, this should never be scheduled.
+			return new NeverCompleteFuture(delay);
+		}
+
+		@Override
+		public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+			// used to schedule periodic checkpoints.
+			// this would use configured 'manualDelay' to let the task schedule with the wanted delay.
+			return scheduledExecutor.scheduleWithFixedDelay(command, manualDelay, period, unit);
+		}
+
+		@Override
+		public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void execute(Runnable command) {
+			scheduledExecutor.execute(command);
+		}
+	}
 }


### PR DESCRIPTION
Mirror of apache flink#9128
##  What is the purpose of the change

After we introduce region failover, pending checkpoints would be aborted when task failed. However, previous implementation would come across a bug leading to periodical checkpoint is invalid.
Previously, when checkpoint coordinator trigger a checkpoint and the size of pending checkpoints is larger than `maxConcurrentCheckpointAttempts` (default 1), it would just assign the `currentPeriodicTrigger` to null. However, the pending checkpoints would then possibly be aborted due to region failover, which lead to no pending checkpoints and no `currentPeriodicTrigger`. In the end, the periodical checkpoint mechanism would become not valid anymore.

## Brief change log

  - Ensure when `CheckpointCoordinator` abort pending checkpoints, the `currentPeriodicTrigger` would must not be null.
  - Add test `FailoverStrategyCheckpointCoordinatorTest` to verify this case.

## Verifying this change

This change added tests and can be verified as follows:

  - Added test `FailoverStrategyCheckpointCoordinatorTest` to verify `currentPeriodicTrigger` is not null when `checkpointCoordinator#abortPendingCheckpointsWithTriggerValidation` is called.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**

