### PR TITLE
Mirror of apache flink#9598

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
@@ -52,9 +52,12 @@ public class FileSystemBlobStore implements BlobStoreService {
 	/** The base path of the blob store. */
 	private final String basePath;
 
+	/** The name of the blob path. */
+	public static final String BLOB_PATH_NAME = "blob";
+
 	public FileSystemBlobStore(FileSystem fileSystem, String storagePath) throws IOException {
 		this.fileSystem = checkNotNull(fileSystem);
-		this.basePath = checkNotNull(storagePath) + "/blob";
+		this.basePath = checkNotNull(storagePath) + "/" + BLOB_PATH_NAME;
 
 		LOG.info("Creating highly available BLOB storage directory at {}", basePath);
 

--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -190,6 +190,22 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-hdfs</artifactId>
+			<scope>test</scope>
+			<type>test-jar</type>
+			<version>${hadoop.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-common</artifactId>
+			<scope>test</scope>
+			<type>test-jar</type>
+			<version>${hadoop.version}</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.curator</groupId>
 			<artifactId>curator-test</artifactId>
 			<version>${curator.version}</version>

--- a/flink-tests/src/test/java/org/apache/flink/test/highavailability/ZooKeeperHaStorageITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/highavailability/ZooKeeperHaStorageITCase.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.highavailability;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.core.fs.FileStatus;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.blob.FileSystemBlobStore;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.filesystem.FsStateBackend;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.runtime.util.ZooKeeperUtils;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.curator.test.TestingServer;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Integration tests for zookeeper high availability storage.
+ */
+public class ZooKeeperHaStorageITCase extends TestLogger {
+
+	private static final int NUM_JMS = 1;
+	private static final int NUM_TMS = 1;
+	private static final int NUM_SLOTS_PER_TM = 1;
+
+	@ClassRule
+	public static final TemporaryFolder TEMP_DIR = new TemporaryFolder();
+
+	private static MiniDFSCluster hdfsCluster;
+	private static Path hdfsRootPath;
+
+	private static String haStorageDir;
+	private static String clusterId = UUID.randomUUID().toString();
+
+	private static TestingServer zkServer;
+
+	private static MiniClusterWithClientResource miniClusterResource;
+
+	private static OneShotLatch waitForCheckpointLatch = new OneShotLatch();
+
+	@BeforeClass
+	public static void setup() throws Exception {
+		// Start zookeeper server
+		zkServer = new TestingServer();
+
+		// Start mini hdfs cluster
+		final File tempDir = TEMP_DIR.newFolder();
+		org.apache.hadoop.conf.Configuration hdConf = new org.apache.hadoop.conf.Configuration();
+		hdConf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, tempDir.getAbsolutePath());
+		MiniDFSCluster.Builder builder = new MiniDFSCluster.Builder(hdConf);
+		hdfsCluster = builder.build();
+		hdfsRootPath = new Path(hdfsCluster.getURI());
+		haStorageDir = hdfsRootPath.toString() + "/flink-ha";
+
+		Configuration config = new Configuration();
+		config.setInteger(ConfigConstants.LOCAL_NUMBER_JOB_MANAGER, NUM_JMS);
+		config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, NUM_TMS);
+		config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, NUM_SLOTS_PER_TM);
+
+		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, haStorageDir);
+		config.setString(HighAvailabilityOptions.HA_CLUSTER_ID, clusterId);
+		config.setString(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zkServer.getConnectString());
+		config.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
+
+		miniClusterResource = new MiniClusterWithClientResource(
+			new MiniClusterResourceConfiguration.Builder()
+				.setConfiguration(config)
+				.setNumberTaskManagers(NUM_TMS)
+				.setNumberSlotsPerTaskManager(NUM_SLOTS_PER_TM)
+				.build());
+
+		miniClusterResource.before();
+	}
+
+	@AfterClass
+	public static void tearDown() throws Exception {
+		if (miniClusterResource.getClusterClient()  != null) {
+			miniClusterResource.after();
+		}
+
+		if (hdfsCluster != null) {
+			hdfsCluster.shutdown();
+		}
+		hdfsCluster = null;
+		hdfsRootPath = null;
+
+		zkServer.stop();
+		zkServer.close();
+	}
+
+	@Test(timeout = 120_000L)
+	public void testHighAvailabilityDirectory() throws Exception {
+		waitForCheckpointLatch = new OneShotLatch();
+
+		JobGraph jobGraph = createJobGraph();
+		ClusterClient<?> clusterClient = miniClusterResource.getClusterClient();
+		clusterClient.setDetached(true);
+		clusterClient.submitJob(jobGraph, ZooKeeperHaStorageITCase.class.getClassLoader());
+
+		// wait until we did some checkpoints
+		waitForCheckpointLatch.await();
+
+		final FileSystem fileSystem = hdfsRootPath.getFileSystem();
+		// Only cluster id path exists
+		FileStatus[] fileStatuses = fileSystem.listStatus(new Path(haStorageDir));
+		Assert.assertEquals(1, fileStatuses.length);
+
+		// Check the blob,submittedJobGraph,checkpoint path should exist under cluster directory.
+		Path clusterPath = new Path(haStorageDir + "/" + clusterId);
+		Assert.assertTrue(fileSystem.exists(clusterPath));
+		int blobNum = 0, submittedJobGraphNum = 0, numCheckpoints = 0;
+		fileStatuses = fileSystem.listStatus(clusterPath);
+		for (FileStatus fileStatus : fileStatuses) {
+			if (fileStatus.getPath().getName().startsWith(FileSystemBlobStore.BLOB_PATH_NAME)) {
+				blobNum++;
+			} else if (fileStatus.getPath().getName().startsWith(ZooKeeperUtils.HA_STORAGE_SUBMITTED_JOBGRAPH_PREFIX)) {
+				submittedJobGraphNum++;
+			} else if (fileStatus.getPath().getName().startsWith(ZooKeeperUtils.HA_STORAGE_COMPLETED_CHECKPOINT)) {
+				numCheckpoints++;
+			}
+		}
+		assertEquals(1, blobNum);
+		assertEquals(1, submittedJobGraphNum);
+		assertTrue(numCheckpoints > 0);
+
+		// Stop the flink minicluster
+		miniClusterResource.after();
+	}
+
+	private static JobGraph createJobGraph() throws IOException {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(1);
+		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(Integer.MAX_VALUE, 0));
+		env.enableCheckpointing(10);
+		env.getCheckpointConfig().setTolerableCheckpointFailureNumber(0);
+
+		File checkpointLocation = TEMP_DIR.newFolder();
+		env.setStateBackend((StateBackend) new FsStateBackend(checkpointLocation.toURI()));
+
+		DataStreamSource<String> source = env.addSource(new UnboundedSource());
+
+		source
+			.keyBy((str) -> str)
+			.map(new TestFunction());
+
+		return env.getStreamGraph().getJobGraph();
+	}
+
+	private static class UnboundedSource implements SourceFunction<String> {
+		private static final long serialVersionUID = 1L;
+		private volatile boolean running = true;
+
+		@Override
+		public void run(SourceContext<String> ctx) throws Exception {
+			while (running) {
+				ctx.collect("hello");
+				// don't overdo it ... ;-)
+				Thread.sleep(50);
+			}
+		}
+
+		@Override
+		public void cancel() {
+			running = false;
+		}
+	}
+
+	private static class TestFunction extends RichMapFunction<String, String> implements CheckpointedFunction{
+
+		private static final long serialVersionUID = 1L;
+		// also have some state to write to the checkpoint
+		private final ValueStateDescriptor<String> stateDescriptor =
+			new ValueStateDescriptor<>("state", StringSerializer.INSTANCE);
+
+		@Override
+		public String map(String value) throws Exception {
+			getRuntimeContext().getState(stateDescriptor).update("42");
+			return value;
+		}
+
+		@Override
+		public void snapshotState(FunctionSnapshotContext context) throws Exception {
+			if (context.getCheckpointId() > 5) {
+				waitForCheckpointLatch.trigger();
+			}
+		}
+
+		@Override
+		public void initializeState(FunctionInitializationContext context) {
+
+		}
+	}
+}


### PR DESCRIPTION
Mirror of apache flink#9598
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request moves submittedJobGraph and completedCheckpoint to cluster-id subdirectory of high-availability storage. If the flink cluster terminates exceptionally, some external tools could be used to clean up these residual files.


## Brief change log

Use cluster-id sub directory instead of ha storage in `ZookeeperUtils#createCompletedCheckpoints()` and `ZookeeperUtils#createJobGraphs()`.


## Verifying this change

This change added tests and can be verified as follows:
  - Added integration tests `ZooKeeperHaStorageITCase` to check the high availability storage directory structure.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

