### PR TITLE
Mirror of apache flink#9228

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketFactory.java
@@ -38,7 +38,9 @@ interface BucketFactory<IN, BucketID> extends Serializable {
 			final Path bucketPath,
 			final long initialPartCounter,
 			final PartFileWriter.PartFileFactory<IN, BucketID> partFileWriterFactory,
-			final RollingPolicy<IN, BucketID> rollingPolicy) throws IOException;
+			final RollingPolicy<IN, BucketID> rollingPolicy,
+			final String partPrefix,
+			final String partSuffix) throws IOException;
 
 	Bucket<IN, BucketID> restoreBucket(
 			final RecoverableWriter fsWriter,
@@ -46,5 +48,7 @@ interface BucketFactory<IN, BucketID> extends Serializable {
 			final long initialPartCounter,
 			final PartFileWriter.PartFileFactory<IN, BucketID> partFileWriterFactory,
 			final RollingPolicy<IN, BucketID> rollingPolicy,
-			final BucketState<BucketID> bucketState) throws IOException;
+			final BucketState<BucketID> bucketState,
+			final String partPrefix,
+			final String partSuffix) throws IOException;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Buckets.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Buckets.java
@@ -77,6 +77,10 @@ public class Buckets<IN, BucketID> {
 
 	private final RecoverableWriter fsWriter;
 
+	private final String partPrefix;
+
+	private final String partSuffix;
+
 	// --------------------------- State Related Fields -----------------------------
 
 	private final BucketStateSerializer<BucketID> bucketStateSerializer;
@@ -96,7 +100,9 @@ public class Buckets<IN, BucketID> {
 			final BucketFactory<IN, BucketID> bucketFactory,
 			final PartFileWriter.PartFileFactory<IN, BucketID> partFileWriterFactory,
 			final RollingPolicy<IN, BucketID> rollingPolicy,
-			final int subtaskIndex) throws IOException {
+			final int subtaskIndex,
+			final String partPrefix,
+			final String partSuffix) throws IOException {
 
 		this.basePath = Preconditions.checkNotNull(basePath);
 		this.bucketAssigner = Preconditions.checkNotNull(bucketAssigner);
@@ -104,6 +110,9 @@ public class Buckets<IN, BucketID> {
 		this.partFileWriterFactory = Preconditions.checkNotNull(partFileWriterFactory);
 		this.rollingPolicy = Preconditions.checkNotNull(rollingPolicy);
 		this.subtaskIndex = subtaskIndex;
+
+		this.partPrefix = partPrefix;
+		this.partSuffix = partSuffix;
 
 		this.activeBuckets = new HashMap<>();
 		this.bucketerContext = new Buckets.BucketerContext();
@@ -180,7 +189,9 @@ public class Buckets<IN, BucketID> {
 						maxPartCounter,
 						partFileWriterFactory,
 						rollingPolicy,
-						recoveredState
+						recoveredState,
+						partPrefix,
+					partSuffix
 				);
 
 		updateActiveBucketId(bucketId, restoredBucket);
@@ -286,7 +297,9 @@ public class Buckets<IN, BucketID> {
 					bucketPath,
 					maxPartCounter,
 					partFileWriterFactory,
-					rollingPolicy);
+					rollingPolicy,
+					partPrefix,
+				partSuffix);
 			activeBuckets.put(bucketId, bucket);
 		}
 		return bucket;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/DefaultBucketFactoryImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/DefaultBucketFactoryImpl.java
@@ -40,7 +40,9 @@ class DefaultBucketFactoryImpl<IN, BucketID> implements BucketFactory<IN, Bucket
 			final Path bucketPath,
 			final long initialPartCounter,
 			final PartFileWriter.PartFileFactory<IN, BucketID> partFileWriterFactory,
-			final RollingPolicy<IN, BucketID> rollingPolicy) {
+			final RollingPolicy<IN, BucketID> rollingPolicy,
+			final String partPrefix,
+			final String partSuffix) {
 
 		return Bucket.getNew(
 				fsWriter,
@@ -49,7 +51,9 @@ class DefaultBucketFactoryImpl<IN, BucketID> implements BucketFactory<IN, Bucket
 				bucketPath,
 				initialPartCounter,
 				partFileWriterFactory,
-				rollingPolicy);
+				rollingPolicy,
+				partPrefix,
+				partSuffix);
 	}
 
 	@Override
@@ -59,7 +63,9 @@ class DefaultBucketFactoryImpl<IN, BucketID> implements BucketFactory<IN, Bucket
 			final long initialPartCounter,
 			final PartFileWriter.PartFileFactory<IN, BucketID> partFileWriterFactory,
 			final RollingPolicy<IN, BucketID> rollingPolicy,
-			final BucketState<BucketID> bucketState) throws IOException {
+			final BucketState<BucketID> bucketState,
+			final String partPrefix,
+			final String partSuffix) throws IOException {
 
 		return Bucket.restore(
 				fsWriter,
@@ -67,6 +73,8 @@ class DefaultBucketFactoryImpl<IN, BucketID> implements BucketFactory<IN, Bucket
 				initialPartCounter,
 				partFileWriterFactory,
 				rollingPolicy,
-				bucketState);
+				bucketState,
+				partPrefix,
+				partSuffix);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/PartFileWriter.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/PartFileWriter.java
@@ -101,6 +101,11 @@ abstract class PartFileWriter<IN, BucketID> implements PartFileInfo<BucketID> {
 		return lastUpdateTime;
 	}
 
+	String getExtension() {
+		return "";
+	}
+
+
 	// ------------------------------------------------------------------------
 
 	/**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketAssignerITCases.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketAssignerITCases.java
@@ -56,7 +56,9 @@ public class BucketAssignerITCases {
 			new DefaultBucketFactoryImpl<>(),
 			new RowWisePartWriter.Factory<>(new SimpleStringEncoder<>()),
 			rollingPolicy,
-			0
+			0,
+			"part",
+			""
 		);
 
 		Bucket<String, String> bucket =

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketTest.java
@@ -64,7 +64,7 @@ public class BucketTest {
 
 		final TestRecoverableWriter recoverableWriter = getRecoverableWriter(path);
 		final Bucket<String, String> bucketUnderTest =
-				createBucket(recoverableWriter, path, 0, 0);
+				createBucket(recoverableWriter, path, 0, 0, "part-", "");
 
 		bucketUnderTest.write("test-element", 0L);
 
@@ -82,7 +82,7 @@ public class BucketTest {
 
 		final TestRecoverableWriter recoverableWriter = getRecoverableWriter(path);
 		final Bucket<String, String> bucketUnderTest =
-				createBucket(recoverableWriter, path, 0, 0);
+				createBucket(recoverableWriter, path, 0, 0, "part-", "");
 
 		bucketUnderTest.write("test-element", 0L);
 
@@ -105,7 +105,7 @@ public class BucketTest {
 
 		final TestRecoverableWriter recoverableWriter = getRecoverableWriter(path);
 		final Bucket<String, String> bucketUnderTest =
-				createBucket(recoverableWriter, path, 0, 0);
+				createBucket(recoverableWriter, path, 0, 0, "part-", "");
 
 		bucketUnderTest.write("test-element", 0L);
 
@@ -115,7 +115,7 @@ public class BucketTest {
 		bucketUnderTest.onSuccessfulCompletionOfCheckpoint(0L);
 
 		final TestRecoverableWriter newRecoverableWriter = getRecoverableWriter(path);
-		restoreBucket(newRecoverableWriter, 0, 1, state);
+		restoreBucket(newRecoverableWriter, 0, 1, state, "part-", "");
 
 		assertThat(newRecoverableWriter, hasCalledDiscard(1)); // that is for checkpoints 0 and 1
 	}
@@ -127,7 +127,7 @@ public class BucketTest {
 
 		final TestRecoverableWriter recoverableWriter = getRecoverableWriter(path);
 		final Bucket<String, String> bucketUnderTest =
-				createBucket(recoverableWriter, path, 0, 0);
+				createBucket(recoverableWriter, path, 0, 0, "part-", "");
 
 		final BucketState<String> state = bucketUnderTest.onReceptionOfCheckpoint(0L);
 		assertThat(state, hasNoActiveInProgressFile());
@@ -378,7 +378,9 @@ public class BucketTest {
 			final RecoverableWriter writer,
 			final Path bucketPath,
 			final int subtaskIdx,
-			final int initialPartCounter) {
+			final int initialPartCounter,
+			final String partPrefix,
+			final String partSuffix) {
 
 		return Bucket.getNew(
 				writer,
@@ -387,14 +389,18 @@ public class BucketTest {
 				bucketPath,
 				initialPartCounter,
 				partFileFactory,
-				rollingPolicy);
+				rollingPolicy,
+				partPrefix,
+				partSuffix);
 	}
 
 	private static Bucket<String, String> restoreBucket(
 			final RecoverableWriter writer,
 			final int subtaskIndex,
 			final long initialPartCounter,
-			final BucketState<String> bucketState) throws Exception {
+			final BucketState<String> bucketState,
+			final String partPrefix,
+			final String partSuffix) throws Exception {
 
 		return Bucket.restore(
 				writer,
@@ -402,8 +408,9 @@ public class BucketTest {
 				initialPartCounter,
 				partFileFactory,
 				rollingPolicy,
-				bucketState
-		);
+				bucketState,
+				partPrefix,
+				partSuffix);
 	}
 
 	private static TestRecoverableWriter getRecoverableWriter(Path path) {
@@ -422,7 +429,7 @@ public class BucketTest {
 	private Bucket<String, String> getRestoredBucketWithOnlyInProgressPart(final BaseStubWriter writer) throws IOException {
 		final BucketState<String> stateWithOnlyInProgressFile =
 				new BucketState<>("test", new Path(), 12345L, new NoOpRecoverable(), new HashMap<>());
-		return Bucket.restore(writer, 0, 1L, partFileFactory, rollingPolicy, stateWithOnlyInProgressFile);
+		return Bucket.restore(writer, 0, 1L, partFileFactory, rollingPolicy, stateWithOnlyInProgressFile, "part-", "");
 	}
 
 	private Bucket<String, String> getRestoredBucketWithOnlyPendingParts(final BaseStubWriter writer, final int numberOfPendingParts) throws IOException {
@@ -431,7 +438,7 @@ public class BucketTest {
 
 		final BucketState<String> initStateWithOnlyInProgressFile =
 				new BucketState<>("test", new Path(), 12345L, null, completePartsPerCheckpoint);
-		return Bucket.restore(writer, 0, 1L, partFileFactory, rollingPolicy, initStateWithOnlyInProgressFile);
+		return Bucket.restore(writer, 0, 1L, partFileFactory, rollingPolicy, initStateWithOnlyInProgressFile, "part-", "");
 	}
 
 	private Map<Long, List<RecoverableWriter.CommitRecoverable>> createPendingPartsPerCheckpoint(int noOfCheckpoints) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BulkWriterTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BulkWriterTest.java
@@ -62,43 +62,79 @@ public class BulkWriterTest extends TestLogger {
 								new DefaultBucketFactoryImpl<>())
 		) {
 
-			testHarness.setup();
-			testHarness.open();
+			testPartFiles(testHarness, outDir, ".part-0-0.inprogress", ".part-0-1.inprogress");
 
-			// this creates a new bucket "test1" and part-0-0
-			testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 1), 1L));
-			TestUtils.checkLocalFs(outDir, 1, 0);
+		}
+	}
 
-			// we take a checkpoint so we roll.
-			testHarness.snapshot(1L, 1L);
+	@Test
+	public void testCustomBulkWriterWithPartConfig() throws Exception {
+		final File outDir = TEMP_FOLDER.newFolder();
 
-			// these will close part-0-0 and open part-0-1
-			testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 2), 2L));
-			testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 3), 3L));
+		// we set the max bucket size to small so that we can know when it rolls
+		try (
+			OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> testHarness =
+				TestUtils.createTestSinkWithBulkEncoder(
+					outDir,
+					1,
+					0,
+					10L,
+					new TestUtils.TupleToStringBucketer(),
+					new TestBulkWriterFactory(),
+					new DefaultBucketFactoryImpl<>(),
+					"prefix-",
+					".ext")
+		) {
 
-			// we take a checkpoint so we roll again.
-			testHarness.snapshot(2L, 2L);
+			testPartFiles(testHarness, outDir, ".prefix-0-0.ext.inprogress", ".prefix-0-1.ext.inprogress");
 
-			TestUtils.checkLocalFs(outDir, 2, 0);
+		}
+	}
 
-			Map<File, String> contents = TestUtils.getFileContentByPath(outDir);
-			int fileCounter = 0;
-			for (Map.Entry<File, String> fileContents : contents.entrySet()) {
-				if (fileContents.getKey().getName().contains(".part-0-0.inprogress")) {
-					fileCounter++;
-					Assert.assertEquals("test1@1\n", fileContents.getValue());
-				} else if (fileContents.getKey().getName().contains(".part-0-1.inprogress")) {
-					fileCounter++;
-					Assert.assertEquals("test1@2\ntest1@3\n", fileContents.getValue());
-				}
+	private void testPartFiles(
+						OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> testHarness,
+						File outDir,
+						String partFileName1,
+						String partFileName2) throws Exception {
+
+		testHarness.setup();
+		testHarness.open();
+
+		// this creates a new bucket "test1" and part-0-0
+		testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 1), 1L));
+		TestUtils.checkLocalFs(outDir, 1, 0);
+
+		// we take a checkpoint so we roll.
+		testHarness.snapshot(1L, 1L);
+
+		// these will close part-0-0 and open part-0-1
+		testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 2), 2L));
+		testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 3), 3L));
+
+		// we take a checkpoint so we roll again.
+		testHarness.snapshot(2L, 2L);
+
+		TestUtils.checkLocalFs(outDir, 2, 0);
+
+		Map<File, String> contents = TestUtils.getFileContentByPath(outDir);
+		int fileCounter = 0;
+		for (Map.Entry<File, String> fileContents : contents.entrySet()) {
+			if (fileContents.getKey().getName().contains(partFileName1)) {
+				fileCounter++;
+				Assert.assertEquals("test1@1\n", fileContents.getValue());
+			} else if (fileContents.getKey().getName().contains(partFileName2)) {
+				fileCounter++;
+				Assert.assertEquals("test1@2\ntest1@3\n", fileContents.getValue());
 			}
-			Assert.assertEquals(2L, fileCounter);
+		}
+		Assert.assertEquals(2L, fileCounter);
 
 			// we acknowledge the latest checkpoint, so everything should be published.
 			testHarness.notifyOfCompletedCheckpoint(2L);
 			TestUtils.checkLocalFs(outDir, 0, 2);
-		}
+
 	}
+
 
 	/**
 	 * A {@link BulkWriter} used for the tests.
@@ -127,6 +163,7 @@ public class BulkWriterTest extends TestLogger {
 		public void finish() throws IOException {
 			flush();
 		}
+
 	}
 
 	/**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/RollingPolicyTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/RollingPolicyTest.java
@@ -190,7 +190,9 @@ public class RollingPolicyTest {
 				new DefaultBucketFactoryImpl<>(),
 				new RowWisePartWriter.Factory<>(new SimpleStringEncoder<>()),
 				rollingPolicyToTest,
-				0
+				0,
+				"part",
+				""
 		);
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/TestUtils.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/TestUtils.java
@@ -116,12 +116,27 @@ public class TestUtils {
 			final BulkWriter.Factory<Tuple2<String, Integer>> writer,
 			final BucketFactory<Tuple2<String, Integer>, String> bucketFactory) throws Exception {
 
+		return createTestSinkWithBulkEncoder(outDir, totalParallelism, taskIdx, bucketCheckInterval, bucketer, writer, bucketFactory, "part-", "");
+	}
+
+	static OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> createTestSinkWithBulkEncoder(
+		final File outDir,
+		final int totalParallelism,
+		final int taskIdx,
+		final long bucketCheckInterval,
+		final BucketAssigner<Tuple2<String, Integer>, String> bucketer,
+		final BulkWriter.Factory<Tuple2<String, Integer>> writer,
+		final BucketFactory<Tuple2<String, Integer>, String> bucketFactory,
+		final String partPrefix,
+		final String partSuffix) throws Exception {
+
 		StreamingFileSink<Tuple2<String, Integer>> sink = StreamingFileSink
-				.forBulkFormat(new Path(outDir.toURI()), writer)
-				.withBucketAssigner(bucketer)
-				.withBucketCheckInterval(bucketCheckInterval)
-				.withBucketFactory(bucketFactory)
-				.build();
+			.forBulkFormat(new Path(outDir.toURI()), writer)
+			.withBucketAssigner(bucketer)
+			.withBucketCheckInterval(bucketCheckInterval)
+			.withBucketFactory(bucketFactory)
+			.withPartFileConfig(partPrefix, partSuffix)
+			.build();
 
 		return new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink), MAX_PARALLELISM, totalParallelism, taskIdx);
 	}


### PR DESCRIPTION
Mirror of apache flink#9228
## What is the purpose of the change
Allow part file name to be configurable


## Brief change log
- Bucket have part name prefix and suffix

## Verifying this change
This change added tests to BulkWritterTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (don't know)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)

