### PR TITLE
Mirror of apache flink#9125

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -50,6 +50,12 @@ public class SourceStreamTask<OUT, SRC extends SourceFunction<OUT>, OP extends S
 
 	private volatile boolean externallyInducedCheckpoints;
 
+	/**
+	 * Indicates whether this Task was purposefully finished (by finishTask()), in this case we
+	 * want to ignore exceptions thrown after finishing, to ensure shutdown works smoothly.
+	 */
+	private volatile boolean isFinished = false;
+
 	public SourceStreamTask(Environment env) {
 		super(env);
 	}
@@ -110,7 +116,12 @@ public class SourceStreamTask<OUT, SRC extends SourceFunction<OUT>, OP extends S
 		final LegacySourceFunctionThread sourceThread = new LegacySourceFunctionThread(getName());
 		sourceThread.start();
 		sourceThread.getCompletionFuture().whenComplete((Void ignore, Throwable sourceThreadThrowable) -> {
-			if (sourceThreadThrowable == null) {
+			if (sourceThreadThrowable == null || isFinished) {
+
+				// the isFinished is only set in the case of SYNC_SAVEPOINT. In this case, the final savepoint is
+				// already completed, so we do not risk the POISON_PILL to overpass the savepoint barrier and lead
+				// to a deadlock.
+
 				mailboxProcessor.allActionsCompleted();
 			} else {
 				mailboxProcessor.reportThrowable(sourceThreadThrowable);
@@ -127,10 +138,7 @@ public class SourceStreamTask<OUT, SRC extends SourceFunction<OUT>, OP extends S
 
 	@Override
 	protected void finishTask() throws Exception {
-		// We tell the mailbox to finish, to prevent any exceptions that might occur during
-		// finishing from leading to a FAILED state. This could happen, for example, when cancelling
-		// sources as part of a "stop-with-savepoint".
-		mailboxProcessor.allActionsCompleted();
+		isFinished = true;
 		cancelTask();
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -117,11 +117,6 @@ public class SourceStreamTask<OUT, SRC extends SourceFunction<OUT>, OP extends S
 		sourceThread.start();
 		sourceThread.getCompletionFuture().whenComplete((Void ignore, Throwable sourceThreadThrowable) -> {
 			if (sourceThreadThrowable == null || isFinished) {
-
-				// the isFinished is only set in the case of SYNC_SAVEPOINT. In this case, the final savepoint is
-				// already completed, so we do not risk the POISON_PILL to overpass the savepoint barrier and lead
-				// to a deadlock.
-
 				mailboxProcessor.allActionsCompleted();
 			} else {
 				mailboxProcessor.reportThrowable(sourceThreadThrowable);


### PR DESCRIPTION
Mirror of apache flink#9125
## What is the purpose of the change

This PR fixes the race condition that may manifest itself during `stop-with-savepoint`, as described in the related JIRA.

## Verifying this change

This change is already covered by existing tests, such as `SourceStreamTaskTest.finishingIgnoresExceptions()`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

