### PR TITLE
Mirror of apache flink#9587

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -84,6 +84,17 @@ public class YarnConfigOptions {
 				.build());
 
 	/**
+	 * The scheduler maximum-allocation-vcores exposed by YARN. This is a global property of the Yarn scheduler."
+	 */
+	public static final ConfigOption<Integer> SCHEDULER_MAX_VCORE =
+		key("yarn.scheduler.maximum-allocation-vcores")
+			.defaultValue(4)
+			.withDescription(
+					"This is the maximum allocation for every container request at the Resource Manager, in terms of" +
+					" virtual CPU cores. Requests higher than this won't take effect and will get capped to this" +
+					" value You can do this by setting the %s.");
+
+	/**
 	 * The maximum number of failed YARN containers before entirely stopping
 	 * the YARN session / job on YARN.
 	 * By default, we take the number of initially requested containers.


### PR DESCRIPTION
Mirror of apache flink#9587

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fail fast and give reasoning if Flink YARN deployment requests more cores (the number of task manager slots) than YARN resource manager allows.

## Brief change log

  - Retrieve maximum-allocation-vcores values from yarn-site.xml.
  - Fail Flink job immediately if the number of taskmanager slots requires higher than YARN yarn.scheduler.maximum-allocation-vcores.

## Verifying this change

This change added tests and can be verified manually as follows:

  - Find the value of yarn.scheduler.maximum-allocation-vcores in yarn-site.xml in the system. The default is ```4``` since YARN 2.6.2.
  - Run flink yarn deployment with more task manager slots than yarn.scheduler.maximum-allocation-vcores, eg: ```flink -m yarn-cluster -ys 8 examples/streaming/WordCount.jar```, will eventually timeout.
  - With this change, any Flink job will validate against YARN configurations. If the number of task manager slots is requested more than yarn.scheduler.maximum-allocation-vcores allows, it fails immediately.   
  - Tested with positive and negative testcases manually

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (yes / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

