### PR TITLE
Mirror of apache flink#9534

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_ha.sh
+++ b/flink-end-to-end-tests/test-scripts/common_ha.sh
@@ -66,7 +66,7 @@ function verify_logs() {
     fi
 
     # checks that all apart from the first JM recover the failed jobgraph.
-    if ! verify_num_occurences_in_logs 'standalonesession' 'Recovered SubmittedJobGraph' ${JM_FAILURES}; then
+    if ! verify_num_occurences_in_logs 'standalonesession' 'Recovered JobGraph' ${JM_FAILURES}; then
         echo "FAILURE: A JM did not take over."
         EXIT_CODE=1
     fi


### PR DESCRIPTION
Mirror of apache flink#9534
## What is the purpose of the change

With FLINK-13573 we removed the SubmittedJobGraph and replaced it with the JobGraph.
Consequently, we no longer see the log statement "Recovered SubmittedJobGraph" which
was used by the common_ha.sh script to count the number of job recoveries. Now we need
to look for "Recovered JobGraph" instead.

## Verifying this change

- Manually tested that failing e2e test passes

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

