### PR TITLE
Mirror of apache flink#9673

### DIFF
--- a/flink-examples/flink-examples-table/pom.xml
+++ b/flink-examples/flink-examples-table/pom.xml
@@ -51,6 +51,11 @@ under the License.
 			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
@@ -154,6 +159,28 @@ under the License.
 					</execution>
 
 					<execution>
+						<id>BlinkStreamSQL</id>
+						<phase>package</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+
+						<configuration>
+							<classifier>BlinkStreamSQL</classifier>
+
+							<archive>
+								<manifestEntries>
+									<program-class>org.apache.flink.table.examples.java.BlinkStreamSQL</program-class>
+								</manifestEntries>
+							</archive>
+
+							<includes>
+								<include>org/apache/flink/table/examples/java/BlinkStreamSQL*</include>
+							</includes>
+						</configuration>
+					</execution>
+
+					<execution>
 						<id>StreamTableExample</id>
 						<phase>package</phase>
 						<goals>
@@ -213,6 +240,7 @@ under the License.
 								<copy file="${project.basedir}/target/flink-examples-table_${scala.binary.version}-${project.version}-WordCountTable.jar" tofile="${project.basedir}/target/WordCountTable.jar"/>
 								<copy file="${project.basedir}/target/flink-examples-table_${scala.binary.version}-${project.version}-StreamTableExample.jar" tofile="${project.basedir}/target/StreamTableExample.jar"/>
 								<copy file="${project.basedir}/target/flink-examples-table_${scala.binary.version}-${project.version}-TPCHQuery3Table.jar" tofile="${project.basedir}/target/TPCHQuery3Table.jar"/>
+								<copy file="${project.basedir}/target/flink-examples-table_${scala.binary.version}-${project.version}-BlinkStreamSQL.jar" tofile="${project.basedir}/target/BlinkStreamSQL.jar"/>
 							</target>
 						</configuration>
 					</execution>

--- a/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/BlinkStreamSQL.java
+++ b/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/BlinkStreamSQL.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.examples.java;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.java.StreamTableEnvironment;
+
+import java.util.Arrays;
+
+/**
+ * Simple example for demonstrating the use of SQL on a Stream Table with blink planner in Java.
+ *
+ * <p>This example shows how to:
+ *  - Convert DataStreams to Tables
+ *  - Register a Table under a name
+ *  - Run a StreamSQL query on the registered Table
+ */
+public class BlinkStreamSQL {
+
+	// *************************************************************************
+	//     PROGRAM
+	// *************************************************************************
+
+	public static void main(String[] args)throws Exception{
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		// set blink planner in streaming mode
+		EnvironmentSettings settings = EnvironmentSettings.newInstance()
+			.useBlinkPlanner()
+			.inStreamingMode()
+			.build();
+		StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, settings);
+
+		DataStream<Order> orderA = env.fromCollection(Arrays.asList(
+			new Order(1L, "beer", 3),
+			new Order(1L, "diaper", 4),
+			new Order(3L, "rubber", 2)));
+
+		DataStream<Order> orderB = env.fromCollection(Arrays.asList(
+			new Order(2L, "pen", 3),
+			new Order(2L, "rubber", 3),
+			new Order(4L, "beer", 1)));
+
+		// convert DataStream to Table
+		Table tableA = tEnv.fromDataStream(orderA, "productId, product, amount");
+		// register DataStream as Table
+		tEnv.registerDataStream("OrderB", orderB, "productId, product, amount");
+
+		// union the two tables
+		Table result = tEnv.sqlQuery("SELECT * FROM " + tableA + " WHERE amount > 2 UNION ALL " +
+			"SELECT * FROM OrderB WHERE amount < 2");
+
+		tEnv.toAppendStream(result, Order.class).print();
+
+		tEnv.execute("");
+	}
+
+	// *************************************************************************
+	//     USER DATA TYPES
+	// *************************************************************************
+
+	/**
+	 * Simple POJO.
+	 */
+	public static class Order {
+		public Long productId;
+		public String product;
+		public int amount;
+
+		public Order() {
+		}
+
+		public Order(Long productId, String product, int amount) {
+			this.productId = productId;
+			this.product = product;
+			this.amount = amount;
+		}
+
+		@Override
+		public String toString() {
+			return "Order{" +
+				"productId=" + productId +
+				", product='" + product + '\'' +
+				", amount=" + amount +
+				'}';
+		}
+	}
+}

--- a/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/BlinkStreamSQL.scala
+++ b/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/BlinkStreamSQL.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.examples.scala
+
+import org.apache.flink.api.scala._
+import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.table.api.EnvironmentSettings
+import org.apache.flink.table.api.scala.{StreamTableEnvironment, _}
+
+/**
+  * Simple example for demonstrating the use of SQL on a Stream Table with blink planner in Scala.
+  *
+  * <p>This example shows how to:
+  *  - Convert DataStreams to Tables
+  *  - Register a Table under a name
+  *  - Run a StreamSQL query on the registered Table
+  */
+object BlinkStreamSQL {
+
+  // *************************************************************************
+  //     PROGRAM
+  // *************************************************************************
+
+  def main(args: Array[String]): Unit = {
+
+    // set up execution environment
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    // set blink planner in streaming mode
+    val settings = EnvironmentSettings.newInstance()
+      .useBlinkPlanner()
+      .inStreamingMode()
+      .build()
+    val tEnv = StreamTableEnvironment.create(env, settings)
+
+    val orderA = env.fromCollection(Seq(
+      Order(1L, "beer", 3),
+      Order(1L, "diaper", 4),
+      Order(3L, "rubber", 2)))
+
+    val orderB = env.fromCollection(Seq(
+      Order(2L, "pen", 3),
+      Order(2L, "rubber", 3),
+      Order(4L, "beer", 1)))
+
+    // convert DataStream to Table
+    val tableA = tEnv.fromDataStream(orderA, 'productId, 'product, 'amount)
+    // register DataStream as Table
+    tEnv.registerDataStream("OrderB", orderB, 'productId, 'product, 'amount)
+
+    // union the two tables
+    val result = tEnv.sqlQuery(
+        s"""
+          |SELECT * FROM $tableA WHERE amount > 2
+          |UNION ALL
+          |SELECT * FROM OrderB WHERE amount < 2
+        """.stripMargin)
+
+    result.toAppendStream[Order].print()
+
+    env.execute()
+  }
+
+  // *************************************************************************
+  //     USER DATA TYPES
+  // *************************************************************************
+
+  case class Order(productId: Long, product: String, amount: Int)
+}


### PR DESCRIPTION
Mirror of apache flink#9673
## What is the purpose of the change
Added the blink planner dependency and examples which use blink planner to flink-examples-table.

## Brief change log
- Add the blink planner dependency.
- Add examples which use blink planner.

## Verifying this change
Manually verified. Ran examples on idea and a local cluster.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

