### PR TITLE
Mirror of apache flink#9676

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -312,6 +312,15 @@ public class TaskManagerOptions {
 
 	// ------------------------------------------------------------------------
 
+	/**
+	 * Toggle to switch between FLIP-49 and current task manager memory configurations.
+	 */
+	@Documentation.ExcludeFromDocumentation("FLIP-49 is still in development.")
+	public static final ConfigOption<Boolean> ENABLE_FLIP_49_CONFIG =
+			key("taskmanager.enable-flip-49")
+			.defaultValue(false)
+			.withDescription("Toggle to switch between FLIP-49 and current task manager memory configurations.");
+
 	/** Not intended to be instantiated. */
 	private TaskManagerOptions() {}
 }


### PR DESCRIPTION
Mirror of apache flink#9676
## What is the purpose of the change

This PR introduce a config switch for enabling FLIP-49 task executor memory configurations. This is a temporal config option for developing purpose.

## Brief change log

- Introduce "taskmanager.enable-flip-49" for enabling FLIP-49 task executor memory configurations.

## Verifying this change

This change is a trivial work without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

