### PR TITLE
Mirror of apache flink#9238

### DIFF
--- a/flink-runtime-web/web-dashboard/old-version/partials/taskmanager/taskmanager.log.html
+++ b/flink-runtime-web/web-dashboard/old-version/partials/taskmanager/taskmanager.log.html
@@ -24,7 +24,7 @@ limitations under the License.
         <div class="row">
           <div class="col-xs-10">Task Manager Logs</div>
           <div class="col-xs-1 text-right"><a ng-click="reloadData()" class="show-pointer"><i class="fa fa-refresh"></i></a></div>
-          <div class="col-xs-1 text-left"><a href="taskmanagers/{{taskmanagerid}}/log"><i class="fa fa-download"></i></a></div>
+          <div class="col-xs-1 text-left"><a href="../taskmanagers/{{taskmanagerid}}/log"><i class="fa fa-download"></i></a></div>
         </div>
       </th>
     </tr>

--- a/flink-runtime-web/web-dashboard/old-version/partials/taskmanager/taskmanager.stdout.html
+++ b/flink-runtime-web/web-dashboard/old-version/partials/taskmanager/taskmanager.stdout.html
@@ -24,7 +24,7 @@ limitations under the License.
         <div class="row">
           <div class="col-xs-10">Task Manager Output</div>
           <div class="col-xs-1 text-right"><a ng-click="reloadData()" class="show-pointer"><i class="fa fa-refresh"></i></a></div>
-          <div class="col-xs-1 text-left"><a href="taskmanagers/{{taskmanagerid}}/stdout"><i class="fa fa-download"></i></a></div>
+          <div class="col-xs-1 text-left"><a href="../taskmanagers/{{taskmanagerid}}/stdout"><i class="fa fa-download"></i></a></div>
         </div>
       </th>
     </tr>


### PR DESCRIPTION
Mirror of apache flink#9238
Corrects the URLs used by the WebUI when downloading the logs. When using the WebUI the URL contains a `old-version` prefix, which leaks into the relative path defined in the `.html` files. The JS files are unaffected as they ignore the prefix and have their own way of assembling URLs.

This PR simply modifies the `href` to go up one layer, which effectively removes the prefix from the call.
