### PR TITLE
Mirror of apache flink#9221

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.OutputTypeConfigurable;
 import org.apache.flink.streaming.api.operators.StreamSourceContexts;
@@ -61,7 +62,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  */
 @Internal
 public class ContinuousFileReaderOperator<OUT> extends AbstractStreamOperator<OUT>
-	implements OneInputStreamOperator<TimestampedFileInputSplit, OUT>, OutputTypeConfigurable<OUT> {
+	implements OneInputStreamOperator<TimestampedFileInputSplit, OUT>, OutputTypeConfigurable<OUT>, BoundedOneInput {
 
 	private static final long serialVersionUID = 1L;
 
@@ -196,6 +197,17 @@ public class ContinuousFileReaderOperator<OUT> extends AbstractStreamOperator<OU
 	public void close() throws Exception {
 		super.close();
 
+		waitReaderFinishing();
+
+		output.close();
+	}
+
+	@Override
+	public void endInput() throws Exception {
+		waitReaderFinishing();
+	}
+
+	private void waitReaderFinishing() throws InterruptedException {
 		// make sure that we hold the checkpointing lock
 		Thread.holdsLock(checkpointLock);
 
@@ -215,8 +227,8 @@ public class ContinuousFileReaderOperator<OUT> extends AbstractStreamOperator<OU
 		if (readerContext != null) {
 			readerContext.emitWatermark(Watermark.MAX_WATERMARK);
 			readerContext.close();
+			readerContext = null;
 		}
-		output.close();
 	}
 
 	private class SplitReader<OT> extends Thread {

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/api/ContinuousFileReaderOperatorITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/api/ContinuousFileReaderOperatorITCase.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.streaming.api;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.test.util.AbstractTestBase;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.PrintWriter;
+
+import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.STRING_TYPE_INFO;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Integration tests for {@link org.apache.flink.streaming.api.functions.source.ContinuousFileReaderOperator}.
+ */
+public class ContinuousFileReaderOperatorITCase extends AbstractTestBase {
+
+	@Test
+	public void testEndInput() throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(1);
+		final File sourceFile = TEMPORARY_FOLDER.newFile();
+		try (PrintWriter printWriter = new PrintWriter(sourceFile)) {
+			for (int i = 0; i < 10000; i++) {
+				printWriter.println(i);
+			}
+		}
+
+		DataStreamSource<String> source = env.readTextFile(sourceFile.getAbsolutePath());
+
+		// check the endInput is invoked at the right time
+		TestBoundedOneInputStreamOperator checkingOperator = new TestBoundedOneInputStreamOperator();
+		DataStream<String> endInputChecking = source.transform("EndInputChecking", STRING_TYPE_INFO, checkingOperator);
+
+		endInputChecking.addSink(new NoOpSink());
+
+		env.execute("ContinuousFileReaderOperatorITCase.testEndInput");
+	}
+
+	private static class TestBoundedOneInputStreamOperator extends AbstractStreamOperator<String>
+		implements OneInputStreamOperator<String, String>, BoundedOneInput {
+
+		private boolean isEnded = false;
+
+		TestBoundedOneInputStreamOperator() {
+			// this operator must be chained with ContinuousFileReaderOperator
+			// that way, this end input would be triggered after ContinuousFileReaderOperator
+			chainingStrategy = ChainingStrategy.ALWAYS;
+		}
+
+		@Override
+		public void endInput() throws Exception {
+			isEnded = true;
+		}
+
+		@Override
+		public void processElement(StreamRecord<String> element) throws Exception {
+			assertFalse(isEnded);
+			output.collect(element);
+		}
+	}
+
+	private static class NoOpSink implements SinkFunction<String> {}
+}


### PR DESCRIPTION
Mirror of apache flink#9221
… semantics of BoundedOneInput

## What is the purpose of the change

* Currently `ContinuousFileReaderOperator` does not respect the semantics of `BoundedOneInput`
* If there are some operators chained with `ContinuousFileReaderOperator`, the `endInput` of these operators might be triggered before all datum finishing

## Brief change log

* Make `ContinuousFileReaderOperator` implementing `BoundedOneInput`
* Make `ContinuousFileReaderOperator` blocking in `endInput` instead of `close`
* Leave the blocking logic in `close` due to compatibility (I think the `BoundedOneInput.endInput` might be unstable)

## Verifying this change

* This change added an integration test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

