### PR TITLE
Mirror of apache flink#9602

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
@@ -26,6 +26,8 @@ import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.StateUtil;
 import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
 import org.apache.flink.util.ExceptionUtils;
 
 import org.slf4j.Logger;
@@ -40,6 +42,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -254,14 +258,14 @@ public class CompletedCheckpoint implements Serializable {
 
 			// discard private state objects
 			try {
-				StateUtil.bestEffortDiscardAllStateObjects(operatorStates.values());
+				StateUtil.bestEffortDiscardAllStateObjects(getIncrementKeyedStates());
 			} catch (Exception e) {
 				exception = ExceptionUtils.firstOrSuppressed(e, exception);
 			}
 
 			// discard location as a whole
 			try {
-				storageLocation.disposeStorageLocation();
+				storageLocation.disposeStorageLocation(true);
 			}
 			catch (Exception e) {
 				exception = ExceptionUtils.firstOrSuppressed(e, exception);
@@ -280,6 +284,34 @@ public class CompletedCheckpoint implements Serializable {
 			}
 		}
 	}
+
+	private Set<KeyedStateHandle> getIncrementKeyedStates() {
+		Set<KeyedStateHandle> incrementKeyedState = new HashSet<>(operatorStates.size());
+
+		//reference SavepointV2Serializer.serializeKeyedStateHandle
+		operatorStates.values().forEach(operatorState -> {
+			operatorState.getStates().forEach(operatorSubtaskState -> {
+				if (operatorSubtaskState != null && operatorSubtaskState.getManagedKeyedState() != null) {
+					for (KeyedStateHandle managedKeyedState : operatorSubtaskState.getManagedKeyedState()) {
+						if (managedKeyedState instanceof IncrementalRemoteKeyedStateHandle) {
+							incrementKeyedState.add(managedKeyedState);
+						}
+					}
+				}
+
+				if (operatorSubtaskState != null && operatorSubtaskState.getRawKeyedState() != null) {
+					for (KeyedStateHandle rawKeyedState : operatorSubtaskState.getRawKeyedState()) {
+						if (rawKeyedState instanceof IncrementalRemoteKeyedStateHandle) {
+							incrementKeyedState.add(rawKeyedState);
+						}
+					}
+				}
+			});
+		});
+
+		return incrementKeyedState;
+	}
+
 
 	// ------------------------------------------------------------------------
 	//  Miscellaneous

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CompletedCheckpointStorageLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CompletedCheckpointStorageLocation.java
@@ -45,4 +45,17 @@ public interface CompletedCheckpointStorageLocation extends java.io.Serializable
 	 * like the checkpoint directory.
 	 */
 	void disposeStorageLocation() throws IOException;
+
+	/**
+	 * Disposes the storage location. This method should be called after all state objects have
+	 * been released. It typically disposes the base structure of the checkpoint storage,
+	 * like the checkpoint directory.
+	 *
+	 * @param recursive
+	 *  if path is a directory and set to <code>true</code>, the directory is deleted else throws an exception. In
+	 * 	case of a file the recursive can be set to either <code>true</code> or <code>false</code>.
+	 *
+	 * @throws IOException
+	 */
+	void disposeStorageLocation(boolean recursive) throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCompletedCheckpointStorageLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCompletedCheckpointStorageLocation.java
@@ -64,9 +64,14 @@ public class FsCompletedCheckpointStorageLocation implements CompletedCheckpoint
 
 	@Override
 	public void disposeStorageLocation() throws IOException {
+		disposeStorageLocation(false);
+	}
+
+	@Override
+	public void disposeStorageLocation(boolean recursive) throws IOException {
 		if (fs == null) {
 			fs = exclusiveCheckpointDir.getFileSystem();
 		}
-		fs.delete(exclusiveCheckpointDir, false);
+		fs.delete(exclusiveCheckpointDir, recursive);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/NonPersistentMetadataCheckpointStorageLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/NonPersistentMetadataCheckpointStorageLocation.java
@@ -86,6 +86,11 @@ public class NonPersistentMetadataCheckpointStorageLocation
 
 		@Override
 		public void disposeStorageLocation() {}
+
+		@Override
+		public void disposeStorageLocation(boolean recursive) throws IOException {
+
+		}
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -2369,5 +2369,10 @@ public class JobMasterTest extends TestLogger {
 		public void disposeStorageLocation() throws IOException {
 
 		}
+
+		@Override
+		public void disposeStorageLocation(boolean recursive) throws IOException {
+
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/testutils/TestCompletedCheckpointStorageLocation.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/testutils/TestCompletedCheckpointStorageLocation.java
@@ -63,4 +63,9 @@ public class TestCompletedCheckpointStorageLocation implements CompletedCheckpoi
 	public void disposeStorageLocation() throws IOException {
 		disposed = true;
 	}
+
+	@Override
+	public void disposeStorageLocation(boolean recursive) throws IOException {
+		disposed = true;
+	}
 }


### PR DESCRIPTION
Mirror of apache flink#9602
## What is the purpose of the change

*Reduce the delete file api when the checkpoint is completed*


## Brief change log

  - *In full checkpoint, to delete the snapshot(chk-) folder directly*
  - *In incremental checkpoint, deleting the shared state first, and then dropping the exclusive location as a whole.*

## Verifying this change

This change added tests and can be verified as follows:

  - *refator CompletedCheckpoint.doDiscard, add private method  getIncrementKeyedStates to get increment key*
  - *add method void disposeStorageLocation(boolean recursive) throws IOException  in  CompletedCheckpointStorageLocation*
 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)


