### PR TITLE
Mirror of apache flink#9603

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -46,8 +46,9 @@ A walkthrough provides instructions to bootstrap a small Flink project with a co
 <!-- 
 * The [**DataStream API**]() code walkthrough shows how to implement a simple DataStream application and how to extend it to be stateful and use timers.
 -->
-* The [**DataStream API**](./tutorials/datastream_api.html) tutorial shows how to implement a basic DataStream application. 
-* The [**Table API**](./walkthroughs/table_api.html) code walkthrough shows how to implement a simple Table API query on a batch source and how to evolve it into a continuous query on a streaming source.
+* The [**DataStream API**](./tutorials/datastream_api.html) tutorial shows how to implement a basic DataStream application. The DataStream API is Flink's main abstraction to implement stateful streaming applications with sophisticated time semantics in Java or Scala.
+
+* The [**Table API**](./walkthroughs/table_api.html) code walkthrough shows how to implement a simple Table API query on a batch source and how to evolve it into a continuous query on a streaming source. The Table API Flink's language-embedded, relational API to write SQL-like queries in Java or Scala which are automatically optimized similar to SQL queries. Table API queries can be executed on batch or streaming data with identical syntax and semantics.
 
 <!-- 
 ### Starting a new Flink application

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -4,6 +4,7 @@ nav-id: getting-started
 nav-title: '<i class="fa fa-rocket title appetizer" aria-hidden="true"></i> Getting Started'
 nav-parent_id: root
 section-break: true
+nav-show_overview: true
 nav-pos: 1
 ---
 <!--
@@ -24,3 +25,36 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
+
+There are many ways to get started with Apache Flink. Which one is the best for you depends on your goal and prior experience.
+
+### Taking a first look at Flink
+
+The **Docker Playgrounds** provide sandboxed Flink environments that are set up in just a few minutes and which allow you to explore and play with Flink.
+
+* The [**Operations Playground**](./docker-playgrounds/flink_cluster_playground.html) shows you how to operate streaming applications with Flink. You can experience how Flink recovers application from failures, upgrade and scale streaming applications up and down, and query application metrics.
+
+<!-- 
+* The [**Streaming SQL Playground**]() provides a Flink cluster with a SQL CLI client, tables which are fed by streaming data sources, and instructions for how to run continuous streaming SQL queries on these tables. This is the perfect environment for your first steps with streaming SQL. 
+-->
+
+### First steps with one of Flink's APIs
+
+The **Code Walkthroughs** are the best way to get started and introduce you step by step to an API.
+A walkthrough provides instructions to bootstrap a small Flink project with a code skeleton and shows how to extend it to a simple application.
+
+<!-- 
+* The [**DataStream API**]() code walkthrough shows how to implement a simple DataStream application and how to extend it to be stateful and use timers.
+-->
+* The [**DataStream API**](./tutorials/datastream_api.html) tutorial shows how to implement a basic DataStream application. 
+* The [**Table API**](./walkthroughs/table_api.html) code walkthrough shows how to implement a simple Table API query on a batch source and how to evolve it into a continuous query on a streaming source.
+
+<!-- 
+### Starting a new Flink application
+
+The **Project Setup** instructions show you how to create a project for a new Flink application in just a few steps.
+
+* [**DataStream API**]()
+* [**DataSet API**]()
+* [**Table API / SQL**]() 
+ -->


### PR DESCRIPTION
Mirror of apache flink#9603
## What is the purpose of the change

Add an overview page to the "Getting Started" section in the documentation. 
The purpose of the page is 

1. guide users to the right tutorial
2. serve as a landing page from the Tutorials link on the Flink website (flink.apache.org)

Once this PR is merged, we can redirect the Tutorials link on the Flink website.

## Brief change log

* Add overview page to "Getting Started" section
* I've added and commented-out content for future tutorials that are still WIP.

This PR is related to #9210 and #9543.
Depending on whether which PR is merged first, we need to update the others.

## Verifying this change

* Build docs and check content / links manually

## Does this pull request potentially affect one of the following parts:

This is a docs-only change.

## Documentation

This is a docs-only change.
