### PR TITLE
Mirror of apache flink#9549

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/SqlClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/SqlClient.java
@@ -119,14 +119,20 @@ public class SqlClient {
 		try {
 			cli = new CliClient(context, executor);
 			// interactive CLI mode
-			if (options.getUpdateStatement() == null) {
+			if (options.getUpdateStatement() == null && options.getQueryStatement() == null) {
 				cli.open();
 			}
 			// execute single update statement
-			else {
+			else if (options.getUpdateStatement() != null) {
 				final boolean success = cli.submitUpdate(options.getUpdateStatement());
 				if (!success) {
 					throw new SqlClientException("Could not submit given SQL update statement to cluster.");
+				}
+			}
+			else if (options.getQueryStatement() != null) {
+				final boolean success = cli.executeQuery(options.getQueryStatement());
+				if (!success) {
+					throw new SqlClientException("Cound not execute given SQL query statement.");
 				}
 			}
 		} finally {

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -237,6 +237,35 @@ public class CliClient {
 		}).orElse(false);
 	}
 
+	public boolean executeQuery(String statement) {
+		// TODO: long running streaming query would block the process, only support batch query now.
+		//  https://issues.apache.org/jira/browse/FLINK-12814 intros a non-interactive view mode,
+		//  and streaming query would time out and terminate. we could execute streaming query in
+		//  non-interactive view mode.
+		if (!(executor.getSessionProperties(context).containsKey("execution.type")
+			&& "batch".equalsIgnoreCase(executor.getSessionProperties(context).get("execution.type")))) {
+			printError("Unsupported execution mode: please use batch mode!");
+			return false;
+		}
+
+		terminal.writer().println(CliStrings.messageInfo(CliStrings.MESSAGE_WILL_EXECUTE).toAnsi());
+		terminal.writer().println(new AttributedString(statement).toString());
+		terminal.flush();
+
+		final Optional<SqlCommandCall> parsedStatement = parseCommand(statement);
+
+		return parsedStatement.map(cmdCall -> {
+			switch (cmdCall.command) {
+				case SELECT:
+					callSelect(cmdCall);
+					return true;
+				default:
+					printError(CliStrings.MESSAGE_UNSUPPORTED_SQL);
+					return false;
+			}
+		}).orElse(false);
+	}
+
 	// --------------------------------------------------------------------------------------------
 
 	private Optional<SqlCommandCall> parseCommand(String line) {

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliOptions.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliOptions.java
@@ -34,6 +34,7 @@ public class CliOptions {
 	private final List<URL> jars;
 	private final List<URL> libraryDirs;
 	private final String updateStatement;
+	private final String queryStatement;
 
 	public CliOptions(
 			boolean isPrintHelp,
@@ -42,7 +43,8 @@ public class CliOptions {
 			URL defaults,
 			List<URL> jars,
 			List<URL> libraryDirs,
-			String updateStatement) {
+			String updateStatement,
+			String queryStatement) {
 		this.isPrintHelp = isPrintHelp;
 		this.sessionId = sessionId;
 		this.environment = environment;
@@ -50,6 +52,7 @@ public class CliOptions {
 		this.jars = jars;
 		this.libraryDirs = libraryDirs;
 		this.updateStatement = updateStatement;
+		this.queryStatement = queryStatement;
 	}
 
 	public boolean isPrintHelp() {
@@ -78,5 +81,9 @@ public class CliOptions {
 
 	public String getUpdateStatement() {
 		return updateStatement;
+	}
+
+	public String getQueryStatement() {
+		return queryStatement;
 	}
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliOptionsParser.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliOptionsParser.java
@@ -117,6 +117,20 @@ public class CliOptionsParser {
 				"the target sink table.")
 			.build();
 
+	public static final Option OPTION_QUERY = Option
+			.builder("q")
+			.required(false)
+			.longOpt("query")
+			.numberOfArgs(1)
+			.argName("SQL query statement")
+			.desc(
+				"Experimental (for testing only!): Instructs the SQL Client to immediately execute " +
+				"the given query statement after starting up. The process is shut down after the " +
+				"statement has been submitted to the cluster and returns appropriate return results. " +
+				"Currently, this feature is only supported for BATCH mode for a long running streaming " +
+				"job would block the process.")
+			.build();
+
 	private static final Options EMBEDDED_MODE_CLIENT_OPTIONS = getEmbeddedModeClientOptions(new Options());
 	private static final Options GATEWAY_MODE_CLIENT_OPTIONS = getGatewayModeClientOptions(new Options());
 	private static final Options GATEWAY_MODE_GATEWAY_OPTIONS = getGatewayModeGatewayOptions(new Options());
@@ -133,6 +147,7 @@ public class CliOptionsParser {
 		options.addOption(OPTION_JAR);
 		options.addOption(OPTION_LIBRARY);
 		options.addOption(OPTION_UPDATE);
+		options.addOption(OPTION_QUERY);
 		return options;
 	}
 
@@ -141,6 +156,7 @@ public class CliOptionsParser {
 		options.addOption(OPTION_SESSION);
 		options.addOption(OPTION_ENVIRONMENT);
 		options.addOption(OPTION_UPDATE);
+		options.addOption(OPTION_QUERY);
 		return options;
 	}
 
@@ -235,7 +251,8 @@ public class CliOptionsParser {
 				checkUrl(line, CliOptionsParser.OPTION_DEFAULTS),
 				checkUrls(line, CliOptionsParser.OPTION_JAR),
 				checkUrls(line, CliOptionsParser.OPTION_LIBRARY),
-				line.getOptionValue(CliOptionsParser.OPTION_UPDATE.getOpt())
+				line.getOptionValue(CliOptionsParser.OPTION_UPDATE.getOpt()),
+				line.getOptionValue(CliOptionsParser.OPTION_QUERY.getOpt())
 			);
 		}
 		catch (ParseException e) {
@@ -254,7 +271,8 @@ public class CliOptionsParser {
 				null,
 				checkUrls(line, CliOptionsParser.OPTION_JAR),
 				checkUrls(line, CliOptionsParser.OPTION_LIBRARY),
-				line.getOptionValue(CliOptionsParser.OPTION_UPDATE.getOpt())
+				line.getOptionValue(CliOptionsParser.OPTION_UPDATE.getOpt()),
+				line.getOptionValue(CliOptionsParser.OPTION_QUERY.getOpt())
 			);
 		}
 		catch (ParseException e) {
@@ -273,6 +291,7 @@ public class CliOptionsParser {
 				checkUrl(line, CliOptionsParser.OPTION_DEFAULTS),
 				checkUrls(line, CliOptionsParser.OPTION_JAR),
 				checkUrls(line, CliOptionsParser.OPTION_LIBRARY),
+				null,
 				null
 			);
 		}


### PR DESCRIPTION
Mirror of apache flink#9549
…t as input

## What is the purpose of the change

Support -q option to execute a SQL query statement without entering interactive mode.

## Brief change log

Support -q option to execute a SQL query statement without entering interactive mode.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

