### PR TITLE
Mirror of apache flink#9236

### DIFF
--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTypeUtil.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTypeUtil.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.io.jdbc;
 
+import org.apache.flink.api.common.typeinfo.LocalTimeTypeInfo;
 import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -56,6 +57,9 @@ class JDBCTypeUtil {
 		m.put(SqlTimeTypeInfo.DATE, Types.DATE);
 		m.put(SqlTimeTypeInfo.TIME, Types.TIME);
 		m.put(SqlTimeTypeInfo.TIMESTAMP, Types.TIMESTAMP);
+		m.put(LocalTimeTypeInfo.LOCAL_DATE, Types.DATE);
+		m.put(LocalTimeTypeInfo.LOCAL_TIME, Types.TIME);
+		m.put(LocalTimeTypeInfo.LOCAL_DATE_TIME, Types.TIMESTAMP);
 		m.put(BIG_DEC_TYPE_INFO, Types.DECIMAL);
 		m.put(BYTE_PRIMITIVE_ARRAY_TYPE_INFO, Types.BINARY);
 		TYPE_MAPPING = Collections.unmodifiableMap(m);

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCFullTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCFullTest.java
@@ -95,8 +95,12 @@ public class JDBCFullTest extends JDBCTestBase {
 		source.output(JDBCOutputFormat.buildJDBCOutputFormat()
 				.setDrivername(JDBCTestBase.DRIVER_CLASS)
 				.setDBUrl(JDBCTestBase.DB_URL)
-				.setQuery("insert into newbooks (id, title, author, price, qty) values (?,?,?,?,?)")
-				.setSqlTypes(new int[]{Types.INTEGER, Types.VARCHAR, Types.VARCHAR, Types.DOUBLE, Types.INTEGER})
+				.setQuery("insert into newbooks (" +
+					"id, title, author, price, qty, print_date, print_time, print_timestamp) values (" +
+					"?,?,?,?,?,?,?,?)")
+				.setSqlTypes(new int[]{
+					Types.INTEGER, Types.VARCHAR, Types.VARCHAR, Types.DOUBLE, Types.INTEGER,
+					Types.DATE, Types.TIME, Types.TIMESTAMP})
 				.finish());
 
 		environment.execute();

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCOutputFormatTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCOutputFormatTest.java
@@ -30,7 +30,9 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.sql.Types;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -97,12 +99,15 @@ public class JDBCOutputFormatTest extends JDBCTestBase {
 				.finish();
 		jdbcOutputFormat.open(0, 1);
 
-		Row row = new Row(5);
+		Row row = new Row(8);
 		row.setField(0, 4);
 		row.setField(1, "hello");
 		row.setField(2, "world");
 		row.setField(3, 0.99);
 		row.setField(4, "imthewrongtype");
+		row.setField(5, LocalDate.of(2011, 1, 11));
+		row.setField(6, LocalTime.of(1, 1, 11));
+		row.setField(7, LocalDateTime.of(2011, 1, 11, 1, 1, 11));
 
 		jdbcOutputFormat.writeRecord(row);
 		jdbcOutputFormat.close();
@@ -114,22 +119,20 @@ public class JDBCOutputFormatTest extends JDBCTestBase {
 			.setDrivername(DRIVER_CLASS)
 			.setDBUrl(DB_URL)
 			.setQuery(String.format(INSERT_TEMPLATE, OUTPUT_TABLE))
-			.setSqlTypes(new int[] {
-				Types.INTEGER,
-				Types.VARCHAR,
-				Types.VARCHAR,
-				Types.DOUBLE,
-				Types.INTEGER})
+			.setSqlTypes(SQL_TYPES)
 			.finish();
 		jdbcOutputFormat.open(0, 1);
 
 		JDBCTestBase.TestEntry entry = TEST_DATA[0];
-		Row row = new Row(5);
+		Row row = new Row(8);
 		row.setField(0, entry.id);
 		row.setField(1, entry.title);
 		row.setField(2, entry.author);
 		row.setField(3, 0L); // use incompatible type (Long instead of Double)
 		row.setField(4, entry.qty);
+		row.setField(5, LocalDate.of(2011, 1, 11));
+		row.setField(6, LocalTime.of(1, 1, 11));
+		row.setField(7, LocalDateTime.of(2011, 1, 11, 1, 1, 11));
 		jdbcOutputFormat.writeRecord(row);
 	}
 
@@ -140,22 +143,20 @@ public class JDBCOutputFormatTest extends JDBCTestBase {
 			.setDrivername(DRIVER_CLASS)
 			.setDBUrl(DB_URL)
 			.setQuery(String.format(INSERT_TEMPLATE, OUTPUT_TABLE))
-			.setSqlTypes(new int[] {
-				Types.INTEGER,
-				Types.VARCHAR,
-				Types.VARCHAR,
-				Types.DOUBLE,
-				Types.INTEGER})
+			.setSqlTypes(SQL_TYPES)
 			.finish();
 		jdbcOutputFormat.open(0, 1);
 
 		JDBCTestBase.TestEntry entry = TEST_DATA[0];
-		Row row = new Row(5);
+		Row row = new Row(8);
 		row.setField(0, entry.id);
 		row.setField(1, entry.title);
 		row.setField(2, entry.author);
 		row.setField(3, entry.price);
 		row.setField(4, entry.qty);
+		row.setField(5, entry.printDate);
+		row.setField(6, entry.printTime);
+		row.setField(7, entry.printTimestamp);
 		jdbcOutputFormat.writeRecord(row);
 		jdbcOutputFormat.writeRecord(row); // writing the same record twice must yield a unique key violation.
 
@@ -168,6 +169,7 @@ public class JDBCOutputFormatTest extends JDBCTestBase {
 				.setDrivername(DRIVER_CLASS)
 				.setDBUrl(DB_URL)
 				.setQuery(String.format(INSERT_TEMPLATE, OUTPUT_TABLE))
+				.setSqlTypes(SQL_TYPES)
 				.finish();
 		jdbcOutputFormat.open(0, 1);
 
@@ -182,17 +184,7 @@ public class JDBCOutputFormatTest extends JDBCTestBase {
 			PreparedStatement statement = dbConn.prepareStatement(JDBCTestBase.SELECT_ALL_NEWBOOKS);
 			ResultSet resultSet = statement.executeQuery()
 		) {
-			int recordCount = 0;
-			while (resultSet.next()) {
-				assertEquals(TEST_DATA[recordCount].id, resultSet.getObject("id"));
-				assertEquals(TEST_DATA[recordCount].title, resultSet.getObject("title"));
-				assertEquals(TEST_DATA[recordCount].author, resultSet.getObject("author"));
-				assertEquals(TEST_DATA[recordCount].price, resultSet.getObject("price"));
-				assertEquals(TEST_DATA[recordCount].qty, resultSet.getObject("qty"));
-
-				recordCount++;
-			}
-			assertEquals(TEST_DATA.length, recordCount);
+			checkEquals(resultSet, TEST_DATA.length);
 		}
 	}
 
@@ -203,6 +195,7 @@ public class JDBCOutputFormatTest extends JDBCTestBase {
 			.setDBUrl(DB_URL)
 			.setQuery(String.format(INSERT_TEMPLATE, OUTPUT_TABLE_2))
 			.setBatchInterval(3)
+			.setSqlTypes(SQL_TYPES)
 			.finish();
 		try (
 			Connection dbConn = DriverManager.getConnection(DB_URL);
@@ -217,16 +210,7 @@ public class JDBCOutputFormatTest extends JDBCTestBase {
 			}
 			jdbcOutputFormat.writeRecord(toRow(TEST_DATA[2]));
 			try (ResultSet resultSet = statement.executeQuery()) {
-				int recordCount = 0;
-				while (resultSet.next()) {
-					assertEquals(TEST_DATA[recordCount].id, resultSet.getObject("id"));
-					assertEquals(TEST_DATA[recordCount].title, resultSet.getObject("title"));
-					assertEquals(TEST_DATA[recordCount].author, resultSet.getObject("author"));
-					assertEquals(TEST_DATA[recordCount].price, resultSet.getObject("price"));
-					assertEquals(TEST_DATA[recordCount].qty, resultSet.getObject("qty"));
-					recordCount++;
-				}
-				assertEquals(3, recordCount);
+				checkEquals(resultSet, 3);
 			}
 		} finally {
 			jdbcOutputFormat.close();
@@ -246,13 +230,40 @@ public class JDBCOutputFormatTest extends JDBCTestBase {
 		}
 	}
 
+	private void checkEquals(ResultSet resultSet, int cnt) throws SQLException {
+		int recordCount = 0;
+		while (resultSet.next()) {
+			assertEquals(TEST_DATA[recordCount].id, resultSet.getObject("id"));
+			assertEquals(TEST_DATA[recordCount].title, resultSet.getObject("title"));
+			assertEquals(TEST_DATA[recordCount].author, resultSet.getObject("author"));
+			assertEquals(TEST_DATA[recordCount].price, resultSet.getObject("price"));
+			assertEquals(TEST_DATA[recordCount].qty, resultSet.getObject("qty"));
+			// Note that we're directly fetching date/time objects from database, so their types must be java.sql types
+			assertEquals(
+				java.sql.Date.valueOf(TEST_DATA[recordCount].printDate),
+				resultSet.getObject("print_date"));
+			assertEquals(
+				java.sql.Time.valueOf(TEST_DATA[recordCount].printTime),
+				resultSet.getObject("print_time"));
+			assertEquals(
+				java.sql.Timestamp.valueOf(TEST_DATA[recordCount].printTimestamp),
+				resultSet.getObject("print_timestamp"));
+
+			recordCount++;
+		}
+		assertEquals(cnt, recordCount);
+	}
+
 	static Row toRow(TestEntry entry) {
-		Row row = new Row(5);
+		Row row = new Row(8);
 		row.setField(0, entry.id);
 		row.setField(1, entry.title);
 		row.setField(2, entry.author);
 		row.setField(3, entry.price);
 		row.setField(4, entry.qty);
+		row.setField(5, entry.printDate);
+		row.setField(6, entry.printTime);
+		row.setField(7, entry.printTimestamp);
 		return row;
 	}
 }

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTestBase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.java.io.jdbc;
 
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.LocalTimeTypeInfo;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 
 import org.junit.AfterClass;
@@ -31,6 +32,10 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Types;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 /**
  * Base test class for JDBC Input and Output formats.
@@ -49,36 +54,78 @@ public class JDBCTestBase {
 	public static final String SELECT_ALL_NEWBOOKS = "select * from " + OUTPUT_TABLE;
 	public static final String SELECT_ALL_NEWBOOKS_2 = "select * from " + OUTPUT_TABLE_2;
 	public static final String SELECT_EMPTY = "select * from books WHERE QTY < 0";
-	public static final String INSERT_TEMPLATE = "insert into %s (id, title, author, price, qty) values (?,?,?,?,?)";
+	public static final String INSERT_TEMPLATE =
+		"insert into %s (" +
+			"id, title, author, price, qty, print_date, print_time, print_timestamp) values (?,?,?,?,?,?,?,?)";
 	public static final String SELECT_ALL_BOOKS_SPLIT_BY_ID = SELECT_ALL_BOOKS + " WHERE id BETWEEN ? AND ?";
 	public static final String SELECT_ALL_BOOKS_SPLIT_BY_AUTHOR = SELECT_ALL_BOOKS + " WHERE author = ?";
+	public static final String SELECT_ALL_BOOKS_SPLIT_BY_TIMESTAMP =
+		SELECT_ALL_BOOKS + " WHERE print_timestamp BETWEEN ? AND ?";
 
 	public static final TestEntry[] TEST_DATA = {
-			new TestEntry(1001, ("Java public for dummies"), ("Tan Ah Teck"), 11.11, 11),
-			new TestEntry(1002, ("More Java for dummies"), ("Tan Ah Teck"), 22.22, 22),
-			new TestEntry(1003, ("More Java for more dummies"), ("Mohammad Ali"), 33.33, 33),
-			new TestEntry(1004, ("A Cup of Java"), ("Kumar"), 44.44, 44),
-			new TestEntry(1005, ("A Teaspoon of Java"), ("Kevin Jones"), 55.55, 55),
-			new TestEntry(1006, ("A Teaspoon of Java 1.4"), ("Kevin Jones"), 66.66, 66),
-			new TestEntry(1007, ("A Teaspoon of Java 1.5"), ("Kevin Jones"), 77.77, 77),
-			new TestEntry(1008, ("A Teaspoon of Java 1.6"), ("Kevin Jones"), 88.88, 88),
-			new TestEntry(1009, ("A Teaspoon of Java 1.7"), ("Kevin Jones"), 99.99, 99),
-			new TestEntry(1010, ("A Teaspoon of Java 1.8"), ("Kevin Jones"), null, 1010)
+			new TestEntry(
+				1001, ("Java public for dummies"), ("Tan Ah Teck"), 11.11, 11,
+				LocalDate.of(2011, 1, 11), LocalTime.of(1, 1, 11),
+				LocalDateTime.of(2011, 1, 11, 1, 1, 11)),
+			new TestEntry(
+				1002, ("More Java for dummies"), ("Tan Ah Teck"), 22.22, 22,
+				LocalDate.of(2012, 2, 12), LocalTime.of(2, 2, 12),
+				LocalDateTime.of(2012, 2, 12, 2, 2, 12)),
+			new TestEntry(
+				1003, ("More Java for more dummies"), ("Mohammad Ali"), 33.33, 33,
+				LocalDate.of(2013, 3, 13), LocalTime.of(3, 3, 13),
+				LocalDateTime.of(2013, 3, 13, 3, 3, 13)),
+			new TestEntry(
+				1004, ("A Cup of Java"), ("Kumar"), 44.44, 44,
+				LocalDate.of(2014, 4, 14), LocalTime.of(4, 4, 14),
+				LocalDateTime.of(2014, 4, 14, 4, 4, 14)),
+			new TestEntry(
+				1005, ("A Teaspoon of Java"), ("Kevin Jones"), 55.55, 55,
+				LocalDate.of(2015, 5, 15), LocalTime.of(5, 5, 15),
+				LocalDateTime.of(2015, 5, 15, 5, 5, 15)),
+			new TestEntry(
+				1006, ("A Teaspoon of Java 1.4"), ("Kevin Jones"), 66.66, 66,
+				LocalDate.of(2016, 6, 16), LocalTime.of(6, 6, 16),
+				LocalDateTime.of(2016, 6, 16, 6, 6, 16)),
+			new TestEntry(
+				1007, ("A Teaspoon of Java 1.5"), ("Kevin Jones"), 77.77, 77,
+				LocalDate.of(2017, 7, 17), LocalTime.of(7, 7, 17),
+				LocalDateTime.of(2017, 7, 17, 7, 7, 17)),
+			new TestEntry(
+				1008, ("A Teaspoon of Java 1.6"), ("Kevin Jones"), 88.88, 88,
+				LocalDate.of(2018, 8, 18), LocalTime.of(8, 8, 18),
+				LocalDateTime.of(2018, 8, 18, 8, 8, 18)),
+			new TestEntry(
+				1009, ("A Teaspoon of Java 1.7"), ("Kevin Jones"), 99.99, 99,
+				LocalDate.of(2019, 9, 19), LocalTime.of(9, 9, 19),
+				LocalDateTime.of(2019, 9, 19, 9, 9, 19)),
+			new TestEntry(
+				1010, ("A Teaspoon of Java 1.8"), ("Kevin Jones"), null, 1010,
+				LocalDate.of(2020, 10, 20), LocalTime.of(10, 10, 20),
+				LocalDateTime.of(2020, 10, 20, 10, 10, 20))
 	};
 
 	static class TestEntry {
-		protected final Integer id;
-		protected final String title;
-		protected final String author;
-		protected final Double price;
-		protected final Integer qty;
+		final Integer id;
+		final String title;
+		final String author;
+		final Double price;
+		final Integer qty;
+		final LocalDate printDate;
+		final LocalTime printTime;
+		final LocalDateTime printTimestamp;
 
-		private TestEntry(Integer id, String title, String author, Double price, Integer qty) {
+		private TestEntry(
+				Integer id, String title, String author, Double price, Integer qty,
+				LocalDate printDate, LocalTime printTime, LocalDateTime printTimestamp) {
 			this.id = id;
 			this.title = title;
 			this.author = author;
 			this.price = price;
 			this.qty = qty;
+			this.printDate = printDate;
+			this.printTime = printTime;
+			this.printTimestamp = printTimestamp;
 		}
 	}
 
@@ -87,35 +134,54 @@ public class JDBCTestBase {
 		BasicTypeInfo.STRING_TYPE_INFO,
 		BasicTypeInfo.STRING_TYPE_INFO,
 		BasicTypeInfo.DOUBLE_TYPE_INFO,
-		BasicTypeInfo.INT_TYPE_INFO);
+		BasicTypeInfo.INT_TYPE_INFO,
+		LocalTimeTypeInfo.LOCAL_DATE,
+		LocalTimeTypeInfo.LOCAL_TIME,
+		LocalTimeTypeInfo.LOCAL_DATE_TIME);
+
+	public static final int[] SQL_TYPES = new int[] {
+		Types.INTEGER,
+		Types.VARCHAR,
+		Types.VARCHAR,
+		Types.DOUBLE,
+		Types.INTEGER,
+		Types.DATE,
+		Types.TIME,
+		Types.TIMESTAMP};
 
 	public static String getCreateQuery(String tableName) {
-		StringBuilder sqlQueryBuilder = new StringBuilder("CREATE TABLE ");
-		sqlQueryBuilder.append(tableName).append(" (");
-		sqlQueryBuilder.append("id INT NOT NULL DEFAULT 0,");
-		sqlQueryBuilder.append("title VARCHAR(50) DEFAULT NULL,");
-		sqlQueryBuilder.append("author VARCHAR(50) DEFAULT NULL,");
-		sqlQueryBuilder.append("price FLOAT DEFAULT NULL,");
-		sqlQueryBuilder.append("qty INT DEFAULT NULL,");
-		sqlQueryBuilder.append("PRIMARY KEY (id))");
-		return sqlQueryBuilder.toString();
+		return "CREATE TABLE " +
+			tableName + " (" +
+			"id INT NOT NULL DEFAULT 0," +
+			"title VARCHAR(50) DEFAULT NULL," +
+			"author VARCHAR(50) DEFAULT NULL," +
+			"price FLOAT DEFAULT NULL," +
+			"qty INT DEFAULT NULL," +
+			"print_date DATE DEFAULT NULL," +
+			"print_time TIME DEFAULT NULL," +
+			"print_timestamp TIMESTAMP DEFAULT NULL," +
+			"PRIMARY KEY (id))";
 	}
 
 	public static String getInsertQuery() {
-		StringBuilder sqlQueryBuilder = new StringBuilder("INSERT INTO books (id, title, author, price, qty) VALUES ");
+		StringBuilder sqlQueryBuilder = new StringBuilder(
+			"INSERT INTO books (id, title, author, price, qty, print_date, print_time, print_timestamp) VALUES ");
 		for (int i = 0; i < TEST_DATA.length; i++) {
 			sqlQueryBuilder.append("(")
 			.append(TEST_DATA[i].id).append(",'")
 			.append(TEST_DATA[i].title).append("','")
 			.append(TEST_DATA[i].author).append("',")
 			.append(TEST_DATA[i].price).append(",")
-			.append(TEST_DATA[i].qty).append(")");
+			.append(TEST_DATA[i].qty).append(",")
+			.append("'").append(TEST_DATA[i].printDate).append("',")
+			.append("'").append(TEST_DATA[i].printTime).append("',")
+			.append("'").append(
+				TEST_DATA[i].printTimestamp.toString().replace('T', ' ')).append("')");
 			if (i < TEST_DATA.length - 1) {
 				sqlQueryBuilder.append(",");
 			}
 		}
-		String insertQuery = sqlQueryBuilder.toString();
-		return insertQuery;
+		return sqlQueryBuilder.toString();
 	}
 
 	public static final OutputStream DEV_NULL = new OutputStream() {


### PR DESCRIPTION
Mirror of apache flink#9236
## What is the purpose of the change

Currently JDBC connector does not support DataTypes.DATE/TIME/TIMESTAMP with their default conversion classes to be LocalDate/LocalTime/LocalDateTime. This PR fixes the support of these data types for JDBC connector.

## Brief change log

 - Fix JDBC connector with DataTypes.DATE/TIME/TIMESTAMP support

## Verifying this change

This change is already covered by existing tests, such as the existing tests in the jdbc connector package. This PR updates these tests with some time data types.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

