### PR TITLE
Mirror of apache flink#9672

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.common.time.Time;
 import javax.annotation.Nonnull;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -141,6 +143,30 @@ public class ConfigurationUtils {
 		}
 
 		return configuration;
+	}
+
+	/**
+	 * Replaces values whose keys are sensitive according to {@link GlobalConfiguration#isSensitive(String)}
+	 * with {@link GlobalConfiguration#HIDDEN_CONTENT}.
+	 *
+	 * <p>This can be useful when displaying configuration values.
+	 *
+	 * @param keyValuePairs for which to hide sensitive values
+	 * @return A map where all sensitive value are hidden
+	 */
+	@Nonnull
+	public static Map<String, String> hideSensitiveValues(Map<String, String> keyValuePairs) {
+		final HashMap<String, String> result = new HashMap<>();
+
+		for (Map.Entry<String, String> keyValuePair : keyValuePairs.entrySet()) {
+			if (GlobalConfiguration.isSensitive(keyValuePair.getKey())) {
+				result.put(keyValuePair.getKey(), GlobalConfiguration.HIDDEN_CONTENT);
+			} else {
+				result.put(keyValuePair.getKey(), keyValuePair.getValue());
+			}
+		}
+
+		return result;
 	}
 
 	@Nonnull

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationUtilsTest.java
@@ -55,7 +55,7 @@ public class ConfigurationUtilsTest extends TestLogger {
 	}
 
 	@Test
-	public void testHideSensitiveValues() {
+		public void testHideSensitiveValues() {
 		final Map<String, String> keyValuePairs = new HashMap<>();
 		keyValuePairs.put("foobar", "barfoo");
 		final String secretKey1 = "secret.key";

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationUtilsTest.java
@@ -22,6 +22,9 @@ import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -49,6 +52,26 @@ public class ConfigurationUtilsTest extends TestLogger {
 		}
 
 		assertThat(configuration.toMap().size(), is(properties.size()));
+	}
+
+	@Test
+	public void testHideSensitiveValues() {
+		final Map<String, String> keyValuePairs = new HashMap<>();
+		keyValuePairs.put("foobar", "barfoo");
+		final String secretKey1 = "secret.key";
+		keyValuePairs.put(secretKey1, "12345");
+		final String secretKey2 = "my.password";
+		keyValuePairs.put(secretKey2, "12345");
+
+		final Map<String, String> expectedKeyValuePairs = new HashMap<>(keyValuePairs);
+
+		for (String secretKey : Arrays.asList(secretKey1, secretKey2)) {
+			expectedKeyValuePairs.put(secretKey, GlobalConfiguration.HIDDEN_CONTENT);
+		}
+
+		final Map<String, String> hiddenSensitiveValues = ConfigurationUtils.hideSensitiveValues(keyValuePairs);
+
+		assertThat(hiddenSensitiveValues, is(equalTo(expectedKeyValuePairs)));
 	}
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobConfigHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobConfigHandler.java
@@ -80,12 +80,7 @@ public class JobConfigHandler extends AbstractExecutionGraphHandler<JobConfigInf
 		final JobConfigInfo.ExecutionConfigInfo executionConfigInfo;
 
 		if (executionConfig != null) {
-			executionConfigInfo = new JobConfigInfo.ExecutionConfigInfo(
-				executionConfig.getExecutionMode(),
-				executionConfig.getRestartStrategyDescription(),
-				executionConfig.getParallelism(),
-				executionConfig.getObjectReuseEnabled(),
-				executionConfig.getGlobalJobParameters());
+			executionConfigInfo = JobConfigInfo.ExecutionConfigInfo.from(executionConfig);
 		} else {
 			executionConfigInfo = null;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ClusterConfigurationInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ClusterConfigurationInfo.java
@@ -19,10 +19,11 @@
 package org.apache.flink.runtime.rest.messages;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.runtime.rest.handler.cluster.ClusterConfigHandler;
 
 import java.util.ArrayList;
+import java.util.Map;
 
 /**
  * Response of the {@link ClusterConfigHandler}, represented as a list
@@ -40,17 +41,11 @@ public class ClusterConfigurationInfo extends ArrayList<ClusterConfigurationInfo
 	}
 
 	public static ClusterConfigurationInfo from(Configuration config) {
-		ClusterConfigurationInfo clusterConfig = new ClusterConfigurationInfo(config.keySet().size());
+		final ClusterConfigurationInfo clusterConfig = new ClusterConfigurationInfo(config.keySet().size());
+		final Map<String, String> configurationWithHiddenSensitiveValues = ConfigurationUtils.hideSensitiveValues(config.toMap());
 
-		for (String key : config.keySet()) {
-			String value = config.getString(key, null);
-
-			// Mask key values which contain sensitive information
-			if (value != null && GlobalConfiguration.isSensitive(key)) {
-				value = GlobalConfiguration.HIDDEN_CONTENT;
-			}
-
-			clusterConfig.add(new ClusterConfigurationInfoEntry(key, value));
+		for (Map.Entry<String, String> keyValuePair : configurationWithHiddenSensitiveValues.entrySet()) {
+			clusterConfig.add(new ClusterConfigurationInfoEntry(keyValuePair.getKey(), keyValuePair.getValue()));
 		}
 
 		return clusterConfig;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobConfigInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobConfigInfo.java
@@ -189,7 +189,7 @@ public class JobConfigInfo implements ResponseBody {
 		private final int parallelism;
 
 		@JsonProperty(FIELD_NAME_OBJECT_REUSE_MODE)
-		private final boolean isObjectResuse;
+		private final boolean isObjectReuse;
 
 		@JsonProperty(FIELD_NAME_GLOBAL_JOB_PARAMETERS)
 		private final Map<String, String> globalJobParameters;
@@ -199,12 +199,12 @@ public class JobConfigInfo implements ResponseBody {
 				@JsonProperty(FIELD_NAME_EXECUTION_MODE) String executionMode,
 				@JsonProperty(FIELD_NAME_RESTART_STRATEGY) String restartStrategy,
 				@JsonProperty(FIELD_NAME_PARALLELISM) int parallelism,
-				@JsonProperty(FIELD_NAME_OBJECT_REUSE_MODE) boolean isObjectResuse,
+				@JsonProperty(FIELD_NAME_OBJECT_REUSE_MODE) boolean isObjectReuse,
 				@JsonProperty(FIELD_NAME_GLOBAL_JOB_PARAMETERS) Map<String, String> globalJobParameters) {
 			this.executionMode = Preconditions.checkNotNull(executionMode);
 			this.restartStrategy = Preconditions.checkNotNull(restartStrategy);
 			this.parallelism = parallelism;
-			this.isObjectResuse = isObjectResuse;
+			this.isObjectReuse = isObjectReuse;
 			this.globalJobParameters = Preconditions.checkNotNull(globalJobParameters);
 		}
 
@@ -221,8 +221,8 @@ public class JobConfigInfo implements ResponseBody {
 		}
 
 		@JsonIgnore
-		public boolean isObjectResuse() {
-			return isObjectResuse;
+		public boolean isObjectReuse() {
+			return isObjectReuse;
 		}
 
 		public Map<String, String> getGlobalJobParameters() {
@@ -239,7 +239,7 @@ public class JobConfigInfo implements ResponseBody {
 			}
 			ExecutionConfigInfo that = (ExecutionConfigInfo) o;
 			return parallelism == that.parallelism &&
-				isObjectResuse == that.isObjectResuse &&
+				isObjectReuse == that.isObjectReuse &&
 				Objects.equals(executionMode, that.executionMode) &&
 				Objects.equals(restartStrategy, that.restartStrategy) &&
 				Objects.equals(globalJobParameters, that.globalJobParameters);
@@ -247,7 +247,7 @@ public class JobConfigInfo implements ResponseBody {
 
 		@Override
 		public int hashCode() {
-			return Objects.hash(executionMode, restartStrategy, parallelism, isObjectResuse, globalJobParameters);
+			return Objects.hash(executionMode, restartStrategy, parallelism, isObjectReuse, globalJobParameters);
 		}
 
 		public static ExecutionConfigInfo from(ArchivedExecutionConfig archivedExecutionConfig) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobConfigInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobConfigInfo.java
@@ -18,12 +18,15 @@
 
 package org.apache.flink.runtime.rest.messages;
 
+import org.apache.flink.api.common.ArchivedExecutionConfig;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.runtime.rest.handler.job.JobConfigHandler;
 import org.apache.flink.runtime.rest.util.RestMapperUtils;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
@@ -205,6 +208,27 @@ public class JobConfigInfo implements ResponseBody {
 			this.globalJobParameters = Preconditions.checkNotNull(globalJobParameters);
 		}
 
+		public String getExecutionMode() {
+			return executionMode;
+		}
+
+		public String getRestartStrategy() {
+			return restartStrategy;
+		}
+
+		public int getParallelism() {
+			return parallelism;
+		}
+
+		@JsonIgnore
+		public boolean isObjectResuse() {
+			return isObjectResuse;
+		}
+
+		public Map<String, String> getGlobalJobParameters() {
+			return globalJobParameters;
+		}
+
 		@Override
 		public boolean equals(Object o) {
 			if (this == o) {
@@ -224,6 +248,15 @@ public class JobConfigInfo implements ResponseBody {
 		@Override
 		public int hashCode() {
 			return Objects.hash(executionMode, restartStrategy, parallelism, isObjectResuse, globalJobParameters);
+		}
+
+		public static ExecutionConfigInfo from(ArchivedExecutionConfig archivedExecutionConfig) {
+			return new ExecutionConfigInfo(
+				archivedExecutionConfig.getExecutionMode(),
+				archivedExecutionConfig.getRestartStrategyDescription(),
+				archivedExecutionConfig.getParallelism(),
+				archivedExecutionConfig.getObjectReuseEnabled(),
+				ConfigurationUtils.hideSensitiveValues(archivedExecutionConfig.getGlobalJobParameters()));
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobConfigHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobConfigHandlerTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job;
+
+import org.apache.flink.api.common.ArchivedExecutionConfig;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.ConfigurationUtils;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.HandlerRequestException;
+import org.apache.flink.runtime.rest.handler.legacy.ExecutionGraphCache;
+import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionConfigBuilder;
+import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobConfigHeaders;
+import org.apache.flink.runtime.rest.messages.JobConfigInfo;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.JobMessageParameters;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Test for the {@link JobConfigHandler}.
+ */
+public class JobConfigHandlerTest extends TestLogger {
+
+	@Test
+	public void handleRequest_executionConfigWithSecretValues_excludesSecretValuesFromResponse() throws HandlerRequestException {
+		final JobConfigHandler jobConfigHandler = new JobConfigHandler(
+			() -> null,
+			TestingUtils.TIMEOUT(),
+			Collections.emptyMap(),
+			JobConfigHeaders.getInstance(),
+			new ExecutionGraphCache(TestingUtils.TIMEOUT(), TestingUtils.TIMEOUT()),
+			TestingUtils.defaultExecutor());
+
+		final Map<String, String> globalJobParameters = new HashMap<>();
+		globalJobParameters.put("foobar", "barfoo");
+		globalJobParameters.put("bar.secret.foo", "my secret");
+		globalJobParameters.put("password.to.my.safe", "12345");
+
+		final ArchivedExecutionConfig archivedExecutionConfig = new ArchivedExecutionConfigBuilder()
+			.setGlobalJobParameters(globalJobParameters)
+			.build();
+		final AccessExecutionGraph archivedExecutionGraph = new ArchivedExecutionGraphBuilder()
+			.setArchivedExecutionConfig(archivedExecutionConfig)
+			.build();
+		final HandlerRequest<EmptyRequestBody, JobMessageParameters> handlerRequest = createRequest(archivedExecutionGraph.getJobID());
+
+		final JobConfigInfo jobConfigInfoResponse = jobConfigHandler.handleRequest(handlerRequest, archivedExecutionGraph);
+
+		final Map<String, String> filteredGlobalJobParameters = filterSecretValues(globalJobParameters);
+
+		assertThat(jobConfigInfoResponse.getExecutionConfigInfo().getGlobalJobParameters(), is(equalTo(filteredGlobalJobParameters)));
+	}
+
+	private Map<String, String> filterSecretValues(Map<String, String> globalJobParameters) {
+		return ConfigurationUtils.hideSensitiveValues(globalJobParameters);
+	}
+
+	private HandlerRequest<EmptyRequestBody, JobMessageParameters> createRequest(JobID jobId) throws HandlerRequestException {
+		final Map<String, String> pathParameters = new HashMap<>();
+		pathParameters.put(JobIDPathParameter.KEY, jobId.toString());
+
+		return new HandlerRequest<>(
+			EmptyRequestBody.getInstance(),
+			new JobMessageParameters(),
+			pathParameters,
+			Collections.emptyMap());
+	}
+}


### PR DESCRIPTION
Mirror of apache flink#9672
## What is the purpose of the change

This commit replaces sensitive values from the user configuration reported by the `JobConfigHandler` by replacing them with `GlobalConfiguration.HIDDEN_CONTENT`. This behaviour is similar to the `ClusterConfigHandler` where the `ClusterConfigurationInfo` hides sensitive values.

cc <at>GJL

## Verifying this change

- Added `ConfigurationUtilsTest#testHideSensitiveValues`, `JobConfigHandlerTest#handleRequest_executionConfigWithSecretValues_excludesSecretValuesFromResponse` and tried it out manually.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (no)

