### PR TITLE
Mirror of apache flink#9596

### DIFF
--- a/docs/_includes/generated/resource_manager_configuration.html
+++ b/docs/_includes/generated/resource_manager_configuration.html
@@ -18,6 +18,16 @@
             <td>Percentage of heap space to remove from containers (YARN / Mesos), to compensate for other JVM memory usage.</td>
         </tr>
         <tr>
+            <td><h5>jobmanager.containerized.heap-cutoff-min</h5></td>
+            <td style="word-wrap: break-word;">600</td>
+            <td>Minimum amount of heap memory to remove in jobmanager containers, as a safety margin.</td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.containerized.heap-cutoff-ratio</h5></td>
+            <td style="word-wrap: break-word;">0.25</td>
+            <td>Percentage of heap space to remove from jobmanager containers (YARN / Mesos), to compensate for other JVM memory usage.</td>
+        </tr>
+        <tr>
             <td><h5>local.number-resourcemanager</h5></td>
             <td style="word-wrap: break-word;">1</td>
             <td>The number of resource managers start.</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -67,6 +67,18 @@ public class ResourceManagerOptions {
 			" for other JVM memory usage.");
 
 	/**
+	 * Percentage of heap space to remove from jobmanager containers (YARN / Mesos), to compensate
+	 * for other JVM memory usage.
+	 */
+	public static final ConfigOption<Float> JOBMANAGER_CONTAINERIZED_HEAP_CUTOFF_RATIO = ConfigOptions
+		.key("jobmanager.containerized.heap-cutoff-ratio")
+		.defaultValue(0.25f)
+		.withFallbackKeys("containerized.heap-cutoff-ratio")
+		.withDeprecatedKeys("yarn.heap-cutoff-ratio")
+		.withDescription("Percentage of heap space to remove from jobmanager containers (YARN / Mesos), to compensate" +
+			" for other JVM memory usage.");
+
+	/**
 	 * Minimum amount of heap memory to remove in containers, as a safety margin.
 	 */
 	public static final ConfigOption<Integer> CONTAINERIZED_HEAP_CUTOFF_MIN = ConfigOptions
@@ -74,6 +86,16 @@ public class ResourceManagerOptions {
 		.defaultValue(600)
 		.withDeprecatedKeys("yarn.heap-cutoff-min")
 		.withDescription("Minimum amount of heap memory to remove in containers, as a safety margin.");
+
+	/**
+	 * Minimum amount of heap memory to remove in jobmanager containers, as a safety margin.
+	 */
+	public static final ConfigOption<Integer> JOBMANAGER_CONTAINERIZED_HEAP_CUTOFF_MIN = ConfigOptions
+		.key("jobmanager.containerized.heap-cutoff-min")
+		.defaultValue(600)
+		.withFallbackKeys("containerized.heap-cutoff-min")
+		.withDeprecatedKeys("yarn.heap-cutoff-min")
+		.withDescription("Minimum amount of heap memory to remove in jobmanager containers, as a safety margin.");
 
 	/**
 	 * The timeout for a slot request to be discarded, in milliseconds.

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/UtilsTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/UtilsTest.java
@@ -81,58 +81,65 @@ public class UtilsTest extends TestLogger {
 
 	/**
 	 * Remove 15% of the heap, at least 384MB.
-	 *
 	 */
 	@Test
 	public void testHeapCutoff() {
 		Configuration conf = new Configuration();
+		conf.setFloat(ResourceManagerOptions.JOBMANAGER_CONTAINERIZED_HEAP_CUTOFF_RATIO, 0.15F);
+		conf.setInteger(ResourceManagerOptions.JOBMANAGER_CONTAINERIZED_HEAP_CUTOFF_MIN, 384);
+
+		Assert.assertEquals(616, Utils.calculateJobManagerHeapSize(1000, conf));
+		Assert.assertEquals(8500, Utils.calculateJobManagerHeapSize(10000, conf));
+
+		// test different configuration
+		Assert.assertEquals(3400, Utils.calculateJobManagerHeapSize(4000, conf));
+
+		conf.setString(ResourceManagerOptions.JOBMANAGER_CONTAINERIZED_HEAP_CUTOFF_MIN.key(), "1000");
+		conf.setString(ResourceManagerOptions.JOBMANAGER_CONTAINERIZED_HEAP_CUTOFF_RATIO.key(), "0.1");
+		Assert.assertEquals(3000, Utils.calculateJobManagerHeapSize(4000, conf));
+
+		conf.setString(ResourceManagerOptions.JOBMANAGER_CONTAINERIZED_HEAP_CUTOFF_RATIO.key(), "0.5");
+		Assert.assertEquals(2000, Utils.calculateJobManagerHeapSize(4000, conf));
+
+		conf.setString(ResourceManagerOptions.JOBMANAGER_CONTAINERIZED_HEAP_CUTOFF_RATIO.key(), "1");
+		Assert.assertEquals(0, Utils.calculateJobManagerHeapSize(4000, conf));
+
+		// test fallback
+		conf = new Configuration();
 		conf.setFloat(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_RATIO, 0.15F);
 		conf.setInteger(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_MIN, 384);
 
-		Assert.assertEquals(616, Utils.calculateHeapSize(1000, conf));
-		Assert.assertEquals(8500, Utils.calculateHeapSize(10000, conf));
-
-		// test different configuration
-		Assert.assertEquals(3400, Utils.calculateHeapSize(4000, conf));
-
-		conf.setString(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_MIN.key(), "1000");
-		conf.setString(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_RATIO.key(), "0.1");
-		Assert.assertEquals(3000, Utils.calculateHeapSize(4000, conf));
-
-		conf.setString(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_RATIO.key(), "0.5");
-		Assert.assertEquals(2000, Utils.calculateHeapSize(4000, conf));
-
-		conf.setString(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_RATIO.key(), "1");
-		Assert.assertEquals(0, Utils.calculateHeapSize(4000, conf));
+		Assert.assertEquals(616, Utils.calculateJobManagerHeapSize(1000, conf));
+		Assert.assertEquals(8500, Utils.calculateJobManagerHeapSize(10000, conf));
 
 		// test also deprecated keys
 		conf = new Configuration();
 		conf.setDouble(ConfigConstants.YARN_HEAP_CUTOFF_RATIO, 0.15);
 		conf.setInteger(ConfigConstants.YARN_HEAP_CUTOFF_MIN, 384);
 
-		Assert.assertEquals(616, Utils.calculateHeapSize(1000, conf));
-		Assert.assertEquals(8500, Utils.calculateHeapSize(10000, conf));
+		Assert.assertEquals(616, Utils.calculateJobManagerHeapSize(1000, conf));
+		Assert.assertEquals(8500, Utils.calculateJobManagerHeapSize(10000, conf));
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void illegalArgument() {
 		Configuration conf = new Configuration();
 		conf.setString(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_RATIO.key(), "1.1");
-		Assert.assertEquals(0, Utils.calculateHeapSize(4000, conf));
+		Assert.assertEquals(0, Utils.calculateJobManagerHeapSize(4000, conf));
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void illegalArgumentNegative() {
 		Configuration conf = new Configuration();
 		conf.setString(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_RATIO.key(), "-0.01");
-		Assert.assertEquals(0, Utils.calculateHeapSize(4000, conf));
+		Assert.assertEquals(0, Utils.calculateJobManagerHeapSize(4000, conf));
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void tooMuchCutoff() {
 		Configuration conf = new Configuration();
 		conf.setString(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_RATIO.key(), "6000");
-		Assert.assertEquals(0, Utils.calculateHeapSize(4000, conf));
+		Assert.assertEquals(0, Utils.calculateJobManagerHeapSize(4000, conf));
 	}
 
 	@Test

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -1587,7 +1587,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		final  Map<String, String> startCommandValues = new HashMap<>();
 		startCommandValues.put("java", "$JAVA_HOME/bin/java");
 
-		int heapSize = Utils.calculateHeapSize(jobManagerMemoryMb, flinkConfiguration);
+		int heapSize = Utils.calculateJobManagerHeapSize(jobManagerMemoryMb, flinkConfiguration);
 		String jvmHeapMem = String.format("-Xms%sm -Xmx%sm", heapSize, heapSize);
 		startCommandValues.put("jvmmem", jvmHeapMem);
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -92,19 +92,19 @@ public final class Utils {
 	/**
 	 * See documentation.
 	 */
-	public static int calculateHeapSize(int memory, org.apache.flink.configuration.Configuration conf) {
+	public static int calculateJobManagerHeapSize(int memory, org.apache.flink.configuration.Configuration conf) {
 
-		float memoryCutoffRatio = conf.getFloat(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_RATIO);
-		int minCutoff = conf.getInteger(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_MIN);
+		float memoryCutoffRatio = conf.getFloat(ResourceManagerOptions.JOBMANAGER_CONTAINERIZED_HEAP_CUTOFF_RATIO);
+		int minCutoff = conf.getInteger(ResourceManagerOptions.JOBMANAGER_CONTAINERIZED_HEAP_CUTOFF_MIN);
 
 		if (memoryCutoffRatio > 1 || memoryCutoffRatio < 0) {
 			throw new IllegalArgumentException("The configuration value '"
-				+ ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_RATIO.key()
+				+ ResourceManagerOptions.JOBMANAGER_CONTAINERIZED_HEAP_CUTOFF_RATIO.key()
 				+ "' must be between 0 and 1. Value given=" + memoryCutoffRatio);
 		}
 		if (minCutoff > memory) {
 			throw new IllegalArgumentException("The configuration value '"
-				+ ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_MIN.key()
+				+ ResourceManagerOptions.JOBMANAGER_CONTAINERIZED_HEAP_CUTOFF_MIN.key()
 				+ "' is higher (" + minCutoff + ") than the requested amount of memory " + memory);
 		}
 


### PR DESCRIPTION
Mirror of apache flink#9596


## What is the purpose of the change

* Distinguish Memory Configuration for TaskManager and JobManager 

## Brief change log

*(for example:)*
  - Allow to override jobmanager containerized.heap-cutoff-{min,ratio}

## Verifying this change

This change added tests and can be verified as follows:

*added test for config fallback

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)

