### PR TITLE
Mirror of apache flink#9542

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBNativeMetricMonitor.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBNativeMetricMonitor.java
@@ -50,6 +50,8 @@ public class RocksDBNativeMetricMonitor implements Closeable {
 
 	private final Object lock;
 
+	static final String COLUMN_FAMILY_KEY = "column_family";
+
 	@GuardedBy("lock")
 	private RocksDB rocksDB;
 
@@ -71,7 +73,7 @@ public class RocksDBNativeMetricMonitor implements Closeable {
 	 * @param handle native handle to the column family
 	 */
 	void registerColumnFamily(String columnFamilyName, ColumnFamilyHandle handle) {
-		MetricGroup group = metricGroup.addGroup(columnFamilyName);
+		MetricGroup group = metricGroup.addGroup(COLUMN_FAMILY_KEY, columnFamilyName);
 
 		for (String property : options.getProperties()) {
 			RocksDBNativeMetricView gauge = new RocksDBNativeMetricView(handle, property);


### PR DESCRIPTION
Mirror of apache flink#9542
### **What is the purpose of the change**

When we use influxdb reporter report rocksdb metric data，influxdb reporter call {#getLogicalScope()} get the measurements,and call {#getAllVariables()} get tags. and we need column family as tags for group by in influxSQL. In this PR,  change addgroup(columnFamilyName) to addgroup("column_family", columnFamilyName) build metric group, This will help build column family as tags in influx reporter

### **Brief change log**

 change addgroup(columnFamilyName) to addgroup("column_family", columnFamilyName) build metric group

### **Verifying this change**

This change is a trivial rework / code cleanup without any test coverage

### **Does this pull request potentially affect one of the following parts:**

*  Dependencies (does it add or upgrade a dependency): (no)
* The public API, i.e., is any changed class annotated with <at>Public(Evolving): (no.)
* The serializers: (no)
* The runtime per-record code paths (performance sensitive): (no)
* Anything that affects deployment or recovery: JobManager (and its components),  Checkpointing, Yarn/Mesos, ZooKeeper: (no)
* The S3 file system connector: (no)

### **Documentation**

Does this pull request introduce a new feature? no
If yes, how is the feature documented? (not applicable)
