### PR TITLE
Mirror of apache flink#9492

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -68,7 +68,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -124,8 +123,6 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 
 	/** The number of containers requested, but not yet granted. */
 	private int numPendingContainerRequests;
-
-	private final Map<ResourceProfile, Integer> resourcePriorities = new HashMap<>();
 
 	private final Collection<ResourceProfile> slotsPerWorker;
 


### PR DESCRIPTION
Mirror of apache flink#9492
## What is the purpose of the change

Remove the variable since it isn't used: https://jira.apache.org/jira/browse/FLINK-13796

## Brief changelog

Got caught by my code quality checker that the variable is unused, and therefore it serves no purpose and should be removed imho.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable) -> it isn't a feature.

