### PR TITLE
Mirror of apache flink#9696

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-subtask.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-subtask.ts
@@ -34,4 +34,5 @@ export interface JobSubTaskInterface {
     'write-records': number;
     'write-records-complete': boolean;
   };
+  'resource-id': string;
 }

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/subtasks/job-overview-drawer-subtasks.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/subtasks/job-overview-drawer-subtasks.component.html
@@ -21,12 +21,13 @@
   [nzSize]="'small'"
   [nzLoading]="isLoading"
   [nzData]="listOfTask"
-  [nzScroll]="{x:'1430px',y:'calc( 100% - 35px )'}"
+  [nzScroll]="{x:'1440px',y:'calc( 100% - 35px )'}"
   [nzFrontPagination]="false"
   [nzShowPagination]="false">
   <thead (nzSortChange)="sort($event)" nzSingleSort>
     <tr>
-      <th nzWidth="80px" nzLeft="0px">ID</th>
+      <th nzWidth="40px" nzLeft="0px">ID</th>
+      <th nzWidth="50px" nzLeft="40px">LOG</th>
       <th nzSortKey="metrics.read-bytes" nzShowSort nzWidth="140px">Bytes Received</th>
       <th nzSortKey="metrics.read-records" nzShowSort nzWidth="150px">Records Received</th>
       <th nzSortKey="metrics.write-bytes" nzShowSort nzWidth="120px">Bytes Sent</th>
@@ -41,8 +42,14 @@
   </thead>
   <tbody>
     <tr *ngFor="let task of listOfTask; trackBy:trackTaskBy;">
-      <td nzLeft="0">
+      <td nzLeft="0" nzWidth="40px">
         {{ task.subtask }}
+      </td>
+      <td nzLeft="40px">
+        <span *ngIf="!task['resource-id'] || task['resource-id'] === '(unassigned)'; else hrefTpl">-</span>
+        <ng-template #hrefTpl>
+          <a [routerLink]="['/task-manager',task['resource-id'],'logs']" target="_blank">LOG {{ task.subtask }}</a>
+        </ng-template>
       </td>
       <td>
         <span *ngIf="task.metrics['read-bytes-complete'];else loadingTemplate">


### PR DESCRIPTION
Mirror of apache flink#9696
## What is the purpose of the change
This pull request adds log link for subtask in the page of job's vertex. Then it's easy for user seeing log.


## Brief change log
- The JobSubTaskInterface in job-subtask.ts add resource-id .
- job-overview-drawer-subtasks.component.html add log logic.



## Verifying this change
no


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not applicable)
