### PR TITLE
Mirror of apache flink#9244

### DIFF
--- a/docs/dev/connectors/filesystem_sink.md
+++ b/docs/dev/connectors/filesystem_sink.md
@@ -23,6 +23,10 @@ specific language governing permissions and limitations
 under the License.
 -->
 
+<div class="alert alert-info">
+The BucketingSink has been deprecated since Flink 1.9 and will be removed in subsequent releases. Please use the StreamingFileSink instead.
+</div>
+
 This connector provides a Sink that writes partitioned files to any filesystem supported by
 [Hadoop FileSystem](http://hadoop.apache.org). To use this connector, add the
 following dependency to your project:

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
@@ -160,6 +160,7 @@ import java.util.UUID;
  *
  * @param <T> Type of the elements emitted by this sink
  */
+@Deprecated
 public class BucketingSink<T>
 		extends RichSinkFunction<T>
 		implements InputTypeConfigurable, CheckpointedFunction, CheckpointListener, ProcessingTimeCallback {


### PR DESCRIPTION
Mirror of apache flink#9244
## What is the purpose of the change

It marks the `BucketingSink` as deprecated in favour of the `StreamingFileSink` and updates the documentation accordingly.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / **JavaDocs** / not documented)

