### PR TITLE
Mirror of apache flink#9235

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/core/fs/AbstractRecoverableWriterTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/AbstractRecoverableWriterTest.java
@@ -331,7 +331,7 @@ public abstract class AbstractRecoverableWriterTest extends TestLogger {
 
 		RecoverableWriter.ResumeRecoverable recoverable;
 		RecoverableFsDataOutputStream stream = null;
-		try{
+		try {
 			stream = writer.open(path);
 			stream.write(testData1.getBytes(StandardCharsets.UTF_8));
 


### PR DESCRIPTION
Mirror of apache flink#9235
## What is the purpose of the change
Currently test cases will fail when trying to close the output stream if all data written but `ClosedByInterruptException` occurs at the ending phase. This PR proposes to close the stream silently if the test case logic passed properly.

## Brief change log
Close the output stream silently in `HadoopRecoverableWriterTest` if the test case logic passed properly.


## Verifying this change
This change is on the test cases and verified by sanity test through modifying hadoop source code to simulate the rarely happening situation that triggers the issue.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

