### PR TITLE
Mirror of apache flink#9550

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/util/CoreMatchers.java
+++ b/flink-core/src/test/java/org/apache/flink/util/CoreMatchers.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import java.util.Optional;
+
+/**
+ * Hamcrest matchers.
+ */
+public class CoreMatchers {
+
+	public static Matcher<Throwable> containsCause(Throwable failureCause) {
+		return new ContainsCauseMatcher(failureCause);
+	}
+
+	private static class ContainsCauseMatcher extends TypeSafeDiagnosingMatcher<Throwable> {
+
+		private final Throwable failureCause;
+
+		private ContainsCauseMatcher(Throwable failureCause) {
+			this.failureCause = failureCause;
+		}
+
+		@Override
+		protected boolean matchesSafely(Throwable throwable, Description description) {
+			final Optional<Throwable> optionalCause = ExceptionUtils.findThrowable(throwable, cause -> cause.equals(failureCause));
+
+			if (!optionalCause.isPresent()) {
+				description
+					.appendText("The throwable ")
+					.appendValue(throwable)
+					.appendText(" does not contain the expected failure cause ")
+					.appendValue(failureCause);
+			}
+
+			return optionalCause.isPresent();
+		}
+
+		@Override
+		public void describeTo(Description description) {
+			description
+				.appendText("Expected failure cause is ")
+				.appendValue(failureCause);
+		}
+	}
+
+	private CoreMatchers() {
+		throw new UnsupportedOperationException("Cannot instantiate an instance of this class.");
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -695,7 +695,9 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 			log.debug("Replacing old registration of TaskExecutor {}.", taskExecutorResourceId);
 
 			// remove old task manager registration from slot manager
-			slotManager.unregisterTaskManager(oldRegistration.getInstanceID());
+			slotManager.unregisterTaskManager(
+				oldRegistration.getInstanceID(),
+				new ResourceManagerException(String.format("TaskExecutor %s re-connected to the ResourceManager.", taskExecutorResourceId)));
 		}
 
 		final WorkerType newWorker = workerStarted(taskExecutorResourceId);
@@ -803,7 +805,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 			log.info("Closing TaskExecutor connection {} because: {}", resourceID, cause.getMessage());
 
 			// TODO :: suggest failed task executor to stop itself
-			slotManager.unregisterTaskManager(workerRegistration.getInstanceID());
+			slotManager.unregisterTaskManager(workerRegistration.getInstanceID(), cause);
 
 			workerRegistration.getTaskExecutorGateway().disconnectResourceManager(cause);
 		} else {
@@ -859,7 +861,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 			}
 		} else {
 			// unregister in order to clean up potential left over state
-			slotManager.unregisterTaskManager(instanceId);
+			slotManager.unregisterTaskManager(instanceId, cause);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/exceptions/ResourceManagerException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/exceptions/ResourceManagerException.java
@@ -19,11 +19,12 @@
 package org.apache.flink.runtime.resourcemanager.exceptions;
 
 import org.apache.flink.runtime.resourcemanager.ResourceManager;
+import org.apache.flink.util.FlinkException;
 
 /**
  * Base class for {@link ResourceManager} exceptions.
  */
-public class ResourceManagerException extends Exception {
+public class ResourceManagerException extends FlinkException {
 	private static final long serialVersionUID = -5503307426519195160L;
 
 	public ResourceManagerException(String message) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -101,9 +101,10 @@ public interface SlotManager extends AutoCloseable {
 	 * from the slot manager.
 	 *
 	 * @param instanceId identifying the task manager to unregister
+	 * @param cause for unregistering the TaskManager
 	 * @return True if there existed a registered task manager with the given instance id
 	 */
-	boolean unregisterTaskManager(InstanceID instanceId);
+	boolean unregisterTaskManager(InstanceID instanceId, Exception cause);
 
 	/**
 	 * Reports the current slot allocations for a task manager identified by the given instance id.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
+
+/**
+ * Base class for exceptions thrown by the {@link SlotManager}.
+ */
+public class SlotManagerException extends ResourceManagerException {
+	public SlotManagerException(String message) {
+		super(message);
+	}
+
+	public SlotManagerException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public SlotManagerException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
@@ -97,7 +97,7 @@ import static org.mockito.Mockito.when;
 /**
  * Tests for the {@link SlotManagerImpl}.
  */
-public class SlotManagerTest extends TestLogger {
+public class SlotManagerImplTest extends TestLogger {
 
 	/**
 	 * Tests that we can register task manager and their slots at the slot manager.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
@@ -49,6 +49,7 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.FunctionUtils;
 import org.apache.flink.util.function.FunctionWithException;
+import org.apache.flink.util.function.ThrowingRunnable;
 
 import org.junit.Test;
 
@@ -802,9 +803,14 @@ public class SlotManagerImplTest extends TestLogger {
 		final SlotStatus slotStatus2 = new SlotStatus(slotId2, resourceProfile);
 		final SlotReport slotReport = new SlotReport(Arrays.asList(slotStatus1, slotStatus2));
 
-		final Executor mainThreadExecutor = TestingUtils.defaultExecutor();
+		final ScheduledExecutor mainThreadExecutor = TestingUtils.defaultScheduledExecutor();
 
-		try (final SlotManagerImpl slotManager = SlotManagerBuilder.newBuilder().build()) {
+		final SlotManagerImpl slotManager = SlotManagerBuilder
+			.newBuilder()
+			.setScheduledExecutor(mainThreadExecutor)
+			.build();
+
+		try {
 
 			slotManager.start(resourceManagerId, mainThreadExecutor, resourceManagerActions);
 
@@ -830,12 +836,6 @@ public class SlotManagerImplTest extends TestLogger {
 			final SlotID requestedSlotId = slotIds.take();
 			final SlotID freeSlotId = requestedSlotId.equals(slotId1) ? slotId2 : slotId1;
 
-			CompletableFuture<Boolean> freeSlotFuture = CompletableFuture.supplyAsync(
-				() -> slotManager.getSlot(freeSlotId).getState() == TaskManagerSlot.State.FREE,
-				mainThreadExecutor);
-
-			assertTrue(freeSlotFuture.get());
-
 			final SlotStatus newSlotStatus1 = new SlotStatus(requestedSlotId, resourceProfile, new JobID(), new AllocationID());
 			final SlotStatus newSlotStatus2 = new SlotStatus(freeSlotId, resourceProfile);
 			final SlotReport newSlotReport = new SlotReport(Arrays.asList(newSlotStatus1, newSlotStatus2));
@@ -849,16 +849,11 @@ public class SlotManagerImplTest extends TestLogger {
 
 			final SlotID requestedSlotId2 = slotIds.take();
 
-			assertEquals(slotId2, requestedSlotId2);
-
-			CompletableFuture<TaskManagerSlot> requestedSlotFuture = CompletableFuture.supplyAsync(
-				() -> slotManager.getSlot(requestedSlotId2),
+			assertEquals(freeSlotId, requestedSlotId2);
+		} finally {
+			CompletableFuture.runAsync(
+				ThrowingRunnable.unchecked(slotManager::close),
 				mainThreadExecutor);
-
-			TaskManagerSlot slot = requestedSlotFuture.get();
-
-			assertTrue(slot.getState() == TaskManagerSlot.State.ALLOCATED);
-			assertEquals(allocationId, slot.getAllocationId());
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
@@ -45,6 +45,7 @@ import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.taskexecutor.exceptions.SlotAllocationException;
 import org.apache.flink.runtime.taskexecutor.exceptions.SlotOccupiedException;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.util.CoreMatchers;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.FunctionUtils;
@@ -74,6 +75,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -92,6 +94,8 @@ import static org.junit.Assert.fail;
  * Tests for the {@link SlotManagerImpl}.
  */
 public class SlotManagerImplTest extends TestLogger {
+
+	private static final FlinkException TEST_EXCEPTION = new FlinkException("Test exception");
 
 	/**
 	 * Tests that we can register task manager and their slots at the slot manager.
@@ -176,7 +180,7 @@ public class SlotManagerImplTest extends TestLogger {
 
 			assertTrue("The pending slot request should have been assigned to slot 2", pendingSlotRequest.isAssigned());
 
-			slotManager.unregisterTaskManager(taskManagerConnection.getInstanceID());
+			slotManager.unregisterTaskManager(taskManagerConnection.getInstanceID(), TEST_EXCEPTION);
 
 			assertTrue(0 == slotManager.getNumberRegisteredSlots());
 			assertFalse(pendingSlotRequest.isAssigned());
@@ -960,9 +964,7 @@ public class SlotManagerImplTest extends TestLogger {
 		final TaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway();
 
 		final TaskExecutorConnection taskExecutorConnection = new TaskExecutorConnection(resourceID, taskExecutorGateway);
-		final SlotStatus slotStatus = new SlotStatus(
-			new SlotID(resourceID, 0),
-			new ResourceProfile(1.0, 1));
+		final SlotStatus slotStatus = createEmptySlotStatus(new SlotID(resourceID, 0), new ResourceProfile(1.0, 1));
 		final SlotReport initialSlotReport = new SlotReport(slotStatus);
 
 		try (final SlotManager slotManager = SlotManagerBuilder.newBuilder()
@@ -980,7 +982,7 @@ public class SlotManagerImplTest extends TestLogger {
 
 			assertEquals(1, slotManager.getNumberRegisteredSlots());
 
-			slotManager.unregisterTaskManager(taskExecutorConnection.getInstanceID());
+			slotManager.unregisterTaskManager(taskExecutorConnection.getInstanceID(), TEST_EXCEPTION);
 
 			assertEquals(0, slotManager.getNumberRegisteredSlots());
 		}
@@ -1070,7 +1072,7 @@ public class SlotManagerImplTest extends TestLogger {
 
 			final ResourceID taskExecutorResourceId = ResourceID.generate();
 			final TaskExecutorConnection taskExecutionConnection = new TaskExecutorConnection(taskExecutorResourceId, testingTaskExecutorGateway);
-			final SlotReport slotReport = new SlotReport(new SlotStatus(new SlotID(taskExecutorResourceId, 0), ResourceProfile.UNKNOWN));
+			final SlotReport slotReport = new SlotReport(createEmptySlotStatus(new SlotID(taskExecutorResourceId, 0), ResourceProfile.UNKNOWN));
 
 			final CompletableFuture<Acknowledge> firstManualSlotRequestResponse = new CompletableFuture<>();
 			responseQueue.offer(firstManualSlotRequestResponse);
@@ -1126,7 +1128,7 @@ public class SlotManagerImplTest extends TestLogger {
 
 			final ResourceID taskExecutorResourceId = ResourceID.generate();
 			final TaskExecutorConnection taskExecutionConnection = new TaskExecutorConnection(taskExecutorResourceId, testingTaskExecutorGateway);
-			final SlotReport slotReport = new SlotReport(new SlotStatus(new SlotID(taskExecutorResourceId, 0), ResourceProfile.UNKNOWN));
+			final SlotReport slotReport = new SlotReport(createEmptySlotStatus(new SlotID(taskExecutorResourceId, 0), ResourceProfile.UNKNOWN));
 
 			final CompletableFuture<Acknowledge> firstManualSlotRequestResponse = new CompletableFuture<>();
 			responseQueue.offer(firstManualSlotRequestResponse);
@@ -1219,7 +1221,7 @@ public class SlotManagerImplTest extends TestLogger {
 			slotManager.registerTaskManager(taskExecutionConnection2, slotReport2);
 
 			// validate for job1.
-			slotManager.unregisterTaskManager(taskExecutionConnection1.getInstanceID());
+			slotManager.unregisterTaskManager(taskExecutionConnection1.getInstanceID(), TEST_EXCEPTION);
 
 			assertThat(allocationFailures, hasSize(2));
 
@@ -1234,7 +1236,7 @@ public class SlotManagerImplTest extends TestLogger {
 			assertThat(failedAllocations, containsInAnyOrder(slotRequest11.getAllocationId(), slotRequest12.getAllocationId()));
 
 			// validate the result for job2 and job3.
-			slotManager.unregisterTaskManager(taskExecutionConnection2.getInstanceID());
+			slotManager.unregisterTaskManager(taskExecutionConnection2.getInstanceID(), TEST_EXCEPTION);
 
 			assertThat(allocationFailures, hasSize(3));
 
@@ -1256,17 +1258,25 @@ public class SlotManagerImplTest extends TestLogger {
 
 	@Nonnull
 	private SlotReport createSlotReport(ResourceID taskExecutorResourceId, int numberSlots) {
-		return createSlotReport(taskExecutorResourceId, numberSlots, ResourceProfile.UNKNOWN);
+		return createSlotReport(taskExecutorResourceId, numberSlots, ResourceProfile.UNKNOWN, this::createEmptySlotStatus);
 	}
 
 	@Nonnull
-	private SlotReport createSlotReport(ResourceID taskExecutorResourceId, int numberSlots, ResourceProfile resourceProfile) {
+	private SlotReport createSlotReport(
+			ResourceID taskExecutorResourceId,
+			int numberSlots,
+			ResourceProfile resourceProfile,
+			BiFunction<SlotID, ResourceProfile, SlotStatus> slotStatusFactory) {
 		final Set<SlotStatus> slotStatusSet = new HashSet<>(numberSlots);
 		for (int i = 0; i < numberSlots; i++) {
-			slotStatusSet.add(new SlotStatus(new SlotID(taskExecutorResourceId, i), resourceProfile));
+			slotStatusSet.add(slotStatusFactory.apply(new SlotID(taskExecutorResourceId, i), resourceProfile));
 		}
 
 		return new SlotReport(slotStatusSet);
+	}
+
+	private SlotStatus createEmptySlotStatus(SlotID slotId, ResourceProfile resourceProfile) {
+		return new SlotStatus(slotId, resourceProfile);
 	}
 
 	@Nonnull
@@ -1402,7 +1412,11 @@ public class SlotManagerImplTest extends TestLogger {
 			final int numberOfferedSlots = 1;
 			final TaskExecutorConnection taskExecutorConnection = createTaskExecutorConnection();
 			final ResourceProfile offeredSlotProfile = new ResourceProfile(2.0, 2);
-			final SlotReport slotReport = createSlotReport(taskExecutorConnection.getResourceID(), numberOfferedSlots, offeredSlotProfile);
+			final SlotReport slotReport = createSlotReport(
+				taskExecutorConnection.getResourceID(),
+				numberOfferedSlots,
+				offeredSlotProfile,
+				this::createEmptySlotStatus);
 
 			slotManager.registerTaskManager(taskExecutorConnection, slotReport);
 
@@ -1450,5 +1464,35 @@ public class SlotManagerImplTest extends TestLogger {
 
 			return result;
 		};
+	}
+
+	/**
+	 * Tests that the unregister cause is being forwarded when failing allocations.
+	 */
+	@Test
+	public void unregisterTaskManager_withAllocatedSlot_failsAllocationsWithCause() throws Exception {
+		CompletableFuture<Exception> allocationFailureCause = new CompletableFuture<>();
+		TestingResourceActions resourceActions = new TestingResourceActionsBuilder()
+			.setNotifyAllocationFailureConsumer(jobIDAllocationIDExceptionTuple3 -> allocationFailureCause.complete(jobIDAllocationIDExceptionTuple3.f2))
+			.build();
+
+		FlinkException failureCause = new FlinkException("unregisterTaskManager test exception.");
+
+		try (SlotManagerImpl slotManager = createSlotManager(ResourceManagerId.generate(), resourceActions)) {
+			TaskExecutorConnection taskExecutorConnection = createTaskExecutorConnection();
+			SlotReport slotReport = createSingleAllocatedSlotReport(taskExecutorConnection.getResourceID(), new JobID());
+			slotManager.registerTaskManager(taskExecutorConnection, slotReport);
+			slotManager.unregisterTaskManager(taskExecutorConnection.getInstanceID(), failureCause);
+
+			assertThat(allocationFailureCause.get(), CoreMatchers.containsCause(failureCause));
+		}
+	}
+
+	private SlotReport createSingleAllocatedSlotReport(ResourceID resourceID, JobID jobId) {
+		return createSlotReport(
+			resourceID,
+			1,
+			ResourceProfile.UNKNOWN,
+			(slotId, resourceProfile) -> new SlotStatus(slotId, resourceProfile, jobId, new AllocationID()));
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
@@ -47,10 +47,10 @@ import org.apache.flink.runtime.taskexecutor.exceptions.SlotOccupiedException;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.FunctionUtils;
 import org.apache.flink.util.function.FunctionWithException;
 
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 
 import javax.annotation.Nonnull;
 
@@ -59,6 +59,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -85,14 +86,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests for the {@link SlotManagerImpl}.
@@ -134,7 +127,7 @@ public class SlotManagerImplTest extends TestLogger {
 	@Test
 	public void testTaskManagerUnregistration() throws Exception {
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
-		final ResourceActions resourceManagerActions = mock(ResourceActions.class);
+		final ResourceActions resourceManagerActions = new TestingResourceActionsBuilder().build();
 		final JobID jobId = new JobID();
 
 		final TaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
@@ -301,7 +294,7 @@ public class SlotManagerImplTest extends TestLogger {
 	@Test
 	public void testUnregisterPendingSlotRequest() throws Exception {
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
-		final ResourceActions resourceManagerActions = mock(ResourceActions.class);
+		final ResourceActions resourceManagerActions = new TestingResourceActionsBuilder().build();
 		final ResourceID resourceID = ResourceID.generate();
 		final SlotID slotId = new SlotID(resourceID, 0);
 		final AllocationID allocationId = new AllocationID();
@@ -399,18 +392,15 @@ public class SlotManagerImplTest extends TestLogger {
 	@Test
 	public void testFreeSlot() throws Exception {
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
-		final ResourceID resourceID = ResourceID.generate();
 		final JobID jobId = new JobID();
+
+		ResourceActions resourceManagerActions = new TestingResourceActionsBuilder().build();
+
+		final TaskExecutorConnection taskExecutorConnection = createTaskExecutorConnection();
+		final ResourceID resourceID = taskExecutorConnection.getResourceID();
 		final SlotID slotId = new SlotID(resourceID, 0);
 		final AllocationID allocationId = new AllocationID();
 		final ResourceProfile resourceProfile = new ResourceProfile(42.0, 1337);
-
-		ResourceActions resourceManagerActions = mock(ResourceActions.class);
-
-		// accept an incoming slot request
-		final TaskExecutorGateway taskExecutorGateway = mock(TaskExecutorGateway.class);
-
-		final TaskExecutorConnection taskExecutorConnection = new TaskExecutorConnection(resourceID, taskExecutorGateway);
 
 		final SlotStatus slotStatus = new SlotStatus(slotId, resourceProfile, jobId, allocationId);
 		final SlotReport slotReport = new SlotReport(slotStatus);
@@ -472,16 +462,15 @@ public class SlotManagerImplTest extends TestLogger {
 	@Test
 	public void testDuplicatePendingSlotRequestAfterSlotReport() throws Exception {
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
-		final ResourceActions resourceManagerActions = mock(ResourceActions.class);
+		final ResourceActions resourceManagerActions = new TestingResourceActionsBuilder().build();
+
+		final TaskExecutorConnection taskManagerConnection = createTaskExecutorConnection();
+		final ResourceID resourceID = taskManagerConnection.getResourceID();
+
 		final JobID jobId = new JobID();
 		final AllocationID allocationId = new AllocationID();
 		final ResourceProfile resourceProfile = new ResourceProfile(1.0, 1);
-		final ResourceID resourceID = ResourceID.generate();
 		final SlotID slotId = new SlotID(resourceID, 0);
-
-		final TaskExecutorGateway taskExecutorGateway = mock(TaskExecutorGateway.class);
-		final TaskExecutorConnection taskManagerConnection = new TaskExecutorConnection(resourceID, taskExecutorGateway);
-
 		final SlotStatus slotStatus = new SlotStatus(slotId, resourceProfile, jobId, allocationId);
 		final SlotReport slotReport = new SlotReport(slotStatus);
 
@@ -594,7 +583,7 @@ public class SlotManagerImplTest extends TestLogger {
 	@Test
 	public void testReceivingUnknownSlotReport() throws Exception {
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
-		final ResourceActions resourceManagerActions = mock(ResourceActions.class);
+		final ResourceActions resourceManagerActions = new TestingResourceActionsBuilder().build();
 
 		final InstanceID unknownInstanceID = new InstanceID();
 		final SlotID unknownSlotId = new SlotID(ResourceID.generate(), 0);
@@ -625,7 +614,9 @@ public class SlotManagerImplTest extends TestLogger {
 		final JobID jobId = new JobID();
 		final AllocationID allocationId = new AllocationID();
 
-		final ResourceID resourceId = ResourceID.generate();
+		final TaskExecutorConnection taskManagerConnection = createTaskExecutorConnection();
+		final ResourceID resourceId = taskManagerConnection.getResourceID();
+
 		final SlotID slotId1 = new SlotID(resourceId, 0);
 		final SlotID slotId2 = new SlotID(resourceId, 1);
 
@@ -637,9 +628,6 @@ public class SlotManagerImplTest extends TestLogger {
 
 		final SlotReport slotReport1 = new SlotReport(Arrays.asList(slotStatus1, slotStatus2));
 		final SlotReport slotReport2 = new SlotReport(Arrays.asList(newSlotStatus2, slotStatus1));
-
-		final TaskExecutorGateway taskExecutorGateway = mock(TaskExecutorGateway.class);
-		final TaskExecutorConnection taskManagerConnection = new TaskExecutorConnection(resourceId, taskExecutorGateway);
 
 		try (SlotManagerImpl slotManager = createSlotManager(resourceManagerId, resourceManagerActions)) {
 			// check that we don't have any slots registered
@@ -720,7 +708,7 @@ public class SlotManagerImplTest extends TestLogger {
 	@SuppressWarnings("unchecked")
 	public void testTaskManagerSlotRequestTimeoutHandling() throws Exception {
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
-		final ResourceActions resourceManagerActions = mock(ResourceActions.class);
+		final ResourceActions resourceManagerActions = new TestingResourceActionsBuilder().build();
 
 		final JobID jobId = new JobID();
 		final AllocationID allocationId = new AllocationID();
@@ -728,15 +716,16 @@ public class SlotManagerImplTest extends TestLogger {
 		final SlotRequest slotRequest = new SlotRequest(jobId, allocationId, resourceProfile, "foobar");
 		final CompletableFuture<Acknowledge> slotRequestFuture1 = new CompletableFuture<>();
 		final CompletableFuture<Acknowledge> slotRequestFuture2 = new CompletableFuture<>();
+		final Iterator<CompletableFuture<Acknowledge>> slotRequestFutureIterator = Arrays.asList(slotRequestFuture1, slotRequestFuture2).iterator();
+		final ArrayBlockingQueue<SlotID> slotIds = new ArrayBlockingQueue<>(2);
 
-		final TaskExecutorGateway taskExecutorGateway = mock(TaskExecutorGateway.class);
-		when(taskExecutorGateway.requestSlot(
-			any(SlotID.class),
-			any(JobID.class),
-			eq(allocationId),
-			anyString(),
-			any(ResourceManagerId.class),
-			any(Time.class))).thenReturn(slotRequestFuture1, slotRequestFuture2);
+		final TestingTaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
+			.setRequestSlotFunction(FunctionUtils.uncheckedFunction(
+				requestSlotParameters -> {
+					slotIds.put(requestSlotParameters.f0);
+					return slotRequestFutureIterator.next();
+				}))
+			.createTestingTaskExecutorGateway();
 
 		final ResourceID resourceId = ResourceID.generate();
 		final TaskExecutorConnection taskManagerConnection = new TaskExecutorConnection(resourceId, taskExecutorGateway);
@@ -753,33 +742,18 @@ public class SlotManagerImplTest extends TestLogger {
 
 			slotManager.registerSlotRequest(slotRequest);
 
-			ArgumentCaptor<SlotID> slotIdCaptor = ArgumentCaptor.forClass(SlotID.class);
-
-			verify(taskExecutorGateway, times(1)).requestSlot(
-				slotIdCaptor.capture(),
-				eq(jobId),
-				eq(allocationId),
-				anyString(),
-				eq(resourceManagerId),
-				any(Time.class));
-
-			TaskManagerSlot failedSlot = slotManager.getSlot(slotIdCaptor.getValue());
+			final SlotID firstSlotId = slotIds.take();
+			TaskManagerSlot failedSlot = slotManager.getSlot(firstSlotId);
 
 			// let the first attempt fail --> this should trigger a second attempt
 			slotRequestFuture1.completeExceptionally(new SlotAllocationException("Test exception."));
 
-			verify(taskExecutorGateway, times(2)).requestSlot(
-				slotIdCaptor.capture(),
-				eq(jobId),
-				eq(allocationId),
-				anyString(),
-				eq(resourceManagerId),
-				any(Time.class));
-
 			// the second attempt succeeds
 			slotRequestFuture2.complete(Acknowledge.get());
 
-			TaskManagerSlot slot = slotManager.getSlot(slotIdCaptor.getValue());
+			final SlotID secondSlotId = slotIds.take();
+
+			TaskManagerSlot slot = slotManager.getSlot(secondSlotId);
 
 			assertTrue(slot.getState() == TaskManagerSlot.State.ALLOCATED);
 			assertEquals(allocationId, slot.getAllocationId());
@@ -797,7 +771,6 @@ public class SlotManagerImplTest extends TestLogger {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testSlotReportWhileActiveSlotRequest() throws Exception {
-		final long verifyTimeout = 10000L;
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final ResourceActions resourceManagerActions = new TestingResourceActionsBuilder().build();
 
@@ -807,14 +780,18 @@ public class SlotManagerImplTest extends TestLogger {
 		final SlotRequest slotRequest = new SlotRequest(jobId, allocationId, resourceProfile, "foobar");
 		final CompletableFuture<Acknowledge> slotRequestFuture1 = new CompletableFuture<>();
 
-		final TaskExecutorGateway taskExecutorGateway = mock(TaskExecutorGateway.class);
-		when(taskExecutorGateway.requestSlot(
-			any(SlotID.class),
-			any(JobID.class),
-			eq(allocationId),
-			anyString(),
-			any(ResourceManagerId.class),
-			any(Time.class))).thenReturn(slotRequestFuture1, CompletableFuture.completedFuture(Acknowledge.get()));
+		final Iterator<CompletableFuture<Acknowledge>> slotRequestFutureIterator = Arrays.asList(
+			slotRequestFuture1,
+			CompletableFuture.completedFuture(Acknowledge.get())).iterator();
+		final ArrayBlockingQueue<SlotID> slotIds = new ArrayBlockingQueue<>(2);
+
+		final TestingTaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
+			.setRequestSlotFunction(FunctionUtils.uncheckedFunction(
+				requestSlotParameters -> {
+					slotIds.put(requestSlotParameters.f0);
+					return slotRequestFutureIterator.next();
+				}))
+			.createTestingTaskExecutorGateway();
 
 		final ResourceID resourceId = ResourceID.generate();
 		final TaskExecutorConnection taskManagerConnection = new TaskExecutorConnection(resourceId, taskExecutorGateway);
@@ -850,17 +827,7 @@ public class SlotManagerImplTest extends TestLogger {
 			// check that no exception has been thrown
 			registrationFuture.get();
 
-			ArgumentCaptor<SlotID> slotIdCaptor = ArgumentCaptor.forClass(SlotID.class);
-
-			verify(taskExecutorGateway, times(1)).requestSlot(
-				slotIdCaptor.capture(),
-				eq(jobId),
-				eq(allocationId),
-				anyString(),
-				eq(resourceManagerId),
-				any(Time.class));
-
-			final SlotID requestedSlotId = slotIdCaptor.getValue();
+			final SlotID requestedSlotId = slotIds.take();
 			final SlotID freeSlotId = requestedSlotId.equals(slotId1) ? slotId2 : slotId1;
 
 			CompletableFuture<Boolean> freeSlotFuture = CompletableFuture.supplyAsync(
@@ -869,7 +836,7 @@ public class SlotManagerImplTest extends TestLogger {
 
 			assertTrue(freeSlotFuture.get());
 
-			final SlotStatus newSlotStatus1 = new SlotStatus(slotIdCaptor.getValue(), resourceProfile, new JobID(), new AllocationID());
+			final SlotStatus newSlotStatus1 = new SlotStatus(requestedSlotId, resourceProfile, new JobID(), new AllocationID());
 			final SlotStatus newSlotStatus2 = new SlotStatus(freeSlotId, resourceProfile);
 			final SlotReport newSlotReport = new SlotReport(Arrays.asList(newSlotStatus1, newSlotStatus2));
 
@@ -880,15 +847,7 @@ public class SlotManagerImplTest extends TestLogger {
 
 			assertTrue(reportSlotStatusFuture.get());
 
-			verify(taskExecutorGateway, timeout(verifyTimeout).times(2)).requestSlot(
-				slotIdCaptor.capture(),
-				eq(jobId),
-				eq(allocationId),
-				anyString(),
-				eq(resourceManagerId),
-				any(Time.class));
-
-			final SlotID requestedSlotId2 = slotIdCaptor.getValue();
+			final SlotID requestedSlotId2 = slotIds.take();
 
 			assertEquals(slotId2, requestedSlotId2);
 
@@ -1001,10 +960,11 @@ public class SlotManagerImplTest extends TestLogger {
 		final Time taskManagerTimeout = Time.milliseconds(10L);
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final ResourceID resourceID = ResourceID.generate();
-		final ResourceActions resourceActions = mock(ResourceActions.class);
-		final TaskExecutorGateway taskExecutorGateway = mock(TaskExecutorGateway.class);
-
-		when(taskExecutorGateway.canBeReleased()).thenReturn(CompletableFuture.completedFuture(true));
+		final CompletableFuture<InstanceID> releaseResourceFuture = new CompletableFuture<>();
+		final ResourceActions resourceActions = new TestingResourceActionsBuilder()
+			.setReleaseResourceConsumer((instanceId, ignored) -> releaseResourceFuture.complete(instanceId))
+			.build();
+		final TaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway();
 
 		final TaskExecutorConnection taskExecutorConnection = new TaskExecutorConnection(resourceID, taskExecutorGateway);
 		final SlotStatus slotStatus = new SlotStatus(
@@ -1023,7 +983,7 @@ public class SlotManagerImplTest extends TestLogger {
 			assertEquals(1, slotManager.getNumberRegisteredSlots());
 
 			// wait for the timeout call to happen
-			verify(resourceActions, timeout(taskManagerTimeout.toMilliseconds() * 20L).atLeast(1)).releaseResource(eq(taskExecutorConnection.getInstanceID()), any(Exception.class));
+			assertThat(releaseResourceFuture.get(), is(taskExecutorConnection.getInstanceID()));
 
 			assertEquals(1, slotManager.getNumberRegisteredSlots());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
@@ -706,7 +706,6 @@ public class SlotManagerImplTest extends TestLogger {
 	 * Tests that a slot request is retried if it times out on the task manager side.
 	 */
 	@Test
-	@SuppressWarnings("unchecked")
 	public void testTaskManagerSlotRequestTimeoutHandling() throws Exception {
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final ResourceActions resourceManagerActions = new TestingResourceActionsBuilder().build();
@@ -770,7 +769,6 @@ public class SlotManagerImplTest extends TestLogger {
 	 * is received.
 	 */
 	@Test
-	@SuppressWarnings("unchecked")
 	public void testSlotReportWhileActiveSlotRequest() throws Exception {
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final ResourceActions resourceManagerActions = new TestingResourceActionsBuilder().build();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
@@ -96,7 +96,7 @@ public class TestingSlotManager implements SlotManager {
 	}
 
 	@Override
-	public boolean unregisterTaskManager(InstanceID instanceId) {
+	public boolean unregisterTaskManager(InstanceID instanceId, Exception cause) {
 		return false;
 	}
 


### PR DESCRIPTION
Mirror of apache flink#9550
## What is the purpose of the change

Forwarding the slot removal cause to the ResourceActions allows to notify the JobMaster
about the allocation failure cause. This improves debuggability and understanding of the
system.

## Verifying this change

- Added `SlotManagerImplTest#unregisterTaskManager_withAllocatedSlot_failsAllocationsWithCause`
- Tested manually that the correct failure cause is forwarded to the `JobMaster`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

