### PR TITLE
Mirror of apache flink#9225

### DIFF
--- a/flink-runtime-web/web-dashboard/old-version/partials/jobmanager/log.html
+++ b/flink-runtime-web/web-dashboard/old-version/partials/jobmanager/log.html
@@ -24,7 +24,7 @@ limitations under the License.
         <div class="row">
           <div class="col-xs-10">Job Manager Logs</div>
           <div class="col-xs-1 text-right"><a ng-click="reloadData()" class="show-pointer"><i class="fa fa-refresh"></i></a></div>
-          <div class="col-xs-1 text-left"><a href="jobmanager/log"><i class="fa fa-download"></i></a></div>
+          <div class="col-xs-1 text-left"><a href="jobmanager/log" download="jobmanager_log"><i class="fa fa-download"></i></a></div>
         </div>
       </th>
     </tr>

--- a/flink-runtime-web/web-dashboard/old-version/partials/jobmanager/stdout.html
+++ b/flink-runtime-web/web-dashboard/old-version/partials/jobmanager/stdout.html
@@ -25,7 +25,7 @@ limitations under the License.
         <div class="row">
           <div class="col-xs-10">Job Manager Output</div>
           <div class="col-xs-1 text-right"><a ng-click="reloadData()" class="show-pointer"><i class="fa fa-refresh"></i></a></div>
-          <div class="col-xs-1 text-left"><a href="jobmanager/stdout"><i class="fa fa-download"></i></a></div>
+          <div class="col-xs-1 text-left"><a href="jobmanager/stdout" download="jobmanager_stdout"><i class="fa fa-download"></i></a></div>
         </div>
       </th>
     </tr>

--- a/flink-runtime-web/web-dashboard/old-version/partials/taskmanager/taskmanager.log.html
+++ b/flink-runtime-web/web-dashboard/old-version/partials/taskmanager/taskmanager.log.html
@@ -24,7 +24,7 @@ limitations under the License.
         <div class="row">
           <div class="col-xs-10">Task Manager Logs</div>
           <div class="col-xs-1 text-right"><a ng-click="reloadData()" class="show-pointer"><i class="fa fa-refresh"></i></a></div>
-          <div class="col-xs-1 text-left"><a href="taskmanagers/{{taskmanagerid}}/log"><i class="fa fa-download"></i></a></div>
+          <div class="col-xs-1 text-left"><a href="taskmanagers/{{taskmanagerid}}/log" download="taskmanager_{{taskmanagerid}}_log"><i class="fa fa-download"></i></a></div>
         </div>
       </th>
     </tr>

--- a/flink-runtime-web/web-dashboard/old-version/partials/taskmanager/taskmanager.stdout.html
+++ b/flink-runtime-web/web-dashboard/old-version/partials/taskmanager/taskmanager.stdout.html
@@ -24,7 +24,7 @@ limitations under the License.
         <div class="row">
           <div class="col-xs-10">Task Manager Output</div>
           <div class="col-xs-1 text-right"><a ng-click="reloadData()" class="show-pointer"><i class="fa fa-refresh"></i></a></div>
-          <div class="col-xs-1 text-left"><a href="taskmanagers/{{taskmanagerid}}/stdout"><i class="fa fa-download"></i></a></div>
+          <div class="col-xs-1 text-left"><a href="taskmanagers/{{taskmanagerid}}/stdout" download="taskmanager_{{taskmanagerid}}_stdout"><i class="fa fa-download"></i></a></div>
         </div>
       </th>
     </tr>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/files/LegacyLogFileHandlerSpecification.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/files/LegacyLogFileHandlerSpecification.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.legacy.files;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
+
+/**
+ * Legacy rest handler specification for the log file of the main cluster component.
+ */
+public class LegacyLogFileHandlerSpecification implements RestHandlerSpecification {
+
+	private static final LegacyLogFileHandlerSpecification INSTANCE = new LegacyLogFileHandlerSpecification();
+
+	private static final String URL = "/old-version/jobmanager/log";
+
+	private LegacyLogFileHandlerSpecification() {}
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.GET;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return URL;
+	}
+
+	public static LegacyLogFileHandlerSpecification getInstance() {
+		return INSTANCE;
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/files/LegacyStdoutFileHandlerSpecification.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/files/LegacyStdoutFileHandlerSpecification.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.legacy.files;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
+
+/**
+ * Legacy rest handler specification for the stdout file of the main cluster component.
+ */
+public class LegacyStdoutFileHandlerSpecification implements RestHandlerSpecification {
+
+	private static final LegacyStdoutFileHandlerSpecification INSTANCE = new LegacyStdoutFileHandlerSpecification();
+
+	private static final String URL = "/old-version/jobmanager/stdout";
+
+	private LegacyStdoutFileHandlerSpecification() {}
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.GET;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return URL;
+	}
+
+	public static LegacyStdoutFileHandlerSpecification getInstance() {
+		return INSTANCE;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/files/StaticFileServerHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/files/StaticFileServerHandler.java
@@ -125,17 +125,22 @@ public class StaticFileServerHandler<T extends RestfulGateway> extends LeaderRet
 	@Override
 	protected void respondAsLeader(ChannelHandlerContext channelHandlerContext, RoutedRequest routedRequest, T gateway) throws Exception {
 		final HttpRequest request = routedRequest.getRequest();
+		String originalRequestPath = routedRequest.getPath();
 		final String requestPath;
 
+		if (originalRequestPath.startsWith("/old-version") && (originalRequestPath.endsWith("/log") || originalRequestPath.endsWith("/stdout"))) {
+			originalRequestPath = originalRequestPath.replace("/old-version", "");
+		}
+
 		// make sure we request the "index.html" in case there is a directory request
-		if (routedRequest.getPath().endsWith("/")) {
-			requestPath = routedRequest.getPath() + "index.html";
+		if (originalRequestPath.endsWith("/")) {
+			requestPath = originalRequestPath + "index.html";
 		}
 		// in case the files being accessed are logs or stdout files, find appropriate paths.
-		else if (routedRequest.getPath().equals("/jobmanager/log") || routedRequest.getPath().equals("/jobmanager/stdout")) {
+		else if (originalRequestPath.equals("/jobmanager/log") || originalRequestPath.equals("/jobmanager/stdout")) {
 			requestPath = "";
 		} else {
-			requestPath = routedRequest.getPath();
+			requestPath = originalRequestPath;
 		}
 
 		respondToRequest(channelHandlerContext, request, requestPath);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/LegacyTaskManagerLogFileHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/LegacyTaskManagerLogFileHeaders.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.taskmanager;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagerLogFileHandler;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.UntypedResponseMessageHeaders;
+
+/**
+ * Legacy headers for the {@link TaskManagerLogFileHandler}.
+ */
+public class LegacyTaskManagerLogFileHeaders implements UntypedResponseMessageHeaders<EmptyRequestBody, TaskManagerMessageParameters> {
+
+	private static final LegacyTaskManagerLogFileHeaders INSTANCE = new LegacyTaskManagerLogFileHeaders();
+
+	private static final String URL = String.format("/old-version/taskmanagers/:%s/log", TaskManagerIdPathParameter.KEY);
+
+	private LegacyTaskManagerLogFileHeaders() {}
+
+	@Override
+	public Class<EmptyRequestBody> getRequestClass() {
+		return EmptyRequestBody.class;
+	}
+
+	@Override
+	public TaskManagerMessageParameters getUnresolvedMessageParameters() {
+		return new TaskManagerMessageParameters();
+	}
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.GET;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return URL;
+	}
+
+	public static LegacyTaskManagerLogFileHeaders getInstance() {
+		return INSTANCE;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/LegacyTaskManagerStdoutFileHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/LegacyTaskManagerStdoutFileHeaders.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.taskmanager;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagerStdoutFileHandler;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.UntypedResponseMessageHeaders;
+
+/**
+ * Legacy headers for the {@link TaskManagerStdoutFileHandler}.
+ */
+public class LegacyTaskManagerStdoutFileHeaders implements UntypedResponseMessageHeaders<EmptyRequestBody, TaskManagerMessageParameters> {
+
+	private static final LegacyTaskManagerStdoutFileHeaders INSTANCE = new LegacyTaskManagerStdoutFileHeaders();
+
+	private static final String URL = String.format("/old-version/taskmanagers/:%s/stdout", TaskManagerIdPathParameter.KEY);
+
+	private LegacyTaskManagerStdoutFileHeaders() {}
+
+	@Override
+	public Class<EmptyRequestBody> getRequestClass() {
+		return EmptyRequestBody.class;
+	}
+
+	@Override
+	public TaskManagerMessageParameters getUnresolvedMessageParameters() {
+		return new TaskManagerMessageParameters();
+	}
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.GET;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return URL;
+	}
+
+	public static LegacyTaskManagerStdoutFileHeaders getInstance() {
+		return INSTANCE;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -72,6 +72,8 @@ import org.apache.flink.runtime.rest.handler.job.savepoints.SavepointDisposalHan
 import org.apache.flink.runtime.rest.handler.job.savepoints.SavepointHandlers;
 import org.apache.flink.runtime.rest.handler.legacy.ConstantTextHandler;
 import org.apache.flink.runtime.rest.handler.legacy.ExecutionGraphCache;
+import org.apache.flink.runtime.rest.handler.legacy.files.LegacyLogFileHandlerSpecification;
+import org.apache.flink.runtime.rest.handler.legacy.files.LegacyStdoutFileHandlerSpecification;
 import org.apache.flink.runtime.rest.handler.legacy.files.LogFileHandlerSpecification;
 import org.apache.flink.runtime.rest.handler.legacy.files.StaticFileServerHandler;
 import org.apache.flink.runtime.rest.handler.legacy.files.StdoutFileHandlerSpecification;
@@ -109,6 +111,8 @@ import org.apache.flink.runtime.rest.messages.job.JobDetailsHeaders;
 import org.apache.flink.runtime.rest.messages.job.SubtaskCurrentAttemptDetailsHeaders;
 import org.apache.flink.runtime.rest.messages.job.SubtaskExecutionAttemptAccumulatorsHeaders;
 import org.apache.flink.runtime.rest.messages.job.SubtaskExecutionAttemptDetailsHeaders;
+import org.apache.flink.runtime.rest.messages.taskmanager.LegacyTaskManagerLogFileHeaders;
+import org.apache.flink.runtime.rest.messages.taskmanager.LegacyTaskManagerStdoutFileHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerDetailsHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerLogFileHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerStdoutFileHeaders;
@@ -608,6 +612,10 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 		handlers.add(Tuple2.of(LogFileHandlerSpecification.getInstance(), logFileHandler));
 		handlers.add(Tuple2.of(StdoutFileHandlerSpecification.getInstance(), stdoutFileHandler));
 
+		//for legacy web ui
+		handlers.add(Tuple2.of(LegacyLogFileHandlerSpecification.getInstance(), logFileHandler));
+		handlers.add(Tuple2.of(LegacyStdoutFileHandlerSpecification.getInstance(), stdoutFileHandler));
+
 		// TaskManager log and stdout file handler
 
 		final Time cacheEntryDuration = Time.milliseconds(restConfiguration.getRefreshInterval());
@@ -632,6 +640,28 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 
 		handlers.add(Tuple2.of(TaskManagerLogFileHeaders.getInstance(), taskManagerLogFileHandler));
 		handlers.add(Tuple2.of(TaskManagerStdoutFileHeaders.getInstance(), taskManagerStdoutFileHandler));
+
+		final TaskManagerLogFileHandler legacyTaskManagerLogFileHandler = new TaskManagerLogFileHandler(
+			leaderRetriever,
+			timeout,
+			responseHeaders,
+			LegacyTaskManagerLogFileHeaders.getInstance(),
+			resourceManagerRetriever,
+			transientBlobService,
+			cacheEntryDuration);
+
+		final TaskManagerStdoutFileHandler legacyTaskManagerStdoutFileHandler = new TaskManagerStdoutFileHandler(
+			leaderRetriever,
+			timeout,
+			responseHeaders,
+			LegacyTaskManagerStdoutFileHeaders.getInstance(),
+			resourceManagerRetriever,
+			transientBlobService,
+			cacheEntryDuration);
+
+		//for legacy web ui
+		handlers.add(Tuple2.of(LegacyTaskManagerLogFileHeaders.getInstance(), legacyTaskManagerLogFileHandler));
+		handlers.add(Tuple2.of(LegacyTaskManagerStdoutFileHeaders.getInstance(), legacyTaskManagerStdoutFileHandler));
 
 		handlers.stream()
 			.map(tuple -> tuple.f1)


### PR DESCRIPTION
Mirror of apache flink#9225

## What is the purpose of the change

*This pull request fixs the problem about taskmanger & jobmanagers logs in the old UI can not be downloaded*


## Brief change log

  - *Fixs the problem about taskmanger & jobmanagers logs in the old UI can not be downloaded*


## Verifying this change

This change is hard to be verified with the test cases, the changes were verified in the local env*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)

