### PR TITLE
Mirror of apache flink#9126

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -1070,6 +1070,13 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 		slotManager.setFailUnfulfillableRequest(failUnfulfillableRequest);
 	}
 
+	/**
+	 * Returns whether {@link SlotManager} is to fail unfulfillable slot requests.
+	 */
+	boolean isFailingUnfulfillableRequest() {
+		return slotManager.isFailingUnfulfillableRequest();
+	}
+
 	// ------------------------------------------------------------------------
 	//  Static utility classes
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.resourcemanager;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -37,6 +38,7 @@ import javax.annotation.Nullable;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -90,6 +92,11 @@ public class StandaloneResourceManager extends ResourceManager<ResourceID> {
 				TimeUnit.MILLISECONDS
 			);
 		}
+	}
+
+	@VisibleForTesting
+	CompletableFuture<Boolean> isFailingUnfulfillableRequestAsync() {
+		return CompletableFuture.supplyAsync(this::isFailingUnfulfillableRequest, getMainThreadExecutor());
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManagerTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.rpc.TestingRpcServiceResource;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.SupplierWithException;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -43,7 +44,7 @@ import static org.junit.Assert.fail;
 /**
  * Tests for the Standalone Resource Manager.
  */
-public class StandaloneResourceManagerTest {
+public class StandaloneResourceManagerTest extends TestLogger {
 
 	@ClassRule
 	public static final TestingRpcServiceResource RPC_SERVICE = new TestingRpcServiceResource();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManagerTest.java
@@ -20,23 +20,24 @@ package org.apache.flink.runtime.resourcemanager;
 
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
-import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.resourcemanager.utils.MockResourceManagerRuntimeServices;
 import org.apache.flink.runtime.rpc.TestingRpcServiceResource;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.function.SupplierWithException;
 import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.time.Duration;
 import java.util.UUID;
-import java.util.function.Supplier;
+import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertFalse;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 /**
@@ -53,36 +54,29 @@ public class StandaloneResourceManagerTest {
 
 	@Test
 	public void testStartupPeriod() throws Exception {
-		final Tuple2<StandaloneResourceManager, SlotManager> managers = createResourceManagerAndSlotManager(Time.milliseconds(1));
-		final StandaloneResourceManager rm = managers.f0;
-		final SlotManager sm = managers.f1;
+		final StandaloneResourceManager rm = createResourceManager(Time.milliseconds(1L));
+		final Deadline deadline = Deadline.fromNow(Duration.ofSeconds(10L));
 
-		assertHappensUntil(sm::isFailingUnfulfillableRequest, Deadline.fromNow(Duration.ofSeconds(10)));
+		assertHappensUntil(() -> isFailingUnfulfillableRequest(rm), deadline);
 
 		rm.close();
 	}
 
 	@Test
 	public void testNoStartupPeriod() throws Exception {
-		final Tuple2<StandaloneResourceManager, SlotManager> managers = createResourceManagerAndSlotManager(Time.milliseconds(-1));
-		final StandaloneResourceManager rm = managers.f0;
-		final SlotManager sm = managers.f1;
+		final StandaloneResourceManager rm = createResourceManager(Time.milliseconds(-1L));
 
 		// startup includes initialization and granting leadership, so by the time we are
 		// here, the initialization method scheduling the startup period will have been executed.
 
-		assertFalse(fatalErrorHandler.hasExceptionOccurred());
-		assertFalse(sm.isFailingUnfulfillableRequest());
+		assertThat(fatalErrorHandler.hasExceptionOccurred(), is(false));
+
+		assertThat(isFailingUnfulfillableRequest(rm), is(false));
 
 		rm.close();
 	}
 
 	private StandaloneResourceManager createResourceManager(Time startupPeriod) throws Exception {
-		return createResourceManagerAndSlotManager(startupPeriod).f0;
-	}
-
-	private Tuple2<StandaloneResourceManager, SlotManager> createResourceManagerAndSlotManager(
-			Time startupPeriod) throws Exception {
 
 		final MockResourceManagerRuntimeServices rmServices = new MockResourceManagerRuntimeServices(
 			RPC_SERVICE.getTestingRpcService(),
@@ -105,10 +99,22 @@ public class StandaloneResourceManagerTest {
 		rm.start();
 		rmServices.grantLeadership();
 
-		return new Tuple2<>(rm, rmServices.slotManager);
+		return rm;
 	}
 
-	private static void assertHappensUntil(Supplier<Boolean> condition, Deadline until) throws InterruptedException {
+	private static boolean isFailingUnfulfillableRequest(
+			StandaloneResourceManager resourceManager) throws InterruptedException {
+		try {
+			return resourceManager.isFailingUnfulfillableRequestAsync().get();
+		} catch (ExecutionException e) {
+			ExceptionUtils.rethrow(e);
+			return false; // should be unreachable
+		}
+	}
+
+	private static void assertHappensUntil(
+			SupplierWithException<Boolean, InterruptedException> condition,
+			Deadline until) throws InterruptedException {
 		while (!condition.get()) {
 			if (!until.hasTimeLeft()) {
 				fail("condition was not fulfilled before the deadline");


### PR DESCRIPTION
Mirror of apache flink#9126
## What is the purpose of the change

In `StandaloneResourceManagerTest` we check `isFailingUnfulfillableRequest` in the test thread, although the underlying field `SlotManager.failUnfulfillableRequest` has no synchronisation and set in the main thread of `StandaloneResourceManager`. This can lead to a visibility problem of `SlotManager.failUnfulfillableRequest`: set in the main thread of `StandaloneResourceManager` but never updated in the test thread.

## Brief change log

The idea for the fix is read `SlotManager.failUnfulfillableRequest` in the main thread of `StandaloneResourceManager`, get future result and check in the `StandaloneResourceManagerTest.assertHappensUntil`.

## Verifying this change

run `StandaloneResourceManagerTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

