### PR TITLE
Mirror of apache flink#9652

### DIFF
--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
@@ -189,6 +189,8 @@ public class LaunchableMesosWorker implements LaunchableTask {
 				"cpus=" + getCPUs() +
 				", memory=" + getMemory() +
 				", gpus=" + getGPUs() +
+				", disk=" + getDisk() +
+				", network=" + getNetworkMbps() +
 				"}";
 		}
 	}

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
@@ -445,8 +445,9 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 
 			LaunchableMesosWorker launchable = createLaunchableMesosWorker(worker.taskID());
 
-			LOG.info("Scheduling Mesos task {} with ({} MB, {} cpus).",
-				launchable.taskID().getValue(), launchable.taskRequest().getMemory(), launchable.taskRequest().getCPUs());
+			LOG.info("Scheduling Mesos task {} with ({} MB, {} cpus, {} gpus, {} disk MB, {} Mbps).",
+				launchable.taskID().getValue(), launchable.taskRequest().getMemory(), launchable.taskRequest().getCPUs(),
+				launchable.taskRequest().getScalarRequests().get("gpus"), launchable.taskRequest().getDisk(), launchable.taskRequest().getNetworkMbps());
 
 			// tell the task monitor about the new plans
 			taskMonitor.tell(new TaskMonitor.TaskGoalStateUpdated(extractGoalState(worker)), selfActor);

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
@@ -758,6 +758,12 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 			}
 
 			@Override
+			public TaskSchedulerBuilder withRejectAllExpiredOffers() {
+				builder.withRejectAllExpiredOffers();
+				return this;
+			}
+
+			@Override
 			public TaskScheduler build() {
 				return builder.build();
 			}

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/scheduler/TaskSchedulerBuilder.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/scheduler/TaskSchedulerBuilder.java
@@ -35,6 +35,11 @@ public interface TaskSchedulerBuilder {
 	TaskSchedulerBuilder withLeaseRejectAction(Action1<VirtualMachineLease> action);
 
 	/**
+	 * Set up TaskScheduler to reject all offers on expiry.
+	 */
+	TaskSchedulerBuilder withRejectAllExpiredOffers();
+
+	/**
 	 * Build a Fenzo task scheduler.
 	 */
 	TaskScheduler build();

--- a/flink-mesos/src/main/scala/org/apache/flink/mesos/scheduler/LaunchCoordinator.scala
+++ b/flink-mesos/src/main/scala/org/apache/flink/mesos/scheduler/LaunchCoordinator.scala
@@ -71,7 +71,10 @@ class LaunchCoordinator(
             + s"of disk: ${lease.diskMB()} MB, network: ${lease.networkMbps()} Mbps")
           schedulerDriver.declineOffer(lease.getOffer.getId)
         }
-      }).build
+      })
+      // avoid situations where we have lots of expired offers and we only expire a few at a time
+      .withRejectAllExpiredOffers()
+      .build
   }
 
   override def postStop(): Unit = {

--- a/flink-mesos/src/main/scala/org/apache/flink/mesos/scheduler/LaunchCoordinator.scala
+++ b/flink-mesos/src/main/scala/org/apache/flink/mesos/scheduler/LaunchCoordinator.scala
@@ -66,7 +66,9 @@ class LaunchCoordinator(
       .withLeaseRejectAction(new Action1[VirtualMachineLease]() {
         def call(lease: VirtualMachineLease) {
           LOG.info(s"Declined offer ${lease.getId} from ${lease.hostname()} "
-            + s"of ${lease.memoryMB()} MB, ${lease.cpuCores()} cpus.")
+            + s"of memory ${lease.memoryMB()} MB, ${lease.cpuCores()} cpus, "
+            + s"${lease.getScalarValue("gpus")} gpus, "
+            + s"of disk: ${lease.diskMB()} MB, network: ${lease.networkMbps()} Mbps")
           schedulerDriver.declineOffer(lease.getOffer.getId)
         }
       }).build
@@ -150,15 +152,18 @@ class LaunchCoordinator(
     case Event(offers: ResourceOffers, data: GatherData) =>
       val leases = offers.offers().asScala.map(new Offer(_))
       if(LOG.isInfoEnabled) {
-        val (cpus, gpus, mem) = leases.foldLeft((0.0,0.0,0.0)) {
-          (z,o) => (z._1 + o.cpuCores(), z._2 + o.gpus(), z._3 + o.memoryMB())
+        val (cpus, gpus, mem, disk, network) = leases.foldLeft((0.0,0.0,0.0, 0.0, 0.0)) {
+          (z,o) => (z._1 + o.cpuCores(), z._2 + o.gpus(), z._3 + o.memoryMB(),
+            z._4 + o.diskMB(), z._5 + o.networkMbps())
         }
-        LOG.info(s"Received offer(s) of $mem MB, $cpus cpus, $gpus gpus:")
+        LOG.info(s"Received offer(s) of $mem MB, $cpus cpus, $gpus gpus, " +
+          s"$disk disk MB, $network Mbps")
         for(l <- leases) {
           val reservations = l.getResources.asScala.map(_.getRole).toSet
           LOG.info(
             s"  ${l.getId} from ${l.hostname()} of ${l.memoryMB()} MB," +
             s" ${l.cpuCores()} cpus, ${l.gpus()} gpus" +
+            s" ${l.diskMB()} disk MB, ${l.networkMbps()} Mbps" +
             s" for ${reservations.mkString("[", ",", "]")}")
         }
       }
@@ -180,7 +185,8 @@ class LaunchCoordinator(
         for(vm <- optimizer.getVmCurrentStates.asScala) {
           val lease = vm.getCurrAvailableResources
           LOG.info(s"  ${vm.getHostname} has ${lease.memoryMB()} MB," +
-            s" ${lease.cpuCores()} cpus, ${lease.getScalarValue("gpus")} gpus")
+            s" ${lease.cpuCores()} cpus, ${lease.getScalarValue("gpus")} gpus" +
+            s" ${lease.diskMB()} disk MB, ${lease.networkMbps()} Mbps")
         }
       }
       log.debug(result.toString)

--- a/flink-mesos/src/test/scala/org/apache/flink/mesos/scheduler/LaunchCoordinatorTest.scala
+++ b/flink-mesos/src/test/scala/org/apache/flink/mesos/scheduler/LaunchCoordinatorTest.scala
@@ -201,11 +201,17 @@ class LaunchCoordinatorTest
     */
   def taskSchedulerBuilder(optimizer: TaskScheduler) = new TaskSchedulerBuilder {
     var leaseRejectAction: Action1[VirtualMachineLease] = null
+    var rejectAllExpiredOffers: Boolean = false
     override def withLeaseRejectAction(
         action: Action1[VirtualMachineLease]): TaskSchedulerBuilder = {
       leaseRejectAction = action
       this
     }
+    override def withRejectAllExpiredOffers(): TaskSchedulerBuilder = {
+      rejectAllExpiredOffers = true
+      this
+    }
+
     override def build(): TaskScheduler = optimizer
   }
 


### PR DESCRIPTION
Mirror of apache flink#9652
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

While digging into why our Flink jobs weren't being scheduled on our internal Mesos setup we noticed that we were hitting Mesos quota limits tied to the way we've set up the Fenzo (https://github.com/Netflix/Fenzo/) library defaults in the Flink project.

Behavior we noticed was that we got a bunch of offers from our Mesos master (50+) out of which only 1 or 2 of them were super skewed and took up a huge chunk of our disk resource quota. Thanks to this we were not sent any new / different offers (as our usage at the time + resource offers reached our Mesos disk quota). As the Flink / Fenzo Mesos scheduling code was not using the 1-2 skewed disk offers they end up expiring. The way we've set up the Fenzo scheduler is to use the default values on when to expire unused offers (120s) and maximum number of unused offer leases at a time (4). Unfortunately as we have a considerable number of outstanding expired offers (50+) we end up in a situation where we reject only 4 or so every 2 mins and we never get around to rejecting the super skewed disk ones which are stopping us from scheduling our Flink job. Thanks to this we end up in a situation where our job is waiting to be scheduled for more than an hour.

An option to work around this is to reject all expired offers at 2 minute expiry time rather than hold on to them. This will allow Mesos to send alternate offers that might be scheduled by Fenzo.

We could also make this aspect of the behavior configurable if needed. Though I'm not sure if it's worth it to add a config knob for this setting to allow users to have Fenzo hold on to expired offers for longer. 

## Brief change log

  - Include missing details on networkMbps, disk resources in the offer and Mesos task startup logs to help debugging. 
  - Update `TaskSchedulerBuilder` to setup the Fenzo `TaskScheduler` to reject all expired offers (rather than just 4). 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: No
  - The serializers: No
  - The runtime per-record code paths (performance sensitive): No
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: Yes (Mesos deployment)
  - The S3 file system connector: No

## Documentation

  - Does this pull request introduce a new feature? No
  - If yes, how is the feature documented? Not applicable

