### PR TITLE
Mirror of apache flink#9651

### DIFF
--- a/tools/travis_controller.sh
+++ b/tools/travis_controller.sh
@@ -127,25 +127,31 @@ if [ $STAGE == "$STAGE_COMPILE" ]; then
     fi
 
     if [ $EXIT_CODE == 0 ]; then
-        ./tools/releasing/collect_license_files.sh ./build-target
-        diff "NOTICE-binary" "licenses-output/NOTICE-binary"
-        EXIT_CODE=$(($EXIT_CODE+$?))
-        diff -r "licenses-binary" "licenses-output/licenses-binary"
-        EXIT_CODE=$(($EXIT_CODE+$?))
+        if [[ $PROFILE == *"scala-2.11"* ]]; then
+          ./tools/releasing/collect_license_files.sh ./build-target
+          diff "NOTICE-binary" "licenses-output/NOTICE-binary"
+          EXIT_CODE=$(($EXIT_CODE+$?))
+          diff -r "licenses-binary" "licenses-output/licenses-binary"
+          EXIT_CODE=$(($EXIT_CODE+$?))
 
-        if [ $EXIT_CODE != 0 ]; then
+          if [ $EXIT_CODE != 0 ]; then
+            echo "=============================================================================="
+            echo "ERROR: binary licensing is out-of-date."
+            echo "Please update NOTICE-binary and licenses-binary:"
+            echo "Step 1: Rebuild flink"
+            echo "Step 2: Run 'tools/releasing/collect_license_files.sh build-target'"
+            echo "  This extracts all the licensing files from the distribution, and puts them in 'licenses-output'."
+            echo "  If the build-target symlink does not exist after building flink, point the tool to 'flink-dist/target/flink-<version>-bin/flink-<version>' instead."
+            echo "Step 3: Replace existing licensing"
+            echo "  Delete NOTICE-binary and the entire licenses-binary directory."
+            echo "  Copy the contents in 'licenses-output' into the root directory of the Flink project."
+            echo "Step 4: Remember to commit the changes!"
+            echo "=============================================================================="
+          fi
+        else
           echo "=============================================================================="
-          echo "ERROR: binary licensing is out-of-date."
-          echo "Please update NOTICE-binary and licenses-binary:"
-          echo "Step 1: Rebuild flink"
-          echo "Step 2: Run 'tools/releasing/collect_license_files.sh build-target'"
-          echo "  This extracts all the licensing files from the distribution, and puts them in 'licenses-output'."
-          echo "  If the build-target symlink does not exist after building flink, point the tool to 'flink-dist/target/flink-<version>-bin/flink-<version>' instead."
-          echo "Step 3: Replace existing licensing"
-          echo "  Delete NOTICE-binary and the entire licenses-binary directory."
-          echo "  Copy the contents in 'licenses-output' into the root directory of the Flink project."
-          echo "Step 4: Remember to commit the changes!"
-          echo "=============================================================================="
+        echo "Ignoring the license file check because built uses different Scala version than 2.11. See FLINK-14008."
+        echo "=============================================================================="
         fi
     else
         echo "=============================================================================="


### PR DESCRIPTION
Mirror of apache flink#9651
## What is the purpose of the change

Ignore license file check for Scala version different than 2.11

## Verifying this change

Run the cron job on my personal Travis account: https://travis-ci.org/tillrohrmann/flink/builds/582557929

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

