### PR TITLE
Mirror of apache flink#9541

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -1867,7 +1867,7 @@ public final class ConfigConstants {
 	public static final int DEFAULT_LOCAL_NUMBER_RESOURCE_MANAGER = 1;
 
 	/**
-	 * Ineffective any more. Will be removed in 2.0.
+	 * @deprecated Has no effect; the web-server is always started. Will be removed in 2.0.
 	 */
 	@Deprecated
 	public static final String LOCAL_START_WEBSERVER = "local.start-webserver";

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -1866,6 +1866,10 @@ public final class ConfigConstants {
 	@Deprecated
 	public static final int DEFAULT_LOCAL_NUMBER_RESOURCE_MANAGER = 1;
 
+	/**
+	 * Ineffective any more. Will be removed in 2.0.
+	 */
+	@Deprecated
 	public static final String LOCAL_START_WEBSERVER = "local.start-webserver";
 
 	// --------------------------- High Availability ---------------------------------

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -50,7 +50,6 @@ import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.api.java.typeutils.ValueTypeInfo;
 import org.apache.flink.api.java.typeutils.runtime.kryo.Serializers;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.core.fs.Path;
@@ -1132,8 +1131,6 @@ public abstract class ExecutionEnvironment {
 	@PublicEvolving
 	public static ExecutionEnvironment createLocalEnvironmentWithWebUI(Configuration conf) {
 		checkNotNull(conf, "conf");
-
-		conf.setBoolean(ConfigConstants.LOCAL_START_WEBSERVER, true);
 
 		if (!conf.contains(RestOptions.PORT)) {
 			// explicitly set this option so that it's not set to 0 later

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
@@ -102,6 +102,8 @@ public class WebFrontendITCase extends TestLogger {
 		} catch (Exception e) {
 			throw new AssertionError("Could not setup test.", e);
 		}
+
+		// !!DO NOT REMOVE!! next line is required for tests
 		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "12m");
 
 		return config;
@@ -227,7 +229,6 @@ public class WebFrontendITCase extends TestLogger {
 		String expected = CLUSTER_CONFIGURATION.getString(TaskManagerOptions.MANAGED_MEMORY_SIZE);
 		String actual = conf.get(TaskManagerOptions.MANAGED_MEMORY_SIZE.key());
 
-		assertNotNull(actual);
 		assertEquals(expected, actual);
 	}
 

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
@@ -103,7 +103,6 @@ public class WebFrontendITCase extends TestLogger {
 			throw new AssertionError("Could not setup test.", e);
 		}
 		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "12m");
-		config.setBoolean(ConfigConstants.LOCAL_START_WEBSERVER, true);
 
 		return config;
 	}
@@ -239,11 +238,13 @@ public class WebFrontendITCase extends TestLogger {
 	public void getConfiguration() {
 		try {
 			String config = TestBaseUtils.getFromHTTP("http://localhost:" + getRestPort() + "/jobmanager/config");
-
 			Map<String, String> conf = WebMonitorUtils.fromKeyValueJsonArray(config);
-			assertEquals(
-				CLUSTER_CONFIGURATION.getString(ConfigConstants.LOCAL_START_WEBSERVER, null),
-				conf.get(ConfigConstants.LOCAL_START_WEBSERVER));
+
+			String expected = CLUSTER_CONFIGURATION.getString(TaskManagerOptions.MANAGED_MEMORY_SIZE);
+			String actual = conf.get(TaskManagerOptions.MANAGED_MEMORY_SIZE.key());
+
+			assertNotNull(actual);
+			assertEquals(expected, actual);
 		} catch (Exception e) {
 			e.printStackTrace();
 			fail(e.getMessage());

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
@@ -113,15 +113,10 @@ public class WebFrontendITCase extends TestLogger {
 	}
 
 	@Test
-	public void getFrontPage() {
-		try {
-			String fromHTTP = TestBaseUtils.getFromHTTP("http://localhost:" + getRestPort() + "/index.html");
-			String text = "Apache Flink Web Dashboard";
-			assertTrue("Startpage should contain " + text, fromHTTP.contains(text));
-		} catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
+	public void getFrontPage() throws Exception {
+		String fromHTTP = TestBaseUtils.getFromHTTP("http://localhost:" + getRestPort() + "/index.html");
+		String text = "Apache Flink Web Dashboard";
+		assertTrue("Startpage should contain " + text, fromHTTP.contains(text));
 	}
 
 	private int getRestPort() {
@@ -139,7 +134,7 @@ public class WebFrontendITCase extends TestLogger {
 			// error!
 			InputStream is = taskManagerConnection.getErrorStream();
 			String errorMessage = IOUtils.toString(is, ConfigConstants.DEFAULT_CHARSET);
-			throw new RuntimeException(errorMessage);
+			fail(errorMessage);
 		}
 
 		// we don't set the content-encoding header
@@ -156,29 +151,24 @@ public class WebFrontendITCase extends TestLogger {
 			Assert.assertNull(notFoundJobConnection.getContentEncoding());
 			Assert.assertEquals("application/json; charset=UTF-8", notFoundJobConnection.getContentType());
 		} else {
-			throw new RuntimeException("Request for non-existing job did not return an error.");
+			fail("Request for non-existing job did not return an error.");
 		}
 	}
 
 	@Test
-	public void getNumberOfTaskManagers() {
-		try {
-			String json = TestBaseUtils.getFromHTTP("http://localhost:" + getRestPort() + "/taskmanagers/");
+	public void getNumberOfTaskManagers() throws Exception {
+		String json = TestBaseUtils.getFromHTTP("http://localhost:" + getRestPort() + "/taskmanagers/");
 
-			ObjectMapper mapper = new ObjectMapper();
-			JsonNode response = mapper.readTree(json);
-			ArrayNode taskManagers = (ArrayNode) response.get("taskmanagers");
+		ObjectMapper mapper = new ObjectMapper();
+		JsonNode response = mapper.readTree(json);
+		ArrayNode taskManagers = (ArrayNode) response.get("taskmanagers");
 
-			assertNotNull(taskManagers);
-			assertEquals(NUM_TASK_MANAGERS, taskManagers.size());
-		} catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
+		assertNotNull(taskManagers);
+		assertEquals(NUM_TASK_MANAGERS, taskManagers.size());
 	}
 
 	@Test
-	public void getTaskmanagers() throws Exception {
+	public void getTaskManagers() throws Exception {
 		String json = TestBaseUtils.getFromHTTP("http://localhost:" + getRestPort() + "/taskmanagers/");
 
 		ObjectMapper mapper = new ObjectMapper();
@@ -208,47 +198,37 @@ public class WebFrontendITCase extends TestLogger {
 	}
 
 	@Test
-	public void getTaskManagerLogAndStdoutFiles() {
-		try {
-			String json = TestBaseUtils.getFromHTTP("http://localhost:" + getRestPort() + "/taskmanagers/");
+	public void getTaskManagerLogAndStdoutFiles() throws Exception {
+		String json = TestBaseUtils.getFromHTTP("http://localhost:" + getRestPort() + "/taskmanagers/");
 
-			ObjectMapper mapper = new ObjectMapper();
-			JsonNode parsed = mapper.readTree(json);
-			ArrayNode taskManagers = (ArrayNode) parsed.get("taskmanagers");
-			JsonNode taskManager = taskManagers.get(0);
-			String id = taskManager.get("id").asText();
+		ObjectMapper mapper = new ObjectMapper();
+		JsonNode parsed = mapper.readTree(json);
+		ArrayNode taskManagers = (ArrayNode) parsed.get("taskmanagers");
+		JsonNode taskManager = taskManagers.get(0);
+		String id = taskManager.get("id").asText();
 
-			WebMonitorUtils.LogFileLocation logFiles = WebMonitorUtils.LogFileLocation.find(CLUSTER_CONFIGURATION);
+		WebMonitorUtils.LogFileLocation logFiles = WebMonitorUtils.LogFileLocation.find(CLUSTER_CONFIGURATION);
 
-			//we check for job manager log files, since no separate taskmanager logs exist
-			FileUtils.writeStringToFile(logFiles.logFile, "job manager log");
-			String logs = TestBaseUtils.getFromHTTP("http://localhost:" + getRestPort() + "/taskmanagers/" + id + "/log");
-			assertTrue(logs.contains("job manager log"));
+		//we check for job manager log files, since no separate taskmanager logs exist
+		FileUtils.writeStringToFile(logFiles.logFile, "job manager log");
+		String logs = TestBaseUtils.getFromHTTP("http://localhost:" + getRestPort() + "/taskmanagers/" + id + "/log");
+		assertTrue(logs.contains("job manager log"));
 
-			FileUtils.writeStringToFile(logFiles.stdOutFile, "job manager out");
-			logs = TestBaseUtils.getFromHTTP("http://localhost:" + getRestPort() + "/taskmanagers/" + id + "/stdout");
-			assertTrue(logs.contains("job manager out"));
-		} catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
+		FileUtils.writeStringToFile(logFiles.stdOutFile, "job manager out");
+		logs = TestBaseUtils.getFromHTTP("http://localhost:" + getRestPort() + "/taskmanagers/" + id + "/stdout");
+		assertTrue(logs.contains("job manager out"));
 	}
 
 	@Test
-	public void getConfiguration() {
-		try {
-			String config = TestBaseUtils.getFromHTTP("http://localhost:" + getRestPort() + "/jobmanager/config");
-			Map<String, String> conf = WebMonitorUtils.fromKeyValueJsonArray(config);
+	public void getConfiguration() throws Exception {
+		String config = TestBaseUtils.getFromHTTP("http://localhost:" + getRestPort() + "/jobmanager/config");
+		Map<String, String> conf = WebMonitorUtils.fromKeyValueJsonArray(config);
 
-			String expected = CLUSTER_CONFIGURATION.getString(TaskManagerOptions.MANAGED_MEMORY_SIZE);
-			String actual = conf.get(TaskManagerOptions.MANAGED_MEMORY_SIZE.key());
+		String expected = CLUSTER_CONFIGURATION.getString(TaskManagerOptions.MANAGED_MEMORY_SIZE);
+		String actual = conf.get(TaskManagerOptions.MANAGED_MEMORY_SIZE.key());
 
-			assertNotNull(actual);
-			assertEquals(expected, actual);
-		} catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
+		assertNotNull(actual);
+		assertEquals(expected, actual);
 	}
 
 	@Test

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -46,7 +46,6 @@ import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.client.program.ContextEnvironment;
 import org.apache.flink.client.program.OptimizerPlanEnvironment;
 import org.apache.flink.client.program.PreviewPlanEnvironment;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.core.fs.Path;
@@ -1689,8 +1688,6 @@ public abstract class StreamExecutionEnvironment {
 	@PublicEvolving
 	public static StreamExecutionEnvironment createLocalEnvironmentWithWebUI(Configuration conf) {
 		checkNotNull(conf, "conf");
-
-		conf.setBoolean(ConfigConstants.LOCAL_START_WEBSERVER, true);
 
 		if (!conf.contains(RestOptions.PORT)) {
 			// explicitly set this option so that it's not set to 0 later


### PR DESCRIPTION
Mirror of apache flink#9541
## What is the purpose of the change

Maybe backport to 1.9.1 because I heard this issue from a user of 1.9.0

Exactly ConfigConstants.LOCAL_START_WEBSERVER has no power any more but we don't mark it as deprecated or give an investigate to revive it. Since it is part of public interface we cannot remove it in minor version but deprecate it is necessary.


## Brief change log

- Remove use points of `ConfigConstants.LOCAL_START_WEBSERVER`
- Deprecate `ConfigConstants.LOCAL_START_WEBSERVER`
- hotfix for test style in `WebFrontendITCase`


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (yes, mark a stale field as deprecated.)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc <at>twalthr 

