### PR TITLE
Mirror of apache flink#9697

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroup.java
@@ -143,20 +143,17 @@ public class TaskMetricGroup extends ComponentMetricGroup<TaskManagerJobMetricGr
 			LOG.warn("The operator name {} exceeded the {} characters length limit and was truncated.", name, METRICS_OPERATOR_NAME_MAX_LENGTH);
 			name = name.substring(0, METRICS_OPERATOR_NAME_MAX_LENGTH);
 		}
-		OperatorMetricGroup operator = new OperatorMetricGroup(this.registry, this, operatorID, name);
+
 		// unique OperatorIDs only exist in streaming, so we have to rely on the name for batch operators
 		final String key = operatorID + name;
+		if (operators.containsKey(key)) {
+			return operators.get(key);
+		}
 
+		OperatorMetricGroup operator = new OperatorMetricGroup(this.registry, this, operatorID, name);
 		synchronized (this) {
-			OperatorMetricGroup previous = operators.put(key, operator);
-			if (previous == null) {
-				// no operator group so far
-				return operator;
-			} else {
-				// already had an operator group. restore that one.
-				operators.put(key, previous);
-				return previous;
-			}
+			operators.put(key, operator);
+			return operator;
 		}
 	}
 


### PR DESCRIPTION
Mirror of apache flink#9697
## What is the purpose of the change

There will be OperatorIOMetricGroup duplicate registration in the TaskMetricGroup's getOrAddOperator() method.


