### PR TITLE
Mirror of apache flink#9496

### DIFF
--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -103,6 +103,9 @@ under the License.
 								</delete>
 								<delete file="${project.basedir}/lib/pyflink.zip"/>
 								<delete dir="${project.basedir}/target"/>
+								<delete dir="${project.basedir}/build"/>
+								<delete dir="${project.basedir}/dist"/>
+								<delete dir="${project.basedir}/apache_flink.egg-info"/>
 							</target>
 						</configuration>
 					</execution>

--- a/tools/releasing/create_source_release.sh
+++ b/tools/releasing/create_source_release.sh
@@ -68,7 +68,7 @@ rsync -a \
   --exclude "docs/content" --exclude ".rubydeps" \
   --exclude "flink-python/lib/pyflink.zip"  --exclude "flink-python/build" \
   --exclude "flink-python/dist" --exclude "flink-python/apache_flink.egg-info" \
-  --exclude "flink-python/.tox" --exclude ".flink-python/.cache" \
+  --exclude "flink-python/.tox" --exclude "flink-python/.cache" \
   --exclude "flink-python/.pytest_cache" \
   . flink-$RELEASE_VERSION
 

--- a/tools/releasing/create_source_release.sh
+++ b/tools/releasing/create_source_release.sh
@@ -66,6 +66,10 @@ rsync -a \
   --exclude "CHANGELOG" --exclude ".github" --exclude "target" \
   --exclude ".idea" --exclude "*.iml" --exclude ".DS_Store" --exclude "build-target" \
   --exclude "docs/content" --exclude ".rubydeps" \
+  --exclude "flink-python/lib/pyflink.zip"  --exclude "flink-python/build" \
+  --exclude "flink-python/dist" --exclude "flink-python/apache_flink.egg-info" \
+  --exclude "flink-python/.tox" --exclude ".flink-python/.cache" \
+  --exclude "flink-python/.pytest_cache" \
   . flink-$RELEASE_VERSION
 
 tar czf ${RELEASE_DIR}/flink-${RELEASE_VERSION}-src.tgz flink-$RELEASE_VERSION


### PR DESCRIPTION
Mirror of apache flink#9496
## What is the purpose of the change
In this JIRA we add the Build logic for Python API release package.

## Brief change log

  -  clear up the build dir for flink-python.
  -  add build python api release logic in create_binary_release.sh.
  - add exclude config for flink-python in create_source_release.sh.

## Verifying this change
This change is a release script changes without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)

