### PR TITLE
Mirror of apache flink#9239

### DIFF
--- a/docs/dev/table/catalog.md
+++ b/docs/dev/table/catalog.md
@@ -168,8 +168,8 @@ Currently `HiveCatalog` supports most Flink data types with the following mappin
 | VARCHAR(p)    |  varchar(p)** |
 | STRING        |  string |
 | BOOLEAN       |  boolean |
-| BYTE          |  tinyint |
-| SHORT         |  smallint |
+| TINYINT       |  tinyint |
+| SMALLINT      |  smallint |
 | INT           |  int |
 | BIGINT        |  long |
 | FLOAT         |  float |
@@ -179,10 +179,11 @@ Currently `HiveCatalog` supports most Flink data types with the following mappin
 | TIMESTAMP_WITHOUT_TIME_ZONE |  Timestamp |
 | TIMESTAMP_WITH_TIME_ZONE |  N/A |
 | TIMESTAMP_WITH_LOCAL_TIME_ZONE |  N/A |
-| INTERVAL |  N/A |
-| BINARY        |  binary |
-| VARBINARY(p)  |  binary |
-| ARRAY\<E>     |  list\<E> |
+| INTERVAL      |   N/A*** |
+| BINARY        |   N/A |
+| VARBINARY(p)  |   N/A |
+| BYTES         |   BINARY |
+| ARRAY\<E>     |  ARRAY\<E> |
 | MAP<K, V>     |  map<K, V> |
 | ROW           |  struct |
 | MULTISET      |  N/A |
@@ -196,6 +197,7 @@ The following limitations in Hive's data types impact the mapping between Flink 
 
 \** maximum length is 65535
 
+\*** `INTERVAL` type can not be mapped to hive `INTERVAL` for now.
 
 Catalog Registration
 --------------------

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTypeUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTypeUtil.java
@@ -103,9 +103,6 @@ public class HiveTypeUtil {
 				return TypeInfoFactory.dateTypeInfo;
 			} else if (type.equals(LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)) {
 				return TypeInfoFactory.timestampTypeInfo;
-			} else if (type.equals(LogicalTypeRoot.BINARY) || type.equals(LogicalTypeRoot.VARBINARY)) {
-				// Hive doesn't support variable-length binary string
-				return TypeInfoFactory.binaryTypeInfo;
 			} else if (type.equals(LogicalTypeRoot.CHAR)) {
 				CharType charType = (CharType) dataType.getLogicalType();
 
@@ -144,6 +141,11 @@ public class HiveTypeUtil {
 			}
 
 			// Flink's primitive types that Hive 2.3.4 doesn't support: Time, TIMESTAMP_WITH_LOCAL_TIME_ZONE
+		}
+
+		if (dataType.equals(DataTypes.BYTES())) {
+			// Hive doesn't support variable-length binary string
+			return TypeInfoFactory.binaryTypeInfo;
 		}
 
 		if (dataType instanceof CollectionDataType) {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogDataTypeTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogDataTypeTest.java
@@ -28,8 +28,6 @@ import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.config.CatalogConfig;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.types.logical.BinaryType;
-import org.apache.flink.table.types.logical.VarBinaryType;
 
 import org.apache.hadoop.hive.common.type.HiveChar;
 import org.apache.hadoop.hive.common.type.HiveVarchar;
@@ -124,8 +122,8 @@ public class HiveCatalogDataTypeTest {
 	@Test
 	public void testNonExactlyMatchedDataTypes() throws Exception {
 		DataType[] types = new DataType[] {
-			DataTypes.BINARY(BinaryType.MAX_LENGTH),
-			DataTypes.VARBINARY(VarBinaryType.MAX_LENGTH)
+			DataTypes.BYTES(),
+			DataTypes.BYTES()
 		};
 
 		CatalogTable table = createCatalogTable(types);

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
@@ -88,7 +88,7 @@ public class HiveCatalogHiveMetadataTest extends CatalogTestBase {
 											.field("fourth", DataTypes.DATE())
 											.field("fifth", DataTypes.DOUBLE())
 											.field("sixth", DataTypes.BIGINT())
-											.field("seventh", DataTypes.VARBINARY(200))
+											.field("seventh", DataTypes.BYTES())
 											.build();
 		CatalogTable catalogTable = new CatalogTableImpl(tableSchema, getBatchTableProperties(), TEST_COMMENT);
 		catalog.createTable(path1, catalogTable, false);


### PR DESCRIPTION
Mirror of apache flink#9239
## What is the purpose of the change
Align Hive data type mapping with FLIP-37. 


## Brief change log
  - *Align Hive data type mapping with FLIP-37*
  - *Not support interval type mapping for now. It's not type mapping related only, also related to data converting, maybe we can do it in the future.*


## Verifying this change

This change is already covered by existing tests, such as *HiveCatalogDataTypeTest.java*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )

