### PR TITLE
Mirror of apache flink#9674

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/TypeStringUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/TypeStringUtils.java
@@ -271,7 +271,7 @@ public class TypeStringUtils {
 
 		private TypeInformation<?> convertType() {
 			final TypeInformation<?> typeInfo;
-			switch (token().literal) {
+			switch (token().literal.toUpperCase()) {
 				case VARCHAR:
 				case STRING:
 					return Types.STRING;

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/TypeStringUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/TypeStringUtilsTest.java
@@ -123,6 +123,13 @@ public class TypeStringUtilsTest {
 				Types.BIG_DEC, Types.BYTE),
 			TypeStringUtils.readTypeInfo("ROW(`he         \nllo` DECIMAL, world TINYINT)"));
 
+		// test type definition with lowercase
+		assertEquals(
+			Types.ROW_NAMED(
+				new String[] {"hello", "world"},
+				Types.BIG_DEC, Types.BYTE),
+			TypeStringUtils.readTypeInfo("ROW(hello DECIMAL, world tinyint)"));
+
 		// test nesting
 		testReadAndWrite(
 			"ROW<singleton ROW<f0 INT>, twoField ROW<`Field 1` ROW<f0 DECIMAL>, `Field``s 2` VARCHAR>>",


### PR DESCRIPTION
Mirror of apache flink#9674
## What is the purpose of the change
This commit fix the case sensitivity when we define data type with lowcase. The corresponding issue: https://issues.apache.org/jira/browse/FLINK-14046
This will be more helpful for user to use DDL and improve user experience

## Verifying this change
add toUpperCase() in TypeStringUtils.convertType() method, and add a test case

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)

