### PR TITLE
Mirror of apache flink#9533

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/PartFileConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/PartFileConfig.java
@@ -18,28 +18,18 @@
 
 package org.apache.flink.streaming.api.functions.sink.filesystem;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.util.Preconditions;
 
 /**
  * Part file name configuration.
  * This allow to define a prefix and a suffix to the part file name.
  */
-class PartFileConfig {
-
-	public static final String DEFAULT_PART_PREFIX = "part";
-
-	public static final String DEFAULT_PART_SUFFIX = "";
+public class PartFileConfig {
 
 	private final String partPrefix;
 
 	private final String partSuffix;
-
-	/**
-	 * Initiates the {@code PartFileConfig} with default values [{@value DEFAULT_PART_PREFIX}, {@value DEFAULT_PART_SUFFIX}].
-	 */
-	PartFileConfig() {
-		this(DEFAULT_PART_PREFIX, DEFAULT_PART_SUFFIX);
-	}
 
 	/**
 	 *	Initiates the {@code PartFileConfig} with values passed as parameters.
@@ -47,7 +37,7 @@ class PartFileConfig {
 	 * @param partPrefix - the beginning of part file name
 	 * @param partSuffix - the ending of part file name
 	 */
-	PartFileConfig(final String partPrefix, final String partSuffix) {
+	public PartFileConfig(final String partPrefix, final String partSuffix) {
 		this.partPrefix = Preconditions.checkNotNull(partPrefix);
 		this.partSuffix = Preconditions.checkNotNull(partSuffix);
 	}
@@ -64,5 +54,43 @@ class PartFileConfig {
 	 */
 	String getPartSuffix() {
 		return partSuffix;
+	}
+
+	public static PartFileConfigBuilder builder() {
+		return new PartFileConfigBuilder();
+	}
+
+	/**
+	 * A builder to create the part file configuration.
+	 */
+	@PublicEvolving
+	public static class PartFileConfigBuilder {
+
+		private static final String DEFAULT_PART_PREFIX = "part";
+
+		private static final String DEFAULT_PART_SUFFIX = "";
+
+		private String partPrefix;
+
+		private String partSuffix;
+
+		public PartFileConfigBuilder() {
+			this.partPrefix = DEFAULT_PART_PREFIX;
+			this.partSuffix = DEFAULT_PART_SUFFIX;
+		}
+
+		public PartFileConfigBuilder withPartPrefix(String prefix) {
+			this.partPrefix = prefix;
+			return this;
+		}
+
+		public PartFileConfigBuilder withPartSuffix(String suffix) {
+			this.partSuffix = suffix;
+			return this;
+		}
+
+		public PartFileConfig build() {
+			return new PartFileConfig(partPrefix, partSuffix);
+		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/PartFileConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/PartFileConfig.java
@@ -21,11 +21,13 @@ package org.apache.flink.streaming.api.functions.sink.filesystem;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.util.Preconditions;
 
+import java.io.Serializable;
+
 /**
  * Part file name configuration.
  * This allow to define a prefix and a suffix to the part file name.
  */
-public class PartFileConfig {
+public class PartFileConfig implements Serializable {
 
 	private final String partPrefix;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/PartFileConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/PartFileConfig.java
@@ -34,19 +34,34 @@ class PartFileConfig {
 
 	private final String partSuffix;
 
+	/**
+	 * Initiates the {@code PartFileConfig} with default values [{@value DEFAULT_PART_PREFIX}, {@value DEFAULT_PART_SUFFIX}].
+	 */
 	PartFileConfig() {
 		this(DEFAULT_PART_PREFIX, DEFAULT_PART_SUFFIX);
 	}
 
+	/**
+	 *	Initiates the {@code PartFileConfig} with values passed as parameters.
+	 *
+	 * @param partPrefix - the beginning of part file name
+	 * @param partSuffix - the ending of part file name
+	 */
 	PartFileConfig(final String partPrefix, final String partSuffix) {
 		this.partPrefix = Preconditions.checkNotNull(partPrefix);
 		this.partSuffix = Preconditions.checkNotNull(partSuffix);
 	}
 
+	/**
+	 * The prefix for the part name.
+	 */
 	String getPartPrefix() {
 		return partPrefix;
 	}
 
+	/**
+	 * The suffix for the part name.
+	 */
 	String getPartSuffix() {
 		return partSuffix;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
@@ -67,9 +67,11 @@ import java.io.Serializable;
  * {@link StreamingFileSink#forBulkFormat(Path, BulkWriter.Factory)}.
  *
  *
- * <p>The filenames of the part files contain the part prefix, "part-", the parallel subtask index of the sink
- * and a rolling counter. For example the file {@code "part-1-17"} contains the data from
- * {@code subtask 1} of the sink and is the {@code 17th} bucket created by that subtask.
+ * <p>The filenames of the part files could be defined using {@link PartFileConfig}, this configuration contain
+ * a part prefix and part suffix, that will be used with the parallel subtask index of the sink
+ * and a rolling counter. For example for a prefix "prefix" and a suffix ".ext" the file create will have a name
+ * {@code "prefix-1-17.ext"} containing the data from {@code subtask 1} of the sink and is the {@code 17th} bucket
+ * created by that subtask.
  * Part files roll based on the user-specified {@link RollingPolicy}. By default, a {@link DefaultRollingPolicy}
  * is used.
  *

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
@@ -202,7 +202,7 @@ public class StreamingFileSink<IN>
 		private final PartFileConfig partFileConfig;
 
 		RowFormatBuilder(Path basePath, Encoder<IN> encoder, BucketAssigner<IN, BucketID> bucketAssigner) {
-			this(basePath, encoder, bucketAssigner, DefaultRollingPolicy.create().build(), 60L * 1000L, new DefaultBucketFactoryImpl<>(), new PartFileConfig());
+			this(basePath, encoder, bucketAssigner, DefaultRollingPolicy.create().build(), 60L * 1000L, new DefaultBucketFactoryImpl<>(), PartFileConfig.builder().build());
 		}
 
 		private RowFormatBuilder(
@@ -286,7 +286,7 @@ public class StreamingFileSink<IN>
 		private final PartFileConfig partFileConfig;
 
 		BulkFormatBuilder(Path basePath, BulkWriter.Factory<IN> writerFactory, BucketAssigner<IN, BucketID> assigner) {
-			this(basePath, writerFactory, assigner, 60L * 1000L, new DefaultBucketFactoryImpl<>(), new PartFileConfig());
+			this(basePath, writerFactory, assigner, 60L * 1000L, new DefaultBucketFactoryImpl<>(), PartFileConfig.builder().build());
 		}
 
 		private BulkFormatBuilder(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
@@ -197,12 +197,10 @@ public class StreamingFileSink<IN>
 
 		private final BucketFactory<IN, BucketID> bucketFactory;
 
-		private final String partFilePrefix;
-
-		private final String partFileSuffix;
+		private final PartFileConfig partFileConfig;
 
 		RowFormatBuilder(Path basePath, Encoder<IN> encoder, BucketAssigner<IN, BucketID> bucketAssigner) {
-			this(basePath, encoder, bucketAssigner, DefaultRollingPolicy.create().build(), 60L * 1000L, new DefaultBucketFactoryImpl<>(), PartFileConfig.DEFAULT_PART_PREFIX, PartFileConfig.DEFAULT_PART_SUFFIX);
+			this(basePath, encoder, bucketAssigner, DefaultRollingPolicy.create().build(), 60L * 1000L, new DefaultBucketFactoryImpl<>(), new PartFileConfig());
 		}
 
 		private RowFormatBuilder(
@@ -212,40 +210,34 @@ public class StreamingFileSink<IN>
 				RollingPolicy<IN, BucketID> policy,
 				long bucketCheckInterval,
 				BucketFactory<IN, BucketID> bucketFactory,
-				String partFilePrefix,
-				String partFileSuffix) {
+				PartFileConfig partFileConfig) {
 			this.basePath = Preconditions.checkNotNull(basePath);
 			this.encoder = Preconditions.checkNotNull(encoder);
 			this.bucketAssigner = Preconditions.checkNotNull(assigner);
 			this.rollingPolicy = Preconditions.checkNotNull(policy);
 			this.bucketCheckInterval = bucketCheckInterval;
 			this.bucketFactory = Preconditions.checkNotNull(bucketFactory);
-			this.partFilePrefix = Preconditions.checkNotNull(partFilePrefix);
-			this.partFileSuffix = Preconditions.checkNotNull(partFileSuffix);
+			this.partFileConfig = Preconditions.checkNotNull(partFileConfig);
 		}
 
 		public StreamingFileSink.RowFormatBuilder<IN, BucketID> withBucketCheckInterval(final long interval) {
-			return new RowFormatBuilder<>(basePath, encoder, bucketAssigner, rollingPolicy, interval, bucketFactory, partFilePrefix, partFileSuffix);
+			return new RowFormatBuilder<>(basePath, encoder, bucketAssigner, rollingPolicy, interval, bucketFactory, partFileConfig);
 		}
 
 		public StreamingFileSink.RowFormatBuilder<IN, BucketID> withBucketAssigner(final BucketAssigner<IN, BucketID> assigner) {
-			return new RowFormatBuilder<>(basePath, encoder, Preconditions.checkNotNull(assigner), rollingPolicy, bucketCheckInterval, bucketFactory, partFilePrefix, partFileSuffix);
+			return new RowFormatBuilder<>(basePath, encoder, Preconditions.checkNotNull(assigner), rollingPolicy, bucketCheckInterval, bucketFactory, partFileConfig);
 		}
 
 		public StreamingFileSink.RowFormatBuilder<IN, BucketID> withRollingPolicy(final RollingPolicy<IN, BucketID> policy) {
-			return new RowFormatBuilder<>(basePath, encoder, bucketAssigner, Preconditions.checkNotNull(policy), bucketCheckInterval, bucketFactory, partFilePrefix, partFileSuffix);
+			return new RowFormatBuilder<>(basePath, encoder, bucketAssigner, Preconditions.checkNotNull(policy), bucketCheckInterval, bucketFactory, partFileConfig);
 		}
 
 		public <ID> StreamingFileSink.RowFormatBuilder<IN, ID> withBucketAssignerAndPolicy(final BucketAssigner<IN, ID> assigner, final RollingPolicy<IN, ID> policy) {
-			return new RowFormatBuilder<>(basePath, encoder, Preconditions.checkNotNull(assigner), Preconditions.checkNotNull(policy), bucketCheckInterval, new DefaultBucketFactoryImpl<>(), partFilePrefix, partFileSuffix);
+			return new RowFormatBuilder<>(basePath, encoder, Preconditions.checkNotNull(assigner), Preconditions.checkNotNull(policy), bucketCheckInterval, new DefaultBucketFactoryImpl<>(), partFileConfig);
 		}
 
-		public StreamingFileSink.RowFormatBuilder<IN, BucketID> withPartFilePrefix(final String partPrefix) {
-			return new RowFormatBuilder<>(basePath, encoder, bucketAssigner, rollingPolicy, bucketCheckInterval, bucketFactory, partPrefix, partFileSuffix);
-		}
-
-		public StreamingFileSink.RowFormatBuilder<IN, BucketID> withPartFileSuffix(final String partSuffix) {
-			return new RowFormatBuilder<>(basePath, encoder, bucketAssigner, rollingPolicy, bucketCheckInterval, bucketFactory, partFilePrefix, partSuffix);
+		public StreamingFileSink.RowFormatBuilder<IN, BucketID> withPartFileConfig(final PartFileConfig partFileConfig) {
+			return new RowFormatBuilder<>(basePath, encoder, bucketAssigner, rollingPolicy, bucketCheckInterval, bucketFactory, partFileConfig);
 		}
 
 		/** Creates the actual sink. */
@@ -262,12 +254,12 @@ public class StreamingFileSink<IN>
 					new RowWisePartWriter.Factory<>(encoder),
 					rollingPolicy,
 					subtaskIndex,
-					new PartFileConfig(partFilePrefix, partFileSuffix));
+					partFileConfig);
 		}
 
 		@VisibleForTesting
 		StreamingFileSink.RowFormatBuilder<IN, BucketID> withBucketFactory(final BucketFactory<IN, BucketID> factory) {
-			return new RowFormatBuilder<>(basePath, encoder, bucketAssigner, rollingPolicy, bucketCheckInterval, Preconditions.checkNotNull(factory), partFilePrefix, partFileSuffix);
+			return new RowFormatBuilder<>(basePath, encoder, bucketAssigner, rollingPolicy, bucketCheckInterval, Preconditions.checkNotNull(factory), partFileConfig);
 		}
 	}
 
@@ -289,12 +281,10 @@ public class StreamingFileSink<IN>
 
 		private final BucketFactory<IN, BucketID> bucketFactory;
 
-		private final String partFilePrefix;
-
-		private final String partFileSuffix;
+		private final PartFileConfig partFileConfig;
 
 		BulkFormatBuilder(Path basePath, BulkWriter.Factory<IN> writerFactory, BucketAssigner<IN, BucketID> assigner) {
-			this(basePath, writerFactory, assigner, 60L * 1000L, new DefaultBucketFactoryImpl<>(), PartFileConfig.DEFAULT_PART_PREFIX, PartFileConfig.DEFAULT_PART_SUFFIX);
+			this(basePath, writerFactory, assigner, 60L * 1000L, new DefaultBucketFactoryImpl<>(), new PartFileConfig());
 		}
 
 		private BulkFormatBuilder(
@@ -303,36 +293,30 @@ public class StreamingFileSink<IN>
 				BucketAssigner<IN, BucketID> assigner,
 				long bucketCheckInterval,
 				BucketFactory<IN, BucketID> bucketFactory,
-				String partFilePrefix,
-				String partFileSuffix) {
+				PartFileConfig partFileConfig) {
 			this.basePath = Preconditions.checkNotNull(basePath);
 			this.writerFactory = writerFactory;
 			this.bucketAssigner = Preconditions.checkNotNull(assigner);
 			this.bucketCheckInterval = bucketCheckInterval;
 			this.bucketFactory = Preconditions.checkNotNull(bucketFactory);
-			this.partFilePrefix = Preconditions.checkNotNull(partFilePrefix);
-			this.partFileSuffix = Preconditions.checkNotNull(partFileSuffix);
+			this.partFileConfig = Preconditions.checkNotNull(partFileConfig);
 		}
 
 		public StreamingFileSink.BulkFormatBuilder<IN, BucketID> withBucketCheckInterval(long interval) {
-			return new BulkFormatBuilder<>(basePath, writerFactory, bucketAssigner, interval, bucketFactory, partFilePrefix, partFileSuffix);
+			return new BulkFormatBuilder<>(basePath, writerFactory, bucketAssigner, interval, bucketFactory, partFileConfig);
 		}
 
 		public <ID> StreamingFileSink.BulkFormatBuilder<IN, ID> withBucketAssigner(BucketAssigner<IN, ID> assigner) {
-			return new BulkFormatBuilder<>(basePath, writerFactory, Preconditions.checkNotNull(assigner), bucketCheckInterval, new DefaultBucketFactoryImpl<>(), partFilePrefix, partFileSuffix);
+			return new BulkFormatBuilder<>(basePath, writerFactory, Preconditions.checkNotNull(assigner), bucketCheckInterval, new DefaultBucketFactoryImpl<>(), partFileConfig);
 		}
 
 		@VisibleForTesting
 		StreamingFileSink.BulkFormatBuilder<IN, BucketID> withBucketFactory(final BucketFactory<IN, BucketID> factory) {
-			return new BulkFormatBuilder<>(basePath, writerFactory, bucketAssigner, bucketCheckInterval, Preconditions.checkNotNull(factory), partFilePrefix, partFileSuffix);
+			return new BulkFormatBuilder<>(basePath, writerFactory, bucketAssigner, bucketCheckInterval, Preconditions.checkNotNull(factory), partFileConfig);
 	}
 
-		public StreamingFileSink.BulkFormatBuilder<IN, BucketID> withPartFilePrefix(final String partPrefix) {
-			return new BulkFormatBuilder<>(basePath, writerFactory, bucketAssigner, bucketCheckInterval, bucketFactory, partPrefix, partFileSuffix);
-		}
-
-		public StreamingFileSink.BulkFormatBuilder<IN, BucketID> withPartFileSuffix(final String partSuffix) {
-			return new BulkFormatBuilder<>(basePath, writerFactory, bucketAssigner, bucketCheckInterval, bucketFactory, partFilePrefix, partSuffix);
+		public StreamingFileSink.BulkFormatBuilder<IN, BucketID> withPartFileConfig(final PartFileConfig partFileConfig) {
+			return new BulkFormatBuilder<>(basePath, writerFactory, bucketAssigner, bucketCheckInterval, bucketFactory, partFileConfig);
 		}
 
 		/** Creates the actual sink. */
@@ -349,7 +333,7 @@ public class StreamingFileSink<IN>
 					new BulkPartWriter.Factory<>(writerFactory),
 					OnCheckpointRollingPolicy.build(),
 					subtaskIndex,
-					new PartFileConfig(partFilePrefix, partFileSuffix));
+					partFileConfig);
 		}
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketAssignerITCases.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketAssignerITCases.java
@@ -57,7 +57,7 @@ public class BucketAssignerITCases {
 			new RowWisePartWriter.Factory<>(new SimpleStringEncoder<>()),
 			rollingPolicy,
 			0,
-			new PartFileConfig()
+			PartFileConfig.builder().build()
 		);
 
 		Bucket<String, String> bucket =

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketTest.java
@@ -64,7 +64,7 @@ public class BucketTest {
 
 		final TestRecoverableWriter recoverableWriter = getRecoverableWriter(path);
 		final Bucket<String, String> bucketUnderTest =
-				createBucket(recoverableWriter, path, 0, 0, new PartFileConfig());
+				createBucket(recoverableWriter, path, 0, 0, PartFileConfig.builder().build());
 
 		bucketUnderTest.write("test-element", 0L);
 
@@ -82,7 +82,7 @@ public class BucketTest {
 
 		final TestRecoverableWriter recoverableWriter = getRecoverableWriter(path);
 		final Bucket<String, String> bucketUnderTest =
-				createBucket(recoverableWriter, path, 0, 0, new PartFileConfig());
+				createBucket(recoverableWriter, path, 0, 0, PartFileConfig.builder().build());
 
 		bucketUnderTest.write("test-element", 0L);
 
@@ -105,7 +105,7 @@ public class BucketTest {
 
 		final TestRecoverableWriter recoverableWriter = getRecoverableWriter(path);
 		final Bucket<String, String> bucketUnderTest =
-				createBucket(recoverableWriter, path, 0, 0, new PartFileConfig());
+				createBucket(recoverableWriter, path, 0, 0, PartFileConfig.builder().build());
 
 		bucketUnderTest.write("test-element", 0L);
 
@@ -115,7 +115,7 @@ public class BucketTest {
 		bucketUnderTest.onSuccessfulCompletionOfCheckpoint(0L);
 
 		final TestRecoverableWriter newRecoverableWriter = getRecoverableWriter(path);
-		restoreBucket(newRecoverableWriter, 0, 1, state, new PartFileConfig());
+		restoreBucket(newRecoverableWriter, 0, 1, state, PartFileConfig.builder().build());
 
 		assertThat(newRecoverableWriter, hasCalledDiscard(1)); // that is for checkpoints 0 and 1
 	}
@@ -127,7 +127,7 @@ public class BucketTest {
 
 		final TestRecoverableWriter recoverableWriter = getRecoverableWriter(path);
 		final Bucket<String, String> bucketUnderTest =
-				createBucket(recoverableWriter, path, 0, 0, new PartFileConfig());
+				createBucket(recoverableWriter, path, 0, 0, PartFileConfig.builder().build());
 
 		final BucketState<String> state = bucketUnderTest.onReceptionOfCheckpoint(0L);
 		assertThat(state, hasNoActiveInProgressFile());
@@ -425,7 +425,7 @@ public class BucketTest {
 	private Bucket<String, String> getRestoredBucketWithOnlyInProgressPart(final BaseStubWriter writer) throws IOException {
 		final BucketState<String> stateWithOnlyInProgressFile =
 				new BucketState<>("test", new Path(), 12345L, new NoOpRecoverable(), new HashMap<>());
-		return Bucket.restore(writer, 0, 1L, partFileFactory, rollingPolicy, stateWithOnlyInProgressFile, new PartFileConfig());
+		return Bucket.restore(writer, 0, 1L, partFileFactory, rollingPolicy, stateWithOnlyInProgressFile, PartFileConfig.builder().build());
 	}
 
 	private Bucket<String, String> getRestoredBucketWithOnlyPendingParts(final BaseStubWriter writer, final int numberOfPendingParts) throws IOException {
@@ -434,7 +434,7 @@ public class BucketTest {
 
 		final BucketState<String> initStateWithOnlyInProgressFile =
 				new BucketState<>("test", new Path(), 12345L, null, completePartsPerCheckpoint);
-		return Bucket.restore(writer, 0, 1L, partFileFactory, rollingPolicy, initStateWithOnlyInProgressFile, new PartFileConfig());
+		return Bucket.restore(writer, 0, 1L, partFileFactory, rollingPolicy, initStateWithOnlyInProgressFile, PartFileConfig.builder().build());
 	}
 
 	private Map<Long, List<RecoverableWriter.CommitRecoverable>> createPendingPartsPerCheckpoint(int noOfCheckpoints) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketsTest.java
@@ -318,7 +318,7 @@ public class BucketsTest {
 				new RowWisePartWriter.Factory<>(new SimpleStringEncoder<>()),
 				DefaultRollingPolicy.create().build(),
 				2,
-				new PartFileConfig()
+				PartFileConfig.builder().build()
 		);
 
 		buckets.onElement(
@@ -377,7 +377,7 @@ public class BucketsTest {
 				basePath,
 				rollingPolicy,
 				subtaskIdx,
-				new PartFileConfig());
+				PartFileConfig.builder().build());
 	}
 
 	private static Buckets<String, String> createBuckets(
@@ -408,7 +408,7 @@ public class BucketsTest {
 				subtaskIdx,
 				bucketState,
 				partCounterState,
-				new PartFileConfig());
+				PartFileConfig.builder().build());
 	}
 
 	private static Buckets<String, String> restoreBuckets(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BulkWriterTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BulkWriterTest.java
@@ -80,8 +80,7 @@ public class BulkWriterTest extends TestLogger {
 							new TestUtils.TupleToStringBucketer(),
 							new TestBulkWriterFactory(),
 							new DefaultBucketFactoryImpl<>(),
-							"prefix",
-							".ext")
+							PartFileConfig.builder().withPartPrefix("prefix").withPartSuffix(".ext").build())
 		) {
 			testPartFiles(testHarness, outDir, ".prefix-0-0.ext.inprogress", ".prefix-0-1.ext.inprogress");
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/RollingPolicyTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/RollingPolicyTest.java
@@ -191,7 +191,7 @@ public class RollingPolicyTest {
 				new RowWisePartWriter.Factory<>(new SimpleStringEncoder<>()),
 				rollingPolicyToTest,
 				0,
-				new PartFileConfig()
+				PartFileConfig.builder().build()
 		);
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/TestUtils.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/TestUtils.java
@@ -144,8 +144,7 @@ public class TestUtils {
 			.withBucketAssigner(bucketer)
 			.withBucketCheckInterval(bucketCheckInterval)
 			.withBucketFactory(bucketFactory)
-			.withPartFilePrefix(partFilePrefix)
-			.withPartFileSuffix(partFileSuffix)
+			.withPartFileConfig(new PartFileConfig(partFilePrefix, partFileSuffix))
 			.build();
 
 		return new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink), MAX_PARALLELISM, totalParallelism, taskIdx);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/TestUtils.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/TestUtils.java
@@ -124,8 +124,7 @@ public class TestUtils {
 				bucketer,
 				writer,
 				bucketFactory,
-				PartFileConfig.DEFAULT_PART_PREFIX,
-				PartFileConfig.DEFAULT_PART_SUFFIX);
+				PartFileConfig.builder().build());
 	}
 
 	static OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> createTestSinkWithBulkEncoder(
@@ -136,15 +135,14 @@ public class TestUtils {
 			final BucketAssigner<Tuple2<String, Integer>, String> bucketer,
 			final BulkWriter.Factory<Tuple2<String, Integer>> writer,
 			final BucketFactory<Tuple2<String, Integer>, String> bucketFactory,
-			final String partFilePrefix,
-			final String partFileSuffix) throws Exception {
+			final PartFileConfig partFileConfig) throws Exception {
 
 		StreamingFileSink<Tuple2<String, Integer>> sink = StreamingFileSink
 			.forBulkFormat(new Path(outDir.toURI()), writer)
 			.withBucketAssigner(bucketer)
 			.withBucketCheckInterval(bucketCheckInterval)
 			.withBucketFactory(bucketFactory)
-			.withPartFileConfig(new PartFileConfig(partFilePrefix, partFileSuffix))
+			.withPartFileConfig(partFileConfig)
 			.build();
 
 		return new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink), MAX_PARALLELISM, totalParallelism, taskIdx);


### PR DESCRIPTION
Mirror of apache flink#9533
## What is the purpose of the change
- Refactor part file configuration into a single method
- add javadoc for part file configuration usage

## Verifying this change
This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: ( no)
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (JavaDocs )

