### PR TITLE
Mirror of apache flink#9495

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSourceContexts.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSourceContexts.java
@@ -383,8 +383,6 @@ public class StreamSourceContexts {
 		@Override
 		public void collect(T element) {
 			synchronized (checkpointLock) {
-				streamStatusMaintainer.toggleStreamStatus(StreamStatus.ACTIVE);
-
 				if (nextCheck != null) {
 					this.failOnNextCheck = false;
 				} else {
@@ -398,8 +396,6 @@ public class StreamSourceContexts {
 		@Override
 		public void collectWithTimestamp(T element, long timestamp) {
 			synchronized (checkpointLock) {
-				streamStatusMaintainer.toggleStreamStatus(StreamStatus.ACTIVE);
-
 				if (nextCheck != null) {
 					this.failOnNextCheck = false;
 				} else {
@@ -414,8 +410,6 @@ public class StreamSourceContexts {
 		public void emitWatermark(Watermark mark) {
 			if (allowWatermark(mark)) {
 				synchronized (checkpointLock) {
-					streamStatusMaintainer.toggleStreamStatus(StreamStatus.ACTIVE);
-
 					if (nextCheck != null) {
 						this.failOnNextCheck = false;
 					} else {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -474,7 +474,7 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 			outSerializer = upStreamConfig.getTypeSerializerOut(taskEnvironment.getUserClassLoader());
 		}
 
-		return new RecordWriterOutput<>(recordWriter, outSerializer, sideOutputTag, this);
+		return new RecordWriterOutput<>(recordWriter, outSerializer, sideOutputTag);
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
Mirror of apache flink#9495
##  What is the purpose of the change

As we know, the watermark could be emitted to downstream only when the stream status is active. For the downstream task we already have the component of StatusWatermarkValve in StreamInputProcessor to handle this logic. But for the source task the current implementation of this logic seems a bit tricky.

There are two scenarios for the source case:

1. In the source WatermarkContext, it would toggle the status as active while collecting/emitting and the status is checked in RecordWriterOutput. If the watermark is triggered by timer for AutomaticWatermarkContext, the timer task would check the status before emitting watermark.

2. TimestampsAndPeriodicWatermarksOperator: The watermark is triggered by timer, but it still relies on RecordWriterOutput to check the status before emitting.

So the check logic in RecordWriterOutput only makes sense for the last scenario, and seems redundant for the first scenario. Even worse, this logic in RecordWriterOutput would bring cycle dependency with StreamStatusMaintainer, which is a blocker for the following work of integrating source processing on runtime side. To solve above issues, the basic idea is to refactor this check logic in upper layer instead of current low level RecordWriterOutput. The solution is migrating the check logic from RecordWriterOutput to TimestampsAndPeriodicWatermarksOperator. And we could further remove the logic of toggling active in WatermarkContext*

## Brief change log

  - *Introduce the `StreamStatusProvider` into `TimestampsAndPeriodicWatermarksOperator`*
  - *Remove the logic of checking status from `RecordWriterOutput`*
  - *Remove the logic of toggling active status in `WatermarkSourceContext`*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
