### PR TITLE
Mirror of apache flink#9222

### DIFF
--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -1336,7 +1336,16 @@ full_outer_result = left.full_outer_join(right, "a = d").select("a, b, e")
         <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
       </td>
     	<td>
-        <p>Currently not supported in python API.</p>
+        <p>Joins a table with the results of a table function. Each row of the left (outer) table is joined with all rows produced by the corresponding call of the table function. A row of the left (outer) table is dropped, if its table function call returns an empty result.
+        </p>
+{% highlight python %}
+# register Java User-Defined Table Function
+table_env.register_java_function("split", "com.my.udf.MySplitUDTF")
+
+# join
+orders = table_env.scan("Orders")
+result = orders.join_lateral("split(c).as(s, t, v)").select("a, b, s, t, v")
+{% endhighlight %}
       </td>
     </tr>
     <tr>
@@ -1345,7 +1354,16 @@ full_outer_result = left.full_outer_join(right, "a = d").select("a, b, e")
         <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
       </td>
       <td>
-        <p>Currently not supported in python API.</p>
+        <p>Joins a table with the results of a table function. Each row of the left (outer) table is joined with all rows produced by the corresponding call of the table function. If a table function call returns an empty result, the corresponding outer row is preserved and the result padded with null values.</p>
+        <p><b>Note:</b> Currently, the predicate of a table function left outer join can only be empty or literal <code>true</code>.</p>
+{% highlight python %}
+# register Java User-Defined Table Function
+table_env.register_java_function("split", "com.my.udf.MySplitUDTF")
+
+# join
+orders = table_env.scan("Orders")
+result = orders.left_outer_join_lateral("split(c).as(s, t, v)").select("a, b, s, t, v")
+{% endhighlight %}
       </td>
     </tr>
     <tr>

--- a/docs/dev/table/tableApi.zh.md
+++ b/docs/dev/table/tableApi.zh.md
@@ -1335,7 +1335,16 @@ full_outer_result = left.full_outer_join(right, "a = d").select("a, b, e")
         <span class="label label-primary">批处理</span> <span class="label label-primary">流处理</span>
       </td>
     	<td>
-        <p>Python API暂不支持。</p>
+        <p>将一张表与一个表函数的执行结果执行内连接操作。左表的每一行都会进行一次表函数调用，调用将会返回0个，1个或多个结果，再与这些结果执行连接操作。如果一行数据对应的表函数调用返回了一个空的结果集，则这行数据会被丢弃。
+        </p>
+{% highlight python %}
+# register Java User-Defined Table Function
+table_env.register_java_function("split", "com.my.udf.MySplitUDTF")
+
+# join
+orders = table_env.scan("Orders")
+result = orders.join_lateral("split(c).as(s, t, v)").select("a, b, s, t, v")
+{% endhighlight %}
       </td>
     </tr>
     <tr>
@@ -1344,7 +1353,16 @@ full_outer_result = left.full_outer_join(right, "a = d").select("a, b, e")
         <span class="label label-primary">批处理</span> <span class="label label-primary">流处理</span>
       </td>
       <td>
-        <p>Python API暂不支持。</p>
+        <p>将一张表与一个表函数的执行结果执行左连接操作。左表的每一行都会进行一次表函数调用，调用将会返回0个，1个或多个结果，再与这些结果执行连接操作。如果一行数据对应的表函数调用返回了一个空的结果集，这行数据依然会被保留，对应的右表数值用null(python为None)填充。</p>
+        <p><b>注意：</b>目前，表函数的左连接操作的连接条件(join predicate)只能为空或者为"true"常量。</p>
+{% highlight python %}
+# register Java User-Defined Table Function
+table_env.register_java_function("split", "com.my.udf.MySplitUDTF")
+
+# join
+orders = table_env.scan("Orders")
+result = orders.left_outer_join_lateral("split(c).as(s, t, v)").select("a, b, s, t, v")
+{% endhighlight %}
       </td>
     </tr>
     <tr>

--- a/flink-python/pyflink/table/table.py
+++ b/flink-python/pyflink/table/table.py
@@ -247,6 +247,57 @@ class Table(object):
         """
         return Table(self._j_table.fullOuterJoin(right._j_table, join_predicate))
 
+    def join_lateral(self, table_function_call, join_predicate=None):
+        """
+        Joins this Table with an user-defined TableFunction. This join is similar to a SQL inner
+        join but works with a table function. Each row of the table is joined with the rows
+        produced by the table function.
+
+        Example:
+        ::
+
+            >>> t_env.register_java_function("split", "java.table.function.class.name")
+            >>> tab.join_lateral("split(text, ' ') as (b)", "a = b")
+
+        :param table_function_call: An expression representing a table function call.
+        :type table_function_call: str
+        :param join_predicate: Optional, The join predicate expression string, join ON TRUE if not
+                               exist.
+        :type join_predicate: str
+        :return: The result Table.
+        :rtype: Table
+        """
+        if join_predicate is None:
+            return Table(self._j_table.joinLateral(table_function_call))
+        else:
+            return Table(self._j_table.joinLateral(table_function_call, join_predicate))
+
+    def left_outer_join_lateral(self, table_function_call, join_predicate=None):
+        """
+        Joins this Table with an user-defined TableFunction. This join is similar to
+        a SQL left outer join but works with a table function. Each row of the table is joined
+        with all rows produced by the table function. If the join does not produce any row, the
+        outer row is padded with nulls.
+
+        Example:
+        ::
+
+            >>> t_env.register_java_function("split", "java.table.function.class.name")
+            >>> tab.left_outer_join_lateral("split(text, ' ') as (b)")
+
+        :param table_function_call: An expression representing a table function call.
+        :type table_function_call: str
+        :param join_predicate: Optional, The join predicate expression string, join ON TRUE if not
+                               exist.
+        :type join_predicate: str
+        :return: The result Table.
+        :rtype: Table
+        """
+        if join_predicate is None:
+            return Table(self._j_table.leftOuterJoinLateral(table_function_call))
+        else:
+            return Table(self._j_table.leftOuterJoinLateral(table_function_call, join_predicate))
+
     def minus(self, right):
         """
         Minus of two :class:`Table` with duplicate records removed.

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -224,6 +224,16 @@ class TableEnvironment(object):
         j_table_name_array = self._j_tenv.listTables()
         return [item for item in j_table_name_array]
 
+    def list_user_defined_functions(self):
+        """
+        Gets the names of all user defined functions registered in this environment.
+
+        :return: List of the names of all user defined functions registered in this environment.
+        :rtype: list[str]
+        """
+        j_udf_name_array = self._j_tenv.listUserDefinedFunctions()
+        return [item for item in j_udf_name_array]
+
     def explain(self, table=None, extended=False):
         """
         Returns the AST of the specified Table API and SQL queries and the execution plan to compute
@@ -496,6 +506,29 @@ class TableEnvironment(object):
                  table source/sink.
         """
         pass
+
+    def register_java_function(self, name, function_class_name):
+        """
+        Registers a java user defined function under a unique name. Replaces already existing
+        user-defined functions under this name. The acceptable function type contains
+        **ScalarFunction**, **TableFunction** and **AggregateFunction**.
+
+        Example:
+        ::
+
+            >>> table_env.register_java_function("func1", "java.user.defined.function.class.name")
+
+        :param name: The name under which the function is registered.
+        :type name: str
+        :param function_class_name: The java full qualified class name of the function to register.
+                                    The function must have a public no-argument constructor and can
+                                    be founded in current Java classloader.
+        :type function_class_name: str
+        """
+        gateway = get_gateway()
+        java_function = gateway.jvm.Thread.currentThread().getContextClassLoader()\
+            .loadClass(function_class_name).newInstance()
+        self._j_tenv.registerFunction(name, java_function)
 
     def execute(self, job_name):
         """

--- a/flink-python/pyflink/table/tests/test_correlate.py
+++ b/flink-python/pyflink/table/tests/test_correlate.py
@@ -1,0 +1,71 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase
+
+
+class CorrelateTests(PyFlinkStreamTableTestCase):
+
+    def test_join_lateral(self):
+        t_env = self.t_env
+        t_env.register_java_function("split", "org.apache.flink.table.utils.TableFunc1")
+        source = t_env.from_elements([("1", "1#3#5#7"), ("2", "2#4#6#8")], ["id", "words"])
+
+        result = source.join_lateral("split(words) as (word)")
+
+        query_operation = result._j_table.getQueryOperation()
+        self.assertEqual('INNER', query_operation.getJoinType().toString())
+        self.assertTrue(query_operation.isCorrelated())
+        self.assertEqual('true', query_operation.getCondition().toString())
+
+    def test_join_lateral_with_join_predicate(self):
+        t_env = self.t_env
+        t_env.register_java_function("split", "org.apache.flink.table.utils.TableFunc1")
+        source = t_env.from_elements([("1", "1#3#5#7"), ("2", "2#4#6#8")], ["id", "words"])
+
+        result = source.join_lateral("split(words) as (word)", "id = word")
+
+        query_operation = result._j_table.getQueryOperation()
+        self.assertEqual('INNER', query_operation.getJoinType().toString())
+        self.assertTrue(query_operation.isCorrelated())
+        self.assertEqual('`default_catalog`.`default_database`.`equals`(id, word)',
+                         query_operation.getCondition().toString())
+
+    def test_left_outer_join_lateral(self):
+        t_env = self.t_env
+        t_env.register_java_function("split", "org.apache.flink.table.utils.TableFunc1")
+        source = t_env.from_elements([("1", "1#3#5#7"), ("2", "2#4#6#8")], ["id", "words"])
+
+        result = source.left_outer_join_lateral("split(words) as (word)")
+
+        query_operation = result._j_table.getQueryOperation()
+        self.assertEqual('LEFT_OUTER', query_operation.getJoinType().toString())
+        self.assertTrue(query_operation.isCorrelated())
+        self.assertEqual('true', query_operation.getCondition().toString())
+
+    def test_left_outer_join_lateral_with_join_predicate(self):
+        t_env = self.t_env
+        t_env.register_java_function("split", "org.apache.flink.table.utils.TableFunc1")
+        source = t_env.from_elements([("1", "1#3#5#7"), ("2", "2#4#6#8")], ["id", "words"])
+
+        # only support "true" as the join predicate currently
+        result = source.left_outer_join_lateral("split(words) as (word)", "true")
+
+        query_operation = result._j_table.getQueryOperation()
+        self.assertEqual('LEFT_OUTER', query_operation.getJoinType().toString())
+        self.assertTrue(query_operation.isCorrelated())
+        self.assertEqual('true', query_operation.getCondition().toString())

--- a/flink-python/pyflink/table/tests/test_environment_completeness.py
+++ b/flink-python/pyflink/table/tests/test_environment_completeness.py
@@ -43,8 +43,7 @@ class EnvironmentAPICompletenessTests(PythonAPICompletenessTestCase, unittest.Te
         # getCompletionHints has been deprecated. It will be removed in the next release.
         # TODO add TableEnvironment#create method with EnvironmentSettings as a parameter
         return {'registerExternalCatalog', 'getRegisteredExternalCatalog', 'registerCatalog',
-                'getCatalog', 'registerFunction', 'listUserDefinedFunctions', 'listTables',
-                'getCompletionHints', 'create'}
+                'getCatalog', 'registerFunction', 'listTables', 'getCompletionHints', 'create'}
 
 
 if __name__ == '__main__':

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -169,6 +169,19 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
         expected = ['1,Hi,Hello', '2,Hello,Hello']
         self.assert_equals(actual, expected)
 
+    def test_register_java_function(self):
+        t_env = self.t_env
+
+        t_env.register_java_function("scalar_func",
+                                     "org.apache.flink.table.expressions.utils.RichFunc0")
+        t_env.register_java_function(
+            "agg_func", "org.apache.flink.table.functions.aggfunctions.ByteMaxAggFunction")
+        t_env.register_java_function("table_func", "org.apache.flink.table.utils.TableFunc1")
+
+        actual = t_env.list_user_defined_functions()
+        expected = ['scalar_func', 'agg_func', 'table_func']
+        self.assert_equals(actual, expected)
+
     def test_create_table_environment(self):
         table_config = TableConfig()
         table_config.set_max_generated_code_length(32000)
@@ -232,6 +245,19 @@ class BatchTableEnvironmentTests(PyFlinkBatchTableTestCase):
 
         with self.assertRaises(TableException):
             t_env.explain(extended=True)
+
+    def test_register_java_function(self):
+        t_env = self.t_env
+
+        t_env.register_java_function("scalar_func",
+                                     "org.apache.flink.table.expressions.utils.RichFunc0")
+        t_env.register_java_function(
+            "agg_func", "org.apache.flink.table.functions.aggfunctions.ByteMaxAggFunction")
+        t_env.register_java_function("table_func", "org.apache.flink.table.utils.TableFunc1")
+
+        actual = t_env.list_user_defined_functions()
+        expected = ['scalar_func', 'agg_func', 'table_func']
+        self.assert_equals(actual, expected)
 
     def test_create_table_environment(self):
         table_config = TableConfig()

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
@@ -499,8 +499,8 @@ public interface Table {
 
 	/**
 	 * Joins this {@link Table} with an user-defined {@link TableFunction}. This join is similar to
-	 * a SQL inner join with ON TRUE predicate but works with a table function. Each row of the
-	 * table is joined with all rows produced by the table function.
+	 * a SQL inner join but works with a table function. Each row of the table is joined with all
+	 * rows produced by the table function.
 	 *
 	 * <p>Example:
 	 *
@@ -522,8 +522,8 @@ public interface Table {
 
 	/**
 	 * Joins this {@link Table} with an user-defined {@link TableFunction}. This join is similar to
-	 * a SQL inner join with ON TRUE predicate but works with a table function. Each row of the
-	 * table is joined with all rows produced by the table function.
+	 * a SQL inner join but works with a table function. Each row of the table is joined with all
+	 * rows produced by the table function.
 	 *
 	 * <p>Scala Example:
 	 *


### PR DESCRIPTION
Mirror of apache flink#9222
## What is the purpose of the change

*This pull request aimed to support registering Java UDFs and using Java UDFs in Python Table API.*


## Brief change log

  - *Add `register_java_function()` and `list_user_defined_functions()` in `TableEnvironment` class to support registering Java UDFs.*
  - *Add `join_lateral()` and `left_outer_join_lateral()` to support using UDTFs in python Table API.*
  - *Fix incorrect documentation of `joinLateral` interfaces. *


## Verifying this change

This change is already covered by existing tests, such as *test_correlate.py* and *test_table_environment_api.py*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (python docs)

