### PR TITLE
Mirror of apache flink#9226

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimLoader.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimLoader.java
@@ -32,8 +32,8 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class HiveShimLoader {
 
-	public static final String HIVE_V1_VERSION_NAME = "1.2.1";
-	public static final String HIVE_V2_VERSION_NAME = "2.3.4";
+	public static final String HIVE_V1_VERSION_NAME = "1.2.";
+	public static final String HIVE_V2_VERSION_NAME = "2.3.";
 
 	private static final Map<String, HiveShim> hiveShims = new ConcurrentHashMap<>(2);
 


### PR DESCRIPTION
Mirror of apache flink#9226
## What is the purpose of the change

This PR fixes the hive version hardcoded issue. With this PR, all the hive versions 1.2.x and 2.3.x are all supported. 


## Brief change log

Only check the major.minor version number and ignore the bug fix version number.


## Verifying this change

Verify it manually on hive 1.2.2

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)

