### PR TITLE
Mirror of apache flink#9678

### DIFF
--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -90,7 +90,7 @@ These examples about how to submit a job in CLI.
 
 -   Run example program using a [per-job YARN cluster]({{site.baseurl}}/ops/deployment/yarn_setup.html#run-a-single-flink-job-on-hadoop-yarn) with 2 TaskManagers:
 
-        ./bin/flink run -m yarn-cluster -yn 2 \
+        ./bin/flink run -m yarn-cluster \
                                ./examples/batch/WordCount.jar \
                                --input hdfs:///user/hamlet.txt --output hdfs:///user/wordcount_out
 
@@ -130,7 +130,7 @@ These examples about how to submit a job in CLI.
 
 -   Run Python Table program using a [per-job YARN cluster]({{site.baseurl}}/ops/deployment/yarn_setup.html#run-a-single-flink-job-on-hadoop-yarn) with 2 TaskManagers:
 
-        ./bin/flink run -m yarn-cluster -yn 2 \
+        ./bin/flink run -m yarn-cluster \
                                -py examples/python/table/batch/word_count.py
 </div>
 
@@ -354,8 +354,6 @@ Action "run" compiles and runs a program.
      -yj,--yarnjar <arg>                  Path to Flink jar file
      -yjm,--yarnjobManagerMemory <arg>    Memory for JobManager Container
                                           with optional unit (default: MB)
-     -yn,--yarncontainer <arg>            Number of YARN container to allocate
-                                          (=Number of Task Managers)
      -ynm,--yarnname <arg>                Set a custom name for the application
                                           on YARN
      -yq,--yarnquery                      Display available YARN resources

--- a/docs/ops/cli.zh.md
+++ b/docs/ops/cli.zh.md
@@ -90,7 +90,7 @@ available.
 
 -   Run example program using a [per-job YARN cluster]({{site.baseurl}}/zh/ops/deployment/yarn_setup.html#run-a-single-flink-job-on-hadoop-yarn) with 2 TaskManagers:
 
-        ./bin/flink run -m yarn-cluster -yn 2 \
+        ./bin/flink run -m yarn-cluster  \
                                ./examples/batch/WordCount.jar \
                                --input hdfs:///user/hamlet.txt --output hdfs:///user/wordcount_out
                                
@@ -130,7 +130,7 @@ available.
 
 -   提交一个运行在有两个TaskManager的[per-job YARN cluster]({{site.baseurl}}/ops/deployment/yarn_setup.html#run-a-single-flink-job-on-hadoop-yarn)的Python Table的作业:
 
-        ./bin/flink run -m yarn-cluster -yn 2 \
+        ./bin/flink run -m yarn-cluster \
                                  -py examples/python/table/batch/word_count.py
                                  
 </div>
@@ -349,8 +349,6 @@ Action "run" compiles and runs a program.
      -yj,--yarnjar <arg>                  Path to Flink jar file
      -yjm,--yarnjobManagerMemory <arg>    Memory for JobManager Container
                                           with optional unit (default: MB)
-     -yn,--yarncontainer <arg>            Number of YARN container to allocate
-                                          (=Number of Task Managers)
      -ynm,--yarnname <arg>                Set a custom name for the application
                                           on YARN
      -yq,--yarnquery                      Display available YARN resources

--- a/docs/ops/deployment/aws.md
+++ b/docs/ops/deployment/aws.md
@@ -65,7 +65,7 @@ export HADOOP_CLASSPATH=`hadoop classpath`
 3. Extract the Flink distribution and you are ready to deploy [Flink jobs via YARN](yarn_setup.html) after **setting the Hadoop config directory**:
 
 {% highlight bash %}
-HADOOP_CONF_DIR=/etc/hadoop/conf ./bin/flink run -m yarn-cluster -yn 1 examples/streaming/WordCount.jar
+HADOOP_CONF_DIR=/etc/hadoop/conf ./bin/flink run -m yarn-cluster examples/streaming/WordCount.jar
 {% endhighlight %}
 
 {% top %}

--- a/docs/ops/deployment/aws.zh.md
+++ b/docs/ops/deployment/aws.zh.md
@@ -65,7 +65,7 @@ export HADOOP_CLASSPATH=`hadoop classpath`
 3. Extract the Flink distribution and you are ready to deploy [Flink jobs via YARN](yarn_setup.html) after **setting the Hadoop config directory**:
 
 {% highlight bash %}
-HADOOP_CONF_DIR=/etc/hadoop/conf ./bin/flink run -m yarn-cluster -yn 1 examples/streaming/WordCount.jar
+HADOOP_CONF_DIR=/etc/hadoop/conf ./bin/flink run -m yarn-cluster examples/streaming/WordCount.jar
 {% endhighlight %}
 
 {% top %}

--- a/flink-end-to-end-tests/test-scripts/test_yarn_kerberos_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/test_yarn_kerberos_docker.sh
@@ -175,7 +175,7 @@ start_time=$(date +%s)
 # it's important to run this with higher parallelism, otherwise we might risk that
 # JM and TM are on the same YARN node and that we therefore don't test the keytab shipping
 if docker exec -it master bash -c "export HADOOP_CLASSPATH=\`hadoop classpath\` && \
-   /home/hadoop-user/$FLINK_DIRNAME/bin/flink run -m yarn-cluster -yn 3 -ys 1 -ytm 1000 -yjm 1000 \
+   /home/hadoop-user/$FLINK_DIRNAME/bin/flink run -m yarn-cluster -ys 1 -ytm 1000 -yjm 1000 \
    -p 3 /home/hadoop-user/$FLINK_DIRNAME/examples/streaming/WordCount.jar $INPUT_ARGS --output $OUTPUT_PATH";
 then
     docker exec -it master bash -c "kinit -kt /home/hadoop-user/hadoop-user.keytab hadoop-user"
@@ -202,7 +202,7 @@ docker exec -it master bash -c "echo \"\" > /home/hadoop-user/$FLINK_DIRNAME/con
 # verify that it doesn't work if we don't configure a keytab
 OUTPUT=$(docker exec -it master bash -c "export HADOOP_CLASSPATH=\`hadoop classpath\` && \
     /home/hadoop-user/$FLINK_DIRNAME/bin/flink run \
-    -m yarn-cluster -yn 3 -ys 1 -ytm 1000 -yjm 1000 -p 3 \
+    -m yarn-cluster -ys 1 -ytm 1000 -yjm 1000 -p 3 \
     /home/hadoop-user/$FLINK_DIRNAME/examples/streaming/WordCount.jar --output $OUTPUT_PATH")
 echo "$OUTPUT"
 

--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonShellParserTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonShellParserTest.java
@@ -53,9 +53,9 @@ public class PythonShellParserTest {
 
 	@Test
 	public void testParseYarnWithOptions() {
-		String[] args = {"yarn", "-n", "2", "-jm", "1024m", "-tm", "4096m"};
+		String[] args = {"yarn", "-jm", "1024m", "-tm", "4096m"};
 		List<String> commandOptions = PythonShellParser.parseYarn(args);
-		String[] expectedCommandOptions = {"yarn", "-m", "yarn-cluster", "-yn", "2", "-yjm", "1024m", "-ytm", "4096m"};
+		String[] expectedCommandOptions = {"yarn", "-m", "yarn-cluster", "-yjm", "1024m", "-ytm", "4096m"};
 		Assert.assertArrayEquals(expectedCommandOptions, commandOptions.toArray());
 	}
 }

--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
@@ -49,7 +49,6 @@ object FlinkShell {
 
   /** YARN configuration object */
   case class YarnConfig(
-    containers: Option[Int] = None,
     jobManagerMemory: Option[String] = None,
     name: Option[String] = None,
     queue: Option[String] = None,
@@ -93,10 +92,6 @@ object FlinkShell {
       cmd("yarn") action {
         (_, c) => c.copy(executionMode = ExecutionMode.YARN, yarnConfig = None)
       } text "Starts Flink scala shell connecting to a yarn cluster" children(
-        opt[Int]("container") abbr ("n") valueName ("arg") action {
-          (x, c) =>
-            c.copy(yarnConfig = Some(ensureYarnConfig(c).copy(containers = Some(x))))
-        } text "Number of YARN container to allocate (= Number of TaskManagers)",
         opt[String]("jobManagerMemory") abbr ("jm") valueName ("arg") action {
           (x, c) =>
             c.copy(yarnConfig = Some(ensureYarnConfig(c).copy(jobManagerMemory = Some(x))))
@@ -246,13 +241,6 @@ object FlinkShell {
     val args = ArrayBuffer[String](
       "-m", "yarn-cluster"
     )
-
-    // number of task managers is required.
-    yarnConfig.containers match {
-      case Some(containers) => args ++= Seq("-yn", containers.toString)
-      case None =>
-        throw new IllegalArgumentException("Number of taskmanagers must be specified.")
-    }
 
     // set configuration from user input
     yarnConfig.jobManagerMemory.foreach((jmMem) => args ++= Seq("-yjm", jmMem.toString))

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/CliFrontendRunWithYarnTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/CliFrontendRunWithYarnTest.java
@@ -81,13 +81,13 @@ public class CliFrontendRunWithYarnTest extends CliFrontendTestBase {
 
 		// test detached mode
 		{
-			String[] parameters = {"-m", "yarn-cluster", "-yn", "1", "-p", "2", "-d", testJarPath};
+			String[] parameters = {"-m", "yarn-cluster", "-p", "2", "-d", testJarPath};
 			verifyCliFrontend(yarnCLI, parameters, 2, true);
 		}
 
 		// test detached mode
 		{
-			String[] parameters = {"-m", "yarn-cluster", "-yn", "1", "-p", "2", "-yd", testJarPath};
+			String[] parameters = {"-m", "yarn-cluster", "-p", "2", "-yd", testJarPath};
 			verifyCliFrontend(yarnCLI, parameters, 2, true);
 		}
 	}

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
@@ -173,7 +173,6 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 					"-yj", flinkUberjar.getAbsolutePath(),
 					"-yt", flinkLibFolder.getAbsolutePath(),
 					"-yt", flinkShadedHadoopDir.getAbsolutePath(),
-					"-yn", "1",
 					"-ys", "2", //test that the job is executed with a DOP of 2
 					"-yjm", "768m",
 					"-ytm", "1024m", exampleJarLocation.getAbsolutePath()},
@@ -218,7 +217,6 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 					"-yj", flinkUberjar.getAbsolutePath(),
 					"-yt", flinkLibFolder.getAbsolutePath(),
 					"-yt", flinkShadedHadoopDir.getAbsolutePath(),
-					"-yn", "1",
 					"-ys", "2", //test that the job is executed with a DOP of 2
 					"-yjm", "768m",
 					"-ytm", taskManagerMemoryMB + "m",
@@ -402,7 +400,6 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 				runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(),
 					"-t", flinkLibFolder.getAbsolutePath(),
 					"-t", flinkShadedHadoopDir.getAbsolutePath(),
-					"-n", "1",
 					"-jm", "768m",
 					"-tm", "1024m",
 					"-qu", "doesntExist"}, "to unknown queue: doesntExist", null, RunTypes.YARN_SESSION, 1);
@@ -431,7 +428,6 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 					"-yj", flinkUberjar.getAbsolutePath(),
 					"-yt", flinkLibFolder.getAbsolutePath(),
 					"-yt", flinkShadedHadoopDir.getAbsolutePath(),
-					"-yn", "1",
 					"-ys", "2",
 					"-yjm", "768m",
 					"-ytm", "1024m", exampleJarLocation.getAbsolutePath()},
@@ -505,7 +501,6 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 				"-yj", flinkUberjar.getAbsolutePath(),
 				"-yt", flinkLibFolder.getAbsolutePath(),
 				"-yt", flinkShadedHadoopDir.getAbsolutePath(),
-				"-yn", "1",
 				"-yjm", "768m",
 				// test if the cutoff is passed correctly (only useful when larger than the value
 				// of containerized.heap-cutoff-min (default: 600MB)

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -105,9 +105,6 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 			args.add("-t");
 			args.add(flinkShadedHadoopDir.getAbsolutePath());
 
-			args.add("-n");
-			args.add("1");
-
 			args.add("-jm");
 			args.add("768m");
 
@@ -248,7 +245,6 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 				"-j", flinkUberjar.getAbsolutePath(),
 				"-t", flinkLibFolder.getAbsolutePath(),
 				"-t", flinkShadedHadoopDir.getAbsolutePath(),
-				"-n", "5",
 				"-jm", "256m",
 				"-tm", "1585m"}, "Number of connected TaskManagers changed to", null, RunTypes.YARN_SESSION, 0);
 			LOG.info("Finished testResourceComputation()");
@@ -281,7 +277,6 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 				"-j", flinkUberjar.getAbsolutePath(),
 				"-t", flinkLibFolder.getAbsolutePath(),
 				"-t", flinkShadedHadoopDir.getAbsolutePath(),
-				"-n", "2",
 				"-jm", "256m",
 				"-tm", "3840m"}, "Number of connected TaskManagers changed to", null, RunTypes.YARN_SESSION, 0);
 			LOG.info("Finished testfullAlloc()");

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -128,7 +128,6 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 	private final Option flinkJar;
 	private final Option jmMemory;
 	private final Option tmMemory;
-	private final Option container;
 	private final Option slots;
 	private final Option zookeeperNamespace;
 	private final Option nodeLabel;
@@ -191,7 +190,6 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 		flinkJar = new Option(shortPrefix + "j", longPrefix + "jar", true, "Path to Flink jar file");
 		jmMemory = new Option(shortPrefix + "jm", longPrefix + "jobManagerMemory", true, "Memory for JobManager Container with optional unit (default: MB)");
 		tmMemory = new Option(shortPrefix + "tm", longPrefix + "taskManagerMemory", true, "Memory per TaskManager Container with optional unit (default: MB)");
-		container = new Option(shortPrefix + "n", longPrefix + "container", true, "Number of YARN container to allocate (=Number of Task Managers)");
 		slots = new Option(shortPrefix + "s", longPrefix + "slots", true, "Number of slots per TaskManager");
 		dynamicproperties = Option.builder(shortPrefix + "D")
 			.argName("property=value")
@@ -210,7 +208,6 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 		allOptions.addOption(flinkJar);
 		allOptions.addOption(jmMemory);
 		allOptions.addOption(tmMemory);
-		allOptions.addOption(container);
 		allOptions.addOption(queue);
 		allOptions.addOption(query);
 		allOptions.addOption(shipPath);
@@ -382,19 +379,6 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 	}
 
 	private ClusterSpecification createClusterSpecification(Configuration configuration, CommandLine cmd) {
-		if (cmd.hasOption(container.getOpt())) { // number of containers is required option!
-			LOG.info("The argument {} is deprecated in will be ignored.", container.getOpt());
-		}
-
-		// TODO: The number of task manager should be deprecated soon
-		final int numberTaskManagers;
-
-		if (cmd.hasOption(container.getOpt())) {
-			numberTaskManagers = Integer.valueOf(cmd.getOptionValue(container.getOpt()));
-		} else {
-			numberTaskManagers = 1;
-		}
-
 		// JobManager Memory
 		final int jobManagerMemoryMB = ConfigurationUtils.getJobManagerHeapMemory(configuration).getMebiBytes();
 
@@ -406,7 +390,6 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 		return new ClusterSpecification.ClusterSpecificationBuilder()
 			.setMasterMemoryMB(jobManagerMemoryMB)
 			.setTaskManagerMemoryMB(taskManagerMemoryMB)
-			.setNumberTaskManagers(numberTaskManagers)
 			.setSlotsPerTaskManager(slotsPerTaskManager)
 			.createClusterSpecification();
 	}
@@ -416,10 +399,6 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 		HelpFormatter formatter = new HelpFormatter();
 		formatter.setWidth(200);
 		formatter.setLeftPadding(5);
-		formatter.setSyntaxPrefix("   Required");
-		Options req = new Options();
-		req.addOption(container);
-		formatter.printHelp(" ", req);
 
 		formatter.setSyntaxPrefix("   Optional");
 		Options options = new Options();

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
@@ -82,7 +82,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 		cli.addRunOptions(options);
 
 		CommandLineParser parser = new DefaultParser();
-		CommandLine cmd = parser.parse(options, new String[]{"run", "-j", "fake.jar", "-n", "15",
+		CommandLine cmd = parser.parse(options, new String[]{"run", "-j", "fake.jar",
 				"-D", "akka.ask.timeout=5 min", "-D", "env.java.opts=-DappName=foobar", "-D", "security.ssl.internal.key-password=changeit"});
 
 		AbstractYarnClusterDescriptor flinkYarnDescriptor = cli.createClusterDescriptor(cmd);
@@ -100,7 +100,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 	@Test
 	public void testCorrectSettingOfMaxSlots() throws Exception {
 		String[] params =
-			new String[] {"-yn", "2", "-ys", "3"};
+			new String[] {"-ys", "3"};
 
 		FlinkYarnSessionCli yarnCLI = new FlinkYarnSessionCli(
 			new Configuration(),
@@ -116,7 +116,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 
 		// each task manager has 3 slots but the parallelism is 7. Thus the slots should be increased.
 		assertEquals(3, clusterSpecification.getSlotsPerTaskManager());
-		assertEquals(2, clusterSpecification.getNumberTaskManagers());
+		assertEquals(1, clusterSpecification.getNumberTaskManagers());
 	}
 
 	@Test
@@ -142,7 +142,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 	public void testZookeeperNamespaceProperty() throws Exception {
 		String zkNamespaceCliInput = "flink_test_namespace";
 
-		String[] params = new String[] {"-yn", "2", "-yz", zkNamespaceCliInput};
+		String[] params = new String[] {"-yz", zkNamespaceCliInput};
 
 		FlinkYarnSessionCli yarnCLI = new FlinkYarnSessionCli(
 			new Configuration(),
@@ -161,7 +161,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 	public void testNodeLabelProperty() throws Exception {
 		String nodeLabelCliInput = "flink_test_nodelabel";
 
-		String[] params = new String[] { "-yn", "2", "-ynl", nodeLabelCliInput };
+		String[] params = new String[] {"-ynl", nodeLabelCliInput };
 
 		FlinkYarnSessionCli yarnCLI = new FlinkYarnSessionCli(
 			new Configuration(),
@@ -358,7 +358,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 	 */
 	@Test
 	public void testHeapMemoryPropertyWithoutUnit() throws Exception {
-		final String[] args = new String[] { "-yn", "2", "-yjm", "1024", "-ytm", "2048" };
+		final String[] args = new String[] { "-yjm", "1024", "-ytm", "2048" };
 		final FlinkYarnSessionCli flinkYarnSessionCli = new FlinkYarnSessionCli(
 			new Configuration(),
 			tmp.getRoot().getAbsolutePath(),
@@ -378,7 +378,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 	 */
 	@Test
 	public void testHeapMemoryPropertyWithUnitMB() throws Exception {
-		final String[] args = new String[] { "-yn", "2", "-yjm", "1024m", "-ytm", "2048m" };
+		final String[] args = new String[] { "-yjm", "1024m", "-ytm", "2048m" };
 		final FlinkYarnSessionCli flinkYarnSessionCli = new FlinkYarnSessionCli(
 			new Configuration(),
 			tmp.getRoot().getAbsolutePath(),
@@ -396,7 +396,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 	 */
 	@Test
 	public void testHeapMemoryPropertyWithArbitraryUnit() throws Exception {
-		final String[] args = new String[] { "-yn", "2", "-yjm", "1g", "-ytm", "2g" };
+		final String[] args = new String[] { "-yjm", "1g", "-ytm", "2g" };
 		final FlinkYarnSessionCli flinkYarnSessionCli = new FlinkYarnSessionCli(
 			new Configuration(),
 			tmp.getRoot().getAbsolutePath(),


### PR DESCRIPTION
Mirror of apache flink#9678

## What is the purpose of the change

*This pull request removes legacy container number config option for Flink on yarn*


## Brief change log

  - *Remove legacy container number config option for Flink on yarn*
  - *Refactored test and document*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no)**
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)

