### PR TITLE
Mirror of apache flink#9490

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonGatewayServer.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonGatewayServer.java
@@ -78,7 +78,7 @@ public class PythonGatewayServer {
 			}
 			gatewayServer.shutdown();
 			System.exit(0);
-		} catch (IOException e) {
+		} finally {
 			System.exit(1);
 		}
 	}

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonGatewayServer.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonGatewayServer.java
@@ -70,11 +70,16 @@ public class PythonGatewayServer {
 			System.exit(1);
 		}
 
-		// Exit on EOF or broken pipe.  This ensures that the server dies
-		// if its parent program dies.
-		while (System.in.read() != -1) {
-			// Do nothing
+		try {
+			// Exit on EOF or broken pipe.  This ensures that the server dies
+			// if its parent program dies.
+			while (System.in.read() != -1) {
+				// Do nothing
+			}
+			gatewayServer.shutdown();
+			System.exit(0);
+		} catch (IOException e) {
+			System.exit(1);
 		}
-		gatewayServer.shutdown();
 	}
 }


### PR DESCRIPTION
Mirror of apache flink#9490
## What is the purpose of the change

*This pull request add System.exit() at the end of PythonGatewayServer to ensure the JVM will exit if its parent process dies.*


## Brief change log

  - *add System.exit() at the end of PythonGatewayServer.*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

