### PR TITLE
Mirror of apache flink#9604

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/CheckpointedFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/CheckpointedFunction.java
@@ -116,7 +116,6 @@ import org.apache.flink.runtime.state.FunctionSnapshotContext;
  * <h4>Operator State</h4>
  * Checkpointing some state that is part of the function object itself is possible in a simpler way
  * by directly implementing the {@link ListCheckpointed} interface.
- * That mechanism is similar to the previously used {@link Checkpointed} interface.
  *
  * <h4>Keyed State</h4>
  * Access to keyed state is possible via the {@link RuntimeContext}'s methods:

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/ListCheckpointed.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/ListCheckpointed.java
@@ -27,8 +27,7 @@ import java.io.Serializable;
 import java.util.List;
 
 /**
- * This interface can be implemented by functions that want to store state in checkpoints.
- * It can be used in a similar way as the deprecated {@link Checkpointed} interface, but
+ * This interface can be implemented by functions that want to store state in checkpoints and
  * supports <b>list-style state redistribution</b> for cases when the parallelism of the
  * transformation is changed.
  *


### PR DESCRIPTION
Mirror of apache flink#9604

## What is the purpose of the change

Drop all the content of removed `Checkpointed` interface.


## Brief change log


## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**

