### PR TITLE
Mirror of apache flink#9547

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimLoader.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimLoader.java
@@ -35,6 +35,8 @@ public class HiveShimLoader {
 	public static final String HIVE_VERSION_V1_2_0 = "1.2.0";
 	public static final String HIVE_VERSION_V1_2_1 = "1.2.1";
 	public static final String HIVE_VERSION_V1_2_2 = "1.2.2";
+	public static final String HIVE_VERSION_V2_1_0 = "2.1.0";
+	public static final String HIVE_VERSION_V2_1_1 = "2.1.1";
 	public static final String HIVE_VERSION_V2_3_0 = "2.3.0";
 	public static final String HIVE_VERSION_V2_3_1 = "2.3.1";
 	public static final String HIVE_VERSION_V2_3_2 = "2.3.2";
@@ -59,6 +61,12 @@ public class HiveShimLoader {
 			}
 			if (v.startsWith(HIVE_VERSION_V1_2_2)) {
 				return new HiveShimV122();
+			}
+			if (v.startsWith(HIVE_VERSION_V2_1_0)) {
+				return new HiveShimV210();
+			}
+			if (v.startsWith(HIVE_VERSION_V2_1_1)) {
+				return new HiveShimV211();
 			}
 			if (v.startsWith(HIVE_VERSION_V2_3_0)) {
 				return new HiveShimV230();

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV210.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV210.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.hive.client;
+
+import org.apache.flink.table.catalog.exceptions.CatalogException;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
+import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.thrift.TException;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * Shim for Hive version 2.1.0.
+ */
+public class HiveShimV210 extends HiveShimV122 {
+
+	@Override
+	public IMetaStoreClient getHiveMetastoreClient(HiveConf hiveConf) {
+		try {
+			Class<?>[] constructorArgTypes = {HiveConf.class};
+			Object[] constructorArgs = {hiveConf};
+			Method method = RetryingMetaStoreClient.class.getMethod("getProxy", HiveConf.class,
+				constructorArgTypes.getClass(), constructorArgs.getClass(), String.class);
+			// getProxy is a static method
+			return (IMetaStoreClient) method.invoke(null, hiveConf, constructorArgTypes, constructorArgs,
+				HiveMetaStoreClient.class.getName());
+		} catch (Exception ex) {
+			throw new CatalogException("Failed to create Hive Metastore client", ex);
+		}
+	}
+
+	@Override
+	public void alterPartition(IMetaStoreClient client, String databaseName, String tableName, Partition partition)
+			throws InvalidOperationException, MetaException, TException {
+		String errorMsg = "Failed to alter partition for table %s in database %s";
+		try {
+			Method method = client.getClass().getMethod("alter_partition", String.class, String.class,
+				Partition.class, EnvironmentContext.class);
+			method.invoke(client, databaseName, tableName, partition, null);
+		} catch (InvocationTargetException ite) {
+			Throwable targetEx = ite.getTargetException();
+			if (targetEx instanceof TException) {
+				throw (TException) targetEx;
+			} else {
+				throw new CatalogException(String.format(errorMsg, tableName, databaseName), targetEx);
+			}
+		} catch (NoSuchMethodException | IllegalAccessException e) {
+			throw new CatalogException(String.format(errorMsg, tableName, databaseName), e);
+		}
+	}
+
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV211.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV211.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.hive.client;
+
+/**
+ * Shim for Hive version 2.1.1.
+ */
+public class HiveShimV211 extends HiveShimV210 {
+
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV230.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV230.java
@@ -28,12 +28,10 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
 import org.apache.hadoop.hive.metastore.TableType;
-import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 import org.apache.hadoop.hive.metastore.api.Function;
 import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
-import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.UnknownDBException;
 import org.apache.hadoop.hive.ql.udf.generic.SimpleGenericUDAFParameterInfo;
@@ -49,7 +47,7 @@ import java.util.List;
 /**
  * Shim for Hive version 2.3.0.
  */
-public class HiveShimV230 extends HiveShimV122 {
+public class HiveShimV230 extends HiveShimV211 {
 
 	@Override
 	public IMetaStoreClient getHiveMetastoreClient(HiveConf hiveConf) {
@@ -99,26 +97,6 @@ public class HiveShimV230 extends HiveShimV122 {
 	public void alterTable(IMetaStoreClient client, String databaseName, String tableName, Table table) throws InvalidOperationException, MetaException, TException {
 		// For Hive-2.3.4, we don't need to tell HMS not to update stats.
 		client.alter_table(databaseName, tableName, table);
-	}
-
-	@Override
-	public void alterPartition(IMetaStoreClient client, String databaseName, String tableName, Partition partition)
-			throws InvalidOperationException, MetaException, TException {
-		String errorMsg = "Failed to alter partition for table %s in database %s";
-		try {
-			Method method = client.getClass().getMethod("alter_partition", String.class, String.class,
-				Partition.class, EnvironmentContext.class);
-			method.invoke(client, databaseName, tableName, partition, null);
-		} catch (InvocationTargetException ite) {
-			Throwable targetEx = ite.getTargetException();
-			if (targetEx instanceof TException) {
-				throw (TException) targetEx;
-			} else {
-				throw new CatalogException(String.format(errorMsg, tableName, databaseName), targetEx);
-			}
-		} catch (NoSuchMethodException | IllegalAccessException e) {
-			throw new CatalogException(String.format(errorMsg, tableName, databaseName), e);
-		}
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveRunnerShimLoader.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveRunnerShimLoader.java
@@ -41,6 +41,8 @@ public class HiveRunnerShimLoader {
 				case HiveShimLoader.HIVE_VERSION_V1_2_1:
 				case HiveShimLoader.HIVE_VERSION_V1_2_2:
 					return new HiveRunnerShimV3();
+				case HiveShimLoader.HIVE_VERSION_V2_1_0:
+				case HiveShimLoader.HIVE_VERSION_V2_1_1:
 				case HiveShimLoader.HIVE_VERSION_V2_3_0:
 				case HiveShimLoader.HIVE_VERSION_V2_3_1:
 				case HiveShimLoader.HIVE_VERSION_V2_3_2:


### PR DESCRIPTION
Mirror of apache flink#9547
## What is the purpose of the change

Support  Hive 2.1.x versions (2.1.0 and 2.1.1).

## Brief change log

  - Added new shims for each version
  - Adjusted shim inheritance heirarchy
  - Relocated one shimmed method


## Verifying this change

This change is already covered by existing tests, and manually ran the tests for all versions.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

