### PR TITLE
Mirror of apache flink#9242

### DIFF
--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
@@ -201,7 +201,6 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 		final ContaineredTaskManagerParameters containeredTaskManagerParameters = taskManagerParameters.containeredParameters();
 		this.slotsPerWorker = updateTaskManagerConfigAndCreateWorkerSlotProfiles(
 			flinkConfig, containeredTaskManagerParameters.taskManagerTotalMemoryMB(), containeredTaskManagerParameters.numSlots());
-		setFailUnfulfillableRequest(true);
 	}
 
 	protected ActorRef createSelfActor() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -930,6 +930,8 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
 			slotManager.start(getFencingToken(), getMainThreadExecutor(), new ResourceActionsImpl());
 
+			setFailUnfulfillableRequest(true);
+
 			return prepareLeadershipAsync().thenApply(ignored -> true);
 		} else {
 			return CompletableFuture.completedFuture(false);
@@ -952,6 +954,8 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 				slotManager.suspend();
 
 				stopHeartbeatServices();
+
+				setFailUnfulfillableRequest(false);
 			});
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
@@ -80,16 +80,7 @@ public class StandaloneResourceManager extends ResourceManager<ResourceID> {
 
 	@Override
 	protected void initialize() throws ResourceManagerException {
-		final long startupPeriodMillis = startupPeriodTime.toMilliseconds();
-
-		if (startupPeriodMillis > 0) {
-			getRpcService().getScheduledExecutor().schedule(
-				() -> getMainThreadExecutor().execute(
-					() -> setFailUnfulfillableRequest(true)),
-				startupPeriodMillis,
-				TimeUnit.MILLISECONDS
-			);
-		}
+		setFailUnfulfillableRequest(true);
 	}
 
 	@Override
@@ -112,4 +103,21 @@ public class StandaloneResourceManager extends ResourceManager<ResourceID> {
 		return resourceID;
 	}
 
+	@Override
+	protected void setFailUnfulfillableRequest(boolean failUnfulfillableRequest) {
+		if (failUnfulfillableRequest) {
+			final long startupPeriodMillis = startupPeriodTime.toMilliseconds();
+
+			if (startupPeriodMillis > 0) {
+				getRpcService().getScheduledExecutor().schedule(
+					() -> getMainThreadExecutor().execute(
+						() -> super.setFailUnfulfillableRequest(failUnfulfillableRequest)),
+					startupPeriodMillis,
+					TimeUnit.MILLISECONDS
+				);
+			}
+		} else {
+			super.setFailUnfulfillableRequest(failUnfulfillableRequest);
+		}
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
@@ -80,7 +80,7 @@ public class StandaloneResourceManager extends ResourceManager<ResourceID> {
 
 	@Override
 	protected void initialize() throws ResourceManagerException {
-		setFailUnfulfillableRequest(true);
+		// nothing to initialize
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/MockResourceManagerRuntimeServices.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/MockResourceManagerRuntimeServices.java
@@ -75,4 +75,8 @@ public class MockResourceManagerRuntimeServices {
 		UUID rmLeaderSessionId = UUID.randomUUID();
 		rmLeaderElectionService.isLeader(rmLeaderSessionId).get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 	}
+
+	public void revokeLeadership() {
+		rmLeaderElectionService.notLeader();
+	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -185,7 +185,6 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 		this.resource = Resource.newInstance(defaultTaskManagerMemoryMB, defaultCpus);
 
 		this.slotsPerWorker = updateTaskManagerConfigAndCreateWorkerSlotProfiles(flinkConfig, defaultTaskManagerMemoryMB, numberOfTaskSlots);
-		setFailUnfulfillableRequest(true);
 	}
 
 	protected AMRMClientAsync<AMRMClient.ContainerRequest> createAndStartResourceManagerClient(


### PR DESCRIPTION
Mirror of apache flink#9242
## What is the purpose of the change

We introduced `StandaloneResourceManager#setFailUnfulfillableRequest` to give some time to task executors to register the available slots before the slot requests can be checked whether they can be fulfilled or not. `setFailUnfulfillableRequest` is scheduled now only once when the RM is initialized but the task executors will register themselves every time this RM gets the leadership. Hence, `setFailUnfulfillableRequest` should be scheduled after each leader election.

## Brief change log

- 5ff534941925c49556462d188b9457334b4f1026: Override `StandaloneResourceManager#setFailUnfulfillableRequest` to schedule invoking `ResourceManager#setFailUnfulfillableRequest` respecting the start up period.
- e41db5e0470c5de4bf998c4fb4b6ca719fd6acb3: Resource managers set fail unfulfillable requests when leadership is granted, and reset it when leadership is revoked.
- bc4bc3a00e1692381368af36b87d233677e8c4ac: Add `StandaloneResourceManagerTest#testStartUpPeriodAfterLeadershipSwitch` validates that StandaloneResourceManager applies a startup period whenever the leadership is acquired.

## Verifying this change

This change added tests and can be verified as follows:

- Add `StandaloneResourceManagerTest#testStartUpPeriodAfterLeadershipSwitch` validates that StandaloneResourceManager applies a startup period whenever the leadership is acquired.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

