### PR TITLE
Mirror of apache flink#9484

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/ExpressionResolver.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/ExpressionResolver.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
 import org.apache.flink.table.expressions.ValueLiteralExpression;
 import org.apache.flink.table.expressions.resolver.lookups.FieldReferenceLookup;
 import org.apache.flink.table.expressions.resolver.lookups.TableReferenceLookup;
+import org.apache.flink.table.expressions.resolver.rules.ResolveCallByArgumentsRule;
 import org.apache.flink.table.expressions.resolver.rules.ResolverRule;
 import org.apache.flink.table.expressions.resolver.rules.ResolverRules;
 import org.apache.flink.table.expressions.utils.ApiExpressionDefaultVisitor;
@@ -289,7 +290,7 @@ public class ExpressionResolver {
 	 * <p>Note: Further resolution or validation will not happen anymore, therefore the created
 	 * expressions must be valid.
 	 */
-	public class PostResolverFactory {
+	public class PostResolverFactory implements ResolveCallByArgumentsRule.PostResolveCallByArguments {
 
 		public CallExpression as(ResolvedExpression expression, String alias) {
 			final FunctionLookup.Result lookupOfAs = functionLookup
@@ -302,6 +303,7 @@ public class ExpressionResolver {
 				expression.getOutputDataType());
 		}
 
+		@Override
 		public CallExpression cast(ResolvedExpression expression, DataType dataType) {
 			final FunctionLookup.Result lookupOfCast = functionLookup
 				.lookupBuiltInFunction(BuiltInFunctionDefinitions.CAST);
@@ -324,6 +326,7 @@ public class ExpressionResolver {
 				expression.getOutputDataType()); // the output type is equal to the input type
 		}
 
+		@Override
 		public CallExpression get(ResolvedExpression composite, ValueLiteralExpression key, DataType dataType) {
 			final FunctionLookup.Result lookupOfGet = functionLookup
 				.lookupBuiltInFunction(BuiltInFunctionDefinitions.GET);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/ResolvedAggInputReference.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/ResolvedAggInputReference.java
@@ -21,18 +21,22 @@ package org.apache.flink.table.planner.expressions;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.ExpressionVisitor;
 import org.apache.flink.table.expressions.FieldReferenceExpression;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.util.Preconditions;
 
 import java.util.Collections;
 import java.util.List;
 
+import static org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromLogicalTypeToDataType;
+
 /**
  * Normally we should use {@link FieldReferenceExpression} to represent an input field.
  * {@link FieldReferenceExpression} uses name to locate the field, in aggregate case, we want to use
  * field index.
  */
-public class ResolvedAggInputReference implements Expression {
+public class ResolvedAggInputReference implements ResolvedExpression {
 
 	private final String name;
 	private final int index;
@@ -57,13 +61,23 @@ public class ResolvedAggInputReference implements Expression {
 	}
 
 	@Override
-	public String asSummaryString() {
-		return name;
+	public DataType getOutputDataType() {
+		return fromLogicalTypeToDataType(resultType);
+	}
+
+	@Override
+	public List<ResolvedExpression> getResolvedChildren() {
+		return Collections.emptyList();
 	}
 
 	@Override
 	public List<Expression> getChildren() {
 		return Collections.emptyList();
+	}
+
+	@Override
+	public String asSummaryString() {
+		return name;
 	}
 
 	@Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/ResolvedAggLocalReference.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/ResolvedAggLocalReference.java
@@ -20,10 +20,14 @@ package org.apache.flink.table.planner.expressions;
 
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.ExpressionVisitor;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 
 import java.util.Collections;
 import java.util.List;
+
+import static org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromLogicalTypeToDataType;
 
 /**
  * Special reference which represent a local filed, such as aggregate buffers or constants.
@@ -32,7 +36,7 @@ import java.util.List;
  *
  * <p>See {@link org.apache.flink.table.planner.codegen.ExprCodeGenerator#visitLocalRef}.
  */
-public class ResolvedAggLocalReference implements Expression {
+public class ResolvedAggLocalReference implements ResolvedExpression {
 
 	private final String fieldTerm;
 	private final String nullTerm;
@@ -57,13 +61,23 @@ public class ResolvedAggLocalReference implements Expression {
 	}
 
 	@Override
-	public String asSummaryString() {
-		return fieldTerm;
+	public DataType getOutputDataType() {
+		return fromLogicalTypeToDataType(resultType);
+	}
+
+	@Override
+	public List<ResolvedExpression> getResolvedChildren() {
+		return Collections.emptyList();
 	}
 
 	@Override
 	public List<Expression> getChildren() {
 		return Collections.emptyList();
+	}
+
+	@Override
+	public String asSummaryString() {
+		return fieldTerm;
 	}
 
 	@Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/ResolvedDistinctKeyReference.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/ResolvedDistinctKeyReference.java
@@ -20,16 +20,20 @@ package org.apache.flink.table.planner.expressions;
 
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.ExpressionVisitor;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.util.Preconditions;
 
 import java.util.Collections;
 import java.util.List;
 
+import static org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromLogicalTypeToDataType;
+
 /**
  * Resolved distinct key reference.
  */
-public class ResolvedDistinctKeyReference implements Expression {
+public class ResolvedDistinctKeyReference implements ResolvedExpression {
 
 	private final String name;
 	private final LogicalType resultType;
@@ -48,13 +52,23 @@ public class ResolvedDistinctKeyReference implements Expression {
 	}
 
 	@Override
-	public String asSummaryString() {
-		return name;
+	public DataType getOutputDataType() {
+		return fromLogicalTypeToDataType(resultType);
+	}
+
+	@Override
+	public List<ResolvedExpression> getResolvedChildren() {
+		return Collections.emptyList();
 	}
 
 	@Override
 	public List<Expression> getChildren() {
 		return Collections.emptyList();
+	}
+
+	@Override
+	public String asSummaryString() {
+		return name;
 	}
 
 	@Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/RexNodeConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/RexNodeConverter.java
@@ -31,8 +31,6 @@ import org.apache.flink.table.expressions.TableReferenceExpression;
 import org.apache.flink.table.expressions.TimeIntervalUnit;
 import org.apache.flink.table.expressions.TimePointUnit;
 import org.apache.flink.table.expressions.TypeLiteralExpression;
-import org.apache.flink.table.expressions.UnresolvedCallExpression;
-import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
 import org.apache.flink.table.expressions.ValueLiteralExpression;
 import org.apache.flink.table.expressions.utils.ApiExpressionUtils;
 import org.apache.flink.table.functions.AggregateFunction;
@@ -121,8 +119,8 @@ import static org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoT
 /**
  * Visit expression to generator {@link RexNode}.
  *
- * <p>TODO actually we should use {@link ResolvedExpressionVisitor} here as it is the output of the API.
- * we will update it after introduce Expression resolve in AggCodeGen.
+ * <p>TODO remove blink expressions(like {@link ResolvedAggInputReference}) and use
+ * {@link ResolvedExpressionVisitor}.
  */
 public class RexNodeConverter implements ExpressionVisitor<RexNode> {
 
@@ -356,7 +354,7 @@ public class RexNodeConverter implements ExpressionVisitor<RexNode> {
 			FunctionDefinition def = call.getFunctionDefinition();
 			if (conversionsOfBuiltInFunc.containsKey(def)) {
 				RexNodeConversion conversion = conversionsOfBuiltInFunc.get(def);
-				return conversion.convert(call);
+				return conversion.convert(call.getChildren());
 			} else {
 				throw new UnsupportedOperationException(def.toString());
 			}
@@ -877,25 +875,17 @@ public class RexNodeConverter implements ExpressionVisitor<RexNode> {
 
 	@Override
 	public RexNode visit(Expression other) {
-		if (other instanceof UnresolvedReferenceExpression) {
-			return visitUnresolvedReferenceExpression((UnresolvedReferenceExpression) other);
-		} else if (other instanceof ResolvedAggInputReference) {
+		if (other instanceof ResolvedAggInputReference) {
 			return visitResolvedAggInputReference((ResolvedAggInputReference) other);
 		} else if (other instanceof ResolvedAggLocalReference) {
 			return visitResolvedAggLocalReference((ResolvedAggLocalReference) other);
 		} else if (other instanceof ResolvedDistinctKeyReference) {
 			return visitResolvedDistinctKeyReference((ResolvedDistinctKeyReference) other);
-		} else if (other instanceof UnresolvedCallExpression) {
-			return visit((UnresolvedCallExpression) other);
 		} else if (other instanceof RexNodeExpression) {
 			return ((RexNodeExpression) other).getRexNode();
 		} else {
 			throw new UnsupportedOperationException(other.getClass().getSimpleName() + ":" + other.toString());
 		}
-	}
-
-	private RexNode visitUnresolvedReferenceExpression(UnresolvedReferenceExpression field) {
-		return relBuilder.field(field.getName());
 	}
 
 	private RexNode visitResolvedAggInputReference(ResolvedAggInputReference reference) {
@@ -920,34 +910,6 @@ public class RexNodeConverter implements ExpressionVisitor<RexNode> {
 				reference.getName(),
 				typeFactory.createFieldTypeFromLogicalType(type),
 				type);
-	}
-
-	private RexNode visit(UnresolvedCallExpression call) {
-		FunctionDefinition func = call.getFunctionDefinition();
-		switch (func.getKind()) {
-			case SCALAR:
-				if (func instanceof ScalarFunctionDefinition) {
-					ScalarFunction scalaFunc = ((ScalarFunctionDefinition) func).getScalarFunction();
-					List<RexNode> child = convertCallChildren(call.getChildren());
-					SqlFunction sqlFunction = UserDefinedFunctionUtils.createScalarSqlFunction(
-							scalaFunc.functionIdentifier(),
-							scalaFunc.toString(),
-							scalaFunc,
-							typeFactory);
-					return relBuilder.call(sqlFunction, child);
-				} else {
-					FunctionDefinition def = call.getFunctionDefinition();
-					if (conversionsOfBuiltInFunc.containsKey(def)) {
-						RexNodeConversion conversion = conversionsOfBuiltInFunc.get(def);
-						return conversion.convert(call);
-					} else {
-						throw new UnsupportedOperationException(def.toString());
-					}
-				}
-
-			default:
-				throw new UnsupportedOperationException();
-		}
 	}
 
 	private RexNode createCollation(RexNode node, RelFieldCollation.Direction direction,
@@ -1025,20 +987,10 @@ public class RexNodeConverter implements ExpressionVisitor<RexNode> {
 	}
 
 	/**
-	 * RexNodeConversion to define how to convert a {@link CallExpression} or a {@link UnresolvedCallExpression} which
+	 * RexNodeConversion to define how to convert a {@link CallExpression} which
 	 * has built-in FunctionDefinition to RexNode.
 	 */
 	private interface RexNodeConversion {
-
 		RexNode convert(List<Expression> children);
-
-		default RexNode convert(CallExpression expression) {
-			return convert(expression.getChildren());
-		}
-
-		default RexNode convert(UnresolvedCallExpression unresolvedCallExpression) {
-			return convert(unresolvedCallExpression.getChildren());
-		}
 	}
-
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/UnresolvedCallExpressionToRexNode.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/UnresolvedCallExpressionToRexNode.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.expressions;
+
+import org.apache.flink.table.expressions.CallExpression;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.expressions.UnresolvedCallExpression;
+import org.apache.flink.table.expressions.ValueLiteralExpression;
+import org.apache.flink.table.expressions.resolver.rules.ResolveCallByArgumentsRule;
+import org.apache.flink.table.functions.BuiltInFunctionDefinition;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.types.DataType;
+
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.tools.RelBuilder;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.table.expressions.utils.ApiExpressionUtils.typeLiteral;
+
+/**
+ * Convert {@link UnresolvedCallExpression} to calcite {@link RexNode}, inputs should only contains
+ * call unresolved expression, other expression should have been resolved.
+ */
+public class UnresolvedCallExpressionToRexNode {
+
+	public static RexNode toRexNode(
+		RelBuilder relBuilder, Expression expressions) {
+		return resolveWithoutCatalog(Collections.singletonList(expressions)).get(0)
+			.accept(new RexNodeConverter(relBuilder));
+	}
+
+	private static List<ResolvedExpression> resolveWithoutCatalog(List<Expression> expressions) {
+		return ResolveCallByArgumentsRule.resolve(expressions,
+			new ResolveCallByArgumentsRule.PostResolveCallByArguments() {
+				@Override
+				public CallExpression cast(ResolvedExpression expression, DataType dataType) {
+					BuiltInFunctionDefinition cast = BuiltInFunctionDefinitions.CAST;
+					return new CallExpression(
+						cast,
+						Arrays.asList(expression, typeLiteral(dataType)),
+						dataType);
+				}
+
+				@Override
+				public CallExpression get(ResolvedExpression composite, ValueLiteralExpression key,
+					DataType dataType) {
+					BuiltInFunctionDefinition get = BuiltInFunctionDefinitions.GET;
+					return new CallExpression(
+						get,
+						Arrays.asList(composite, key),
+						dataType);
+				}
+			},
+			PlannerTypeInferenceUtilImpl.INSTANCE);
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/UnresolvedCallExpressionToRexNode.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/UnresolvedCallExpressionToRexNode.java
@@ -49,7 +49,7 @@ public class UnresolvedCallExpressionToRexNode {
 			.accept(new RexNodeConverter(relBuilder));
 	}
 
-	private static List<ResolvedExpression> resolveWithoutCatalog(List<Expression> expressions) {
+	public static List<ResolvedExpression> resolveWithoutCatalog(List<Expression> expressions) {
 		return ResolveCallByArgumentsRule.resolve(expressions,
 			new ResolveCallByArgumentsRule.PostResolveCallByArguments() {
 				@Override

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/DistinctAggCodeGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/DistinctAggCodeGen.scala
@@ -27,7 +27,7 @@ import org.apache.flink.table.planner.codegen.GenerateUtils.{generateFieldAccess
 import org.apache.flink.table.planner.codegen.GeneratedExpression._
 import org.apache.flink.table.planner.codegen.agg.AggsHandlerCodeGenerator._
 import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, ExprCodeGenerator, GeneratedExpression}
-import org.apache.flink.table.planner.expressions.RexNodeConverter
+import org.apache.flink.table.planner.expressions.UnresolvedCallExpressionToRexNode.toRexNode
 import org.apache.flink.table.planner.plan.utils.DistinctInfo
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromDataTypeToLogicalType
 import org.apache.flink.table.types.DataType
@@ -91,7 +91,6 @@ class DistinctAggCodeGen(
   val isValueChangedTerm: String = s"is_distinct_value_changed_$distinctIndex"
   val isValueEmptyTerm: String = s"is_distinct_value_empty_$distinctIndex"
   val valueGenerator: DistinctValueGenerator = createDistinctValueGenerator()
-  private val rexNodeGen = new RexNodeConverter(relBuilder)
 
   addReusableDistinctAccumulator()
 
@@ -198,7 +197,7 @@ class DistinctAggCodeGen(
     val valueTypeTerm = valueGenerator.valueTypeTerm
     val filterResults = filterExpressions.map {
       case None => None
-      case Some(f) => Some(generator.generateExpression(f.accept(rexNodeGen)).resultTerm)
+      case Some(f) => Some(generator.generateExpression(toRexNode(relBuilder, f)).resultTerm)
     }
 
     val head =
@@ -259,7 +258,7 @@ class DistinctAggCodeGen(
     val valueTypeTerm = valueGenerator.valueTypeTerm
     val filterResults = filterExpressions.map {
       case None => None
-      case Some(f) => Some(generator.generateExpression(f.accept(rexNodeGen)).resultTerm)
+      case Some(f) => Some(generator.generateExpression(toRexNode(relBuilder, f)).resultTerm)
     }
 
     val head =

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/WindowCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/WindowCodeGenerator.scala
@@ -34,7 +34,7 @@ import org.apache.flink.table.planner.codegen._
 import org.apache.flink.table.planner.codegen.agg.batch.AggCodeGenHelper.{buildAggregateArgsMapping, genAggregateByFlatAggregateBuffer, genFlatAggBufferExprs, genInitFlatAggregateBuffer}
 import org.apache.flink.table.planner.codegen.agg.batch.WindowCodeGenerator.{asLong, isTimeIntervalLiteral}
 import org.apache.flink.table.planner.expressions.ExpressionBuilder._
-import org.apache.flink.table.planner.expressions.RexNodeConverter
+import org.apache.flink.table.planner.expressions.UnresolvedCallExpressionToRexNode
 import org.apache.flink.table.planner.functions.aggfunctions.DeclarativeAggregateFunction
 import org.apache.flink.table.planner.functions.utils.UserDefinedFunctionUtils.getAccumulatorTypeOfAggregateFunction
 import org.apache.flink.table.planner.plan.logical.{LogicalWindow, SlidingGroupWindow, TumblingGroupWindow}
@@ -695,8 +695,8 @@ abstract class WindowCodeGenerator(
         plus(remainder, literal(slideSize)),
         remainder)),
       literal(index * slideSize))
-    exprCodegen.generateExpression(expr.accept(
-      new RexNodeConverter(relBuilder.values(inputRowType))))
+    exprCodegen.generateExpression(
+      UnresolvedCallExpressionToRexNode.toRexNode(relBuilder.values(inputRowType), expr))
   }
 
   def getGrouping: Array[Int] = grouping

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/PlannerExpressionConverter.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/PlannerExpressionConverter.scala
@@ -60,7 +60,7 @@ class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExp
 
       case REINTERPRET_CAST =>
         assert(children.size == 3)
-        Reinterpret(
+        return Reinterpret(
           children.head.accept(this),
           fromDataTypeToTypeInfo(
             children(1).asInstanceOf[TypeLiteralExpression].getOutputDataType),

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/PlannerExpressionConverter.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/PlannerExpressionConverter.scala
@@ -821,6 +821,14 @@ class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExp
     other match {
       // already converted planner expressions will pass this visitor without modification
       case plannerExpression: PlannerExpression => plannerExpression
+      case aggInput: ResolvedAggInputReference => PlannerResolvedAggInputReference(
+        aggInput.getName, aggInput.getIndex, fromDataTypeToTypeInfo(aggInput.getOutputDataType))
+      case aggLocal: ResolvedAggLocalReference => PlannerResolvedAggLocalReference(
+        aggLocal.getFieldTerm,
+        aggLocal.getNullTerm,
+        fromDataTypeToTypeInfo(aggLocal.getOutputDataType))
+      case key: ResolvedDistinctKeyReference => PlannerResolvedDistinctKeyReference(
+        key.getName, fromDataTypeToTypeInfo(key.getOutputDataType))
 
       case _ =>
         throw new TableException("Unrecognized expression: " + other)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/logic.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/logic.scala
@@ -19,6 +19,8 @@ package org.apache.flink.table.planner.expressions
 
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo
 import org.apache.flink.table.planner.validate._
+import org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter.fromTypeInfoToLogicalType
+import org.apache.flink.table.runtime.typeutils.TypeCheckUtils.isDecimal
 
 abstract class BinaryPredicate extends BinaryExpression {
   override private[flink] def resultType = BasicTypeInfo.BOOLEAN_TYPE_INFO
@@ -76,7 +78,9 @@ case class If(
 
   override private[flink] def validateInput(): ValidationResult = {
     if (condition.resultType == BasicTypeInfo.BOOLEAN_TYPE_INFO &&
-        ifTrue.resultType == ifFalse.resultType) {
+        ((isDecimal(fromTypeInfoToLogicalType(ifTrue.resultType)) &&
+            isDecimal(fromTypeInfoToLogicalType(ifFalse.resultType))) ||
+            ifTrue.resultType == ifFalse.resultType)) {
       ValidationSuccess
     } else {
       ValidationFailure(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRule.scala
@@ -21,7 +21,7 @@ package org.apache.flink.table.planner.plan.rules.logical
 import org.apache.flink.table.api.config.OptimizerConfigOptions
 import org.apache.flink.table.expressions.Expression
 import org.apache.flink.table.planner.calcite.FlinkContext
-import org.apache.flink.table.planner.expressions.RexNodeConverter
+import org.apache.flink.table.planner.expressions.UnresolvedCallExpressionToRexNode
 import org.apache.flink.table.planner.plan.schema.{FlinkRelOptTable, TableSourceTable}
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic
 import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, RexNodeExtractor}
@@ -112,8 +112,8 @@ class PushFilterIntoTableSourceScanRule extends RelOptRule(
       call.transformTo(newScan)
     } else {
       relBuilder.push(scan)
-      val converter = new RexNodeConverter(relBuilder)
-      val remainingConditions = remainingPredicates.map(_.accept(converter)) ++ unconvertedRexNodes
+      val remainingConditions = remainingPredicates.map(
+        UnresolvedCallExpressionToRexNode.toRexNode(relBuilder, _)) ++ unconvertedRexNodes
       val remainingCondition = remainingConditions.reduce((l, r) => relBuilder.and(l, r))
       val newFilter = filter.copy(filter.getTraitSet, newScan, remainingCondition)
       call.transformTo(newFilter)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRule.scala
@@ -101,7 +101,9 @@ class PushFilterIntoTableSourceScanRule extends RelOptRule(
     }
 
     val remainingPredicates = new util.LinkedList[Expression]()
-    predicates.foreach(e => remainingPredicates.add(e))
+    UnresolvedCallExpressionToRexNode
+        .resolveWithoutCatalog(predicates.toList)
+        .foreach(e => remainingPredicates.add(e))
 
     val newRelOptTable = applyPredicate(remainingPredicates, relOptTable, relBuilder.getTypeFactory)
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
@@ -30,9 +30,9 @@ import org.apache.flink.table.planner.calcite.FlinkRelBuilder.PlannerNamedWindow
 import org.apache.flink.table.planner.calcite.{FlinkTypeFactory, FlinkTypeSystem}
 import org.apache.flink.table.planner.dataview.DataViewUtils.useNullSerializerForStateViewFieldsFromAccType
 import org.apache.flink.table.planner.dataview.{DataViewSpec, MapViewSpec}
-import org.apache.flink.table.planner.expressions.{PlannerProctimeAttribute, PlannerRowtimeAttribute, PlannerWindowEnd, PlannerWindowStart, RexNodeConverter}
+import org.apache.flink.table.planner.expressions.{PlannerProctimeAttribute, PlannerRowtimeAttribute, PlannerWindowEnd, PlannerWindowStart}
 import org.apache.flink.table.planner.functions.aggfunctions.DeclarativeAggregateFunction
-import org.apache.flink.table.planner.functions.sql.{FlinkSqlOperatorTable, SqlListAggFunction, SqlFirstLastValueAggFunction}
+import org.apache.flink.table.planner.functions.sql.{FlinkSqlOperatorTable, SqlFirstLastValueAggFunction, SqlListAggFunction}
 import org.apache.flink.table.planner.functions.utils.AggSqlFunction
 import org.apache.flink.table.planner.functions.utils.UserDefinedFunctionUtils._
 import org.apache.flink.table.planner.plan.`trait`.RelModifiedMonotonicity
@@ -49,7 +49,6 @@ import org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataTy
 
 import org.apache.calcite.rel.`type`._
 import org.apache.calcite.rel.core.{Aggregate, AggregateCall}
-import org.apache.calcite.rex.RexInputRef
 import org.apache.calcite.sql.fun._
 import org.apache.calcite.sql.validate.SqlMonotonicity
 import org.apache.calcite.sql.{SqlKind, SqlRankFunction}
@@ -687,8 +686,7 @@ object AggregateUtil extends Enumeration {
     */
   def timeFieldIndex(
       inputType: RelDataType, relBuilder: RelBuilder, timeField: FieldReferenceExpression): Int = {
-    timeField.accept(new RexNodeConverter(relBuilder.values(inputType)))
-        .asInstanceOf[RexInputRef].getIndex
+    relBuilder.values(inputType).field(timeField.getName).getIndex
   }
 
   /**

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/sources/TableSourceUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/sources/TableSourceUtil.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.expressions.ResolvedFieldReference
 import org.apache.flink.table.expressions.utils.ApiExpressionUtils.{typeLiteral, unresolvedCall, valueLiteral}
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
-import org.apache.flink.table.planner.expressions.RexNodeConverter
+import org.apache.flink.table.planner.expressions.UnresolvedCallExpressionToRexNode
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter
 import org.apache.flink.table.runtime.types.PlannerTypeUtils.isAssignable
 import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter.fromDataTypeToTypeInfo
@@ -290,7 +290,7 @@ object TableSourceUtil {
         expression,
         typeLiteral(DataTypes.TIMESTAMP(3).bridgedTo(classOf[Timestamp])),
         valueLiteral(false))
-      val rexExpression = castExpression.accept(new RexNodeConverter(relBuilder))
+      val rexExpression = UnresolvedCallExpressionToRexNode.toRexNode(relBuilder, castExpression)
       relBuilder.clear()
       rexExpression
     }


### PR DESCRIPTION
Mirror of apache flink#9484
## What is the purpose of the change

0.ResolveCallByArgumentsRule should expose easy interface to use with less dependents.
1.DeclarativeAggregate should resolve expressions and ResolvedAggInputReferences should be ResolvedExpression.
2.TimestampExtractor should resolve expressions.
3.SourceFilterPushDown should resolve expressions after RexNodeToExpressionConverter.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs

