### PR TITLE
Mirror of apache flink#9693

### DIFF
--- a/docs/_includes/generated/task_manager_memory_configuration.html
+++ b/docs/_includes/generated/task_manager_memory_configuration.html
@@ -18,11 +18,6 @@
             <td>Memory allocation method (JVM heap or off-heap), used for managed memory of the TaskManager. For setups with larger quantities of memory, this can improve the efficiency of the operations performed on the memory.<br />When set to true, then it is advised that <span markdown="span">`taskmanager.memory.preallocate`</span> is also set to true.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.memory.preallocate</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Whether TaskManager managed memory should be pre-allocated when the TaskManager is starting. When <span markdown="span">`taskmanager.memory.off-heap`</span> is set to true, then it is advised that this configuration is also set to true. If this configuration is set to false cleaning up of the allocated off-heap memory happens only when the configured JVM parameter MaxDirectMemorySize is reached by triggering a full GC. For streaming setups, it is highly recommended to set this value to false as the core state backends currently do not use the managed memory.</td>
-        </tr>
-        <tr>
             <td><h5>taskmanager.memory.segment-size</h5></td>
             <td style="word-wrap: break-word;">"32kb"</td>
             <td>Size of memory buffers used by the network stack and the memory manager.</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -234,16 +234,15 @@ public class TaskManagerOptions {
 	/**
 	 * Whether TaskManager managed memory should be pre-allocated when the TaskManager is starting.
 	 */
+	@Deprecated
 	public static final ConfigOption<Boolean> MANAGED_MEMORY_PRE_ALLOCATE =
 			key(MANAGED_MEMORY_PRE_ALLOCATE_KEY)
 			.defaultValue(false)
-			.withDescription(Description.builder()
-				.text("Whether TaskManager managed memory should be pre-allocated when the TaskManager is starting." +
-					" When %s is set to true, then it is advised that this configuration is also" +
-					" set to true. If this configuration is set to false cleaning up of the allocated off-heap memory" +
-					" happens only when the configured JVM parameter MaxDirectMemorySize is reached by triggering a full" +
-					" GC. For streaming setups, it is highly recommended to set this value to false as the core state" +
-					" backends currently do not use the managed memory.", code(MEMORY_OFF_HEAP.key())).build());
+			.withDescription(
+				Description
+					.builder()
+					.text("The option is deprecated. It will have no affect and might be removed in future versions.", code(MEMORY_OFF_HEAP.key()))
+					.build());
 
 	/**
 	 * The config parameter for automatically defining the TaskManager's binding address,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/KeyedBudget.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/KeyedBudget.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.memory;
+
+import org.apache.flink.types.Either;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+class KeyedBudget<K> {
+	private final Map<K, Long> maxBudgetByKey;
+
+	@GuardedBy("lock")
+	private final Map<K, Long> availableBudgetByKey;
+
+	private final Object lock = new Object();
+
+	KeyedBudget(Map<K, Long> maxBudgetByKey) {
+		this.maxBudgetByKey = new HashMap<>(maxBudgetByKey);
+		this.availableBudgetByKey = new HashMap<>(maxBudgetByKey);
+	}
+
+	/**
+	 * Tries to acquire budget which equals to the number of pages times page size.
+	 *
+	 * <p>See also {@link #acquirePagedBudgetForKeys(Iterable, long, long)}
+	 */
+	Either<Map<K, Long>, Long> acquirePagedBudget(int pageNum, long pageSize) {
+		return acquirePagedBudgetForKeys(maxBudgetByKey.keySet(), pageNum, pageSize);
+	}
+
+	/**
+	 * Tries to acquire budget for a given key.
+	 *
+	 * <p>No budget is acquired if it was not possible to fully acquire the requested budget.
+	 *
+	 * @param key the key to acquire budget from
+	 * @param size the size of budget to acquire from the given key
+	 * @return the fully acquired budget for the key or max possible budget to acquir
+	 * if it was not possible to acquire the requested budget.
+	 */
+	long acquireBudgetForKey(K key, long size) {
+		Either<Map<K, Long>, Long> result = acquirePagedBudgetForKeys(Collections.singletonList(key), size, 1L);
+		return result.isLeft() ? result.left().get(key) : result.right();
+	}
+
+	/**
+	 * Tries to acquire budget which equals to the number of pages times page size.
+	 *
+	 * <p>The budget will be acquired only from the given keys. Only integer number of pages will be acquired from each key.
+	 * If the next page does not fit into the available budget of some key, it will try to be acquired from another key.
+	 * The acquisition is successful if the acquired number of pages for each key sums up to the requested number of pages.
+	 * The function does not make any preference about which keys from the given keys to acquire from.
+	 *
+	 * @param keys the keys to acquire budget from
+	 * @param pageNum the total number of pages to acquire from the given keys
+	 * @param pageSize the size of budget to acquire per page
+	 * @return the acquired number of pages for each key if the acquisition is successful (either left) or
+	 * the total number of pages which were available for the given keys (either right).
+	 */
+	Either<Map<K, Long>, Long> acquirePagedBudgetForKeys(Iterable<K> keys, long pageNum, long pageSize) {
+		synchronized (lock) {
+			long totalPossiblePages = 0L;
+			Map<K, Long> pagesToReserveByKey = new HashMap<>();
+			for (K key : keys) {
+				long currentKeyBudget = availableBudgetByKey.getOrDefault(key, 0L);
+				long currentKeyPages = currentKeyBudget / pageSize;
+				if (totalPossiblePages + currentKeyPages >= pageNum) {
+					pagesToReserveByKey.put(key, pageNum - totalPossiblePages);
+					totalPossiblePages = pageNum;
+				} else if (currentKeyPages > 0L) {
+					pagesToReserveByKey.put(key, currentKeyPages);
+					totalPossiblePages += currentKeyPages;
+				}
+			}
+			boolean possibleToAcquire = totalPossiblePages == pageNum;
+			if (possibleToAcquire) {
+				for (Entry<K, Long> pagesToReserveForKey : pagesToReserveByKey.entrySet()) {
+					//noinspection ConstantConditions
+					availableBudgetByKey.compute(
+						pagesToReserveForKey.getKey(),
+						(k, v) -> v - (pagesToReserveForKey.getValue() * pageSize));
+				}
+			}
+			return possibleToAcquire ? Either.Left(pagesToReserveByKey) : Either.Right(totalPossiblePages);
+		}
+	}
+
+	void releaseBudgetForKey(K key, long size) {
+		releaseBudgetForKeys(Collections.singletonMap(key, size));
+	}
+
+	void releaseBudgetForKeys(Map<K, Long> sizeByKey) {
+		synchronized (lock) {
+			for (Entry<K, Long> toReleaseForKey : sizeByKey.entrySet()) {
+				long toRelease = toReleaseForKey.getValue();
+				if (toRelease == 0L) {
+					continue;
+				}
+				K keyToReleaseFor = toReleaseForKey.getKey();
+				long maxBudgetForKey = maxBudgetByKey.get(keyToReleaseFor);
+				availableBudgetByKey.compute(keyToReleaseFor, (k, currentBudget) -> {
+					if (currentBudget == null) {
+						throw new IllegalArgumentException("The budget key is not supported: " + keyToReleaseFor);
+					} else if (currentBudget + toRelease > maxBudgetForKey) {
+						throw new IllegalStateException(
+							String.format(
+								"The budget to release %d exceeds the limit %d for key %s",
+								toRelease,
+								maxBudgetForKey,
+								keyToReleaseFor));
+					} else {
+						return currentBudget + toRelease;
+					}
+				});
+			}
+		}
+	}
+
+	void releaseAll() {
+		synchronized (lock) {
+			availableBudgetByKey.putAll(maxBudgetByKey);
+		}
+	}
+
+	long maxTotalBudget() {
+		return maxBudgetByKey.values().stream().mapToLong(b -> b).sum();
+	}
+
+	long totalAvailableBudget() {
+		return availableBudgetForKeys(maxBudgetByKey.keySet());
+	}
+
+	long availableBudgetForKeys(Iterable<K> keys) {
+		synchronized (lock) {
+			long totalSize = 0L;
+			for (K key : keys) {
+				totalSize += availableBudgetForKey(key);
+			}
+			return totalSize;
+		}
+	}
+
+	long availableBudgetForKey(K key) {
+		synchronized (lock) {
+			return availableBudgetByKey.getOrDefault(key, 0L);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/KeyedBudget.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/KeyedBudget.java
@@ -147,6 +147,10 @@ class KeyedBudget<K> {
 		return maxBudgetByKey.values().stream().mapToLong(b -> b).sum();
 	}
 
+	long maxTotalBudgetForKey(K key) {
+		return maxBudgetByKey.get(key);
+	}
+
 	long totalAvailableBudget() {
 		return availableBudgetForKeys(maxBudgetByKey.keySet());
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -19,10 +19,8 @@
 package org.apache.flink.runtime.memory;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.memory.HybridMemorySegment;
 import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.util.MathUtils;
 import org.apache.flink.util.Preconditions;
@@ -30,8 +28,6 @@ import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.ByteBuffer;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.ConcurrentModificationException;
@@ -42,6 +38,9 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
+import static org.apache.flink.core.memory.MemorySegmentFactory.allocateUnpooledOffHeapMemory;
+import static org.apache.flink.core.memory.MemorySegmentFactory.allocateUnpooledSegment;
+
 /**
  * The memory manager governs the memory that Flink uses for sorting, hashing, and caching. Memory
  * is represented in segments of equal size. Operators allocate the memory by requesting a number
@@ -49,14 +48,8 @@ import java.util.Set;
  *
  * <p>The memory may be represented as on-heap byte arrays or as off-heap memory regions
  * (both via {@link HybridMemorySegment}). Which kind of memory the MemoryManager serves can
- * be passed as an argument to the initialization.
- *
- * <p>The memory manager can either pre-allocate all memory, or allocate the memory on demand. In the
- * former version, memory will be occupied and reserved from start on, which means that no OutOfMemoryError
- * can come while requesting memory. Released memory will also return to the MemoryManager's pool.
- * On-demand allocation means that the memory manager only keeps track how many memory segments are
- * currently allocated (bookkeeping only). Releasing a memory segment will not add it back to the pool,
- * but make it re-claimable by the garbage collector.
+ * be passed as an argument to the initialization. Releasing a memory segment will make it re-claimable
+ * by the garbage collector.
  */
 public class MemoryManager {
 
@@ -71,9 +64,6 @@ public class MemoryManager {
 
 	/** The lock used on the shared structures. */
 	private final Object lock = new Object();
-
-	/** The memory pool from which we draw memory segments. Specific to on-heap or off-heap memory */
-	private final MemoryPool memoryPool;
 
 	/** Memory segments allocated per memory owner. */
 	private final HashMap<Object, Set<MemorySegment>> allocatedSegments;
@@ -90,15 +80,14 @@ public class MemoryManager {
 	/** Number of slots of the task manager. */
 	private final int numberOfSlots;
 
-	/** Flag marking whether the memory manager immediately allocates the memory. */
-	private final boolean isPreAllocated;
+	/** Type of the managed memory. */
+	private final MemoryType memoryType;
 
 	/** The number of memory pages that have not been allocated and are available for lazy allocation. */
 	private int numNonAllocatedPages;
 
 	/** Flag whether the close() has already been invoked. */
 	private boolean isShutDown;
-
 
 	/**
 	 * Creates a memory manager with the given capacity and given page size.
@@ -107,37 +96,32 @@ public class MemoryManager {
 	 * @param numberOfSlots The number of slots of the task manager.
 	 * @param pageSize The size of the pages handed out by the memory manager.
 	 * @param memoryType The type of memory (heap / off-heap) that the memory manager should allocate.
-	 * @param preAllocateMemory True, if the memory manager should immediately allocate all memory, false
-	 *                          if it should allocate and release the memory as needed.
 	 */
 	public MemoryManager(
 			long memorySize,
 			int numberOfSlots,
 			int pageSize,
-			MemoryType memoryType,
-			boolean preAllocateMemory) {
-		sanityCheck(memorySize, pageSize, memoryType, preAllocateMemory);
+			MemoryType memoryType) {
+		sanityCheck(memorySize, pageSize, memoryType);
 
 		this.allocatedSegments = new HashMap<>();
 		this.memorySize = memorySize;
 		this.numberOfSlots = numberOfSlots;
 		this.pageSize = pageSize;
-		this.isPreAllocated = preAllocateMemory;
 		this.totalNumPages = calculateTotalNumberOfPages(memorySize, pageSize);
-		this.numNonAllocatedPages = preAllocateMemory ? 0 : this.totalNumPages;
-		this.memoryPool = createMemoryPool(preAllocateMemory ? this.totalNumPages : 0, pageSize, memoryType);
+		this.numNonAllocatedPages = this.totalNumPages;
+		this.memoryType = memoryType;
 
 		LOG.debug("Initialized MemoryManager with total memory size {}, number of slots {}, page size {}, " +
-				"memory type {}, pre allocate memory {} and number of non allocated pages {}.",
+				"memory type {} and number of non allocated pages {}.",
 			memorySize,
 			numberOfSlots,
 			pageSize,
 			memoryType,
-			preAllocateMemory,
 			numNonAllocatedPages);
 	}
 
-	private static void sanityCheck(long memorySize, int pageSize, MemoryType memoryType, boolean preAllocateMemory) {
+	private static void sanityCheck(long memorySize, int pageSize, MemoryType memoryType) {
 		Preconditions.checkNotNull(memoryType);
 		Preconditions.checkArgument(memorySize > 0L, "Size of total memory must be positive.");
 		Preconditions.checkArgument(
@@ -146,15 +130,6 @@ public class MemoryManager {
 		Preconditions.checkArgument(
 			MathUtils.isPowerOf2(pageSize),
 			"The given page size is not a power of two.");
-		warnAboutPreallocationForOffHeap(memoryType, preAllocateMemory);
-	}
-
-	private static void warnAboutPreallocationForOffHeap(MemoryType memoryType, boolean preAllocateMemory) {
-		if (memoryType == MemoryType.OFF_HEAP && !preAllocateMemory) {
-			LOG.warn("It is advisable to set '{}' to true when the memory type '{}' is set to true.",
-				TaskManagerOptions.MANAGED_MEMORY_PRE_ALLOCATE.key(),
-				TaskManagerOptions.MEMORY_OFF_HEAP.key());
-		}
 	}
 
 	private static int calculateTotalNumberOfPages(long memorySize, int pageSize) {
@@ -168,17 +143,6 @@ public class MemoryManager {
 		Preconditions.checkArgument(totalNumPages >= 1, "The given amount of memory amounted to less than one page.");
 
 		return totalNumPages;
-	}
-
-	private static MemoryPool createMemoryPool(int segmentsToAllocate, int pageSize, MemoryType memoryType) {
-		switch (memoryType) {
-			case HEAP:
-				return new HybridHeapMemoryPool(segmentsToAllocate, pageSize);
-			case OFF_HEAP:
-				return new HybridOffHeapMemoryPool(segmentsToAllocate, pageSize);
-			default:
-				throw new IllegalArgumentException("unrecognized memory type: " + memoryType);
-		}
 	}
 
 	// ------------------------------------------------------------------------
@@ -205,8 +169,6 @@ public class MemoryManager {
 						seg.free();
 					}
 				}
-
-				memoryPool.clear();
 			}
 		}
 		// -------------------- END CRITICAL SECTION -------------------
@@ -230,9 +192,7 @@ public class MemoryManager {
 	@VisibleForTesting
 	public boolean verifyEmpty() {
 		synchronized (lock) {
-			return isPreAllocated ?
-					memoryPool.getNumberOfAvailableMemorySegments() == totalNumPages :
-					numNonAllocatedPages == totalNumPages;
+			return numNonAllocatedPages == totalNumPages;
 		}
 	}
 
@@ -241,9 +201,7 @@ public class MemoryManager {
 	// ------------------------------------------------------------------------
 
 	/**
-	 * Allocates a set of memory segments from this memory manager. If the memory manager pre-allocated the
-	 * segments, they will be taken from the pool of memory segments. Otherwise, they will be allocated
-	 * as part of this call.
+	 * Allocates a set of memory segments from this memory manager.
 	 *
 	 * @param owner The owner to associate with the memory segment, for the fallback release.
 	 * @param numPages The number of pages to allocate.
@@ -258,9 +216,7 @@ public class MemoryManager {
 	}
 
 	/**
-	 * Allocates a set of memory segments from this memory manager. If the memory manager pre-allocated the
-	 * segments, they will be taken from the pool of memory segments. Otherwise, they will be allocated
-	 * as part of this call.
+	 * Allocates a set of memory segments from this memory manager.
 	 *
 	 * @param owner The owner to associate with the memory segment, for the fallback release.
 	 * @param target The list into which to put the allocated memory pages.
@@ -288,10 +244,9 @@ public class MemoryManager {
 
 			// in the case of pre-allocated memory, the 'numNonAllocatedPages' is zero, in the
 			// lazy case, the 'freeSegments.size()' is zero.
-			if (numPages > (memoryPool.getNumberOfAvailableMemorySegments() + numNonAllocatedPages)) {
-				throw new MemoryAllocationException("Could not allocate " + numPages + " pages. Only " +
-						(memoryPool.getNumberOfAvailableMemorySegments() + numNonAllocatedPages)
-						+ " pages are remaining.");
+			if (numPages > numNonAllocatedPages) {
+				throw new MemoryAllocationException(
+					String.format("Could not allocate %d pages. Only %d pages are remaining.", numPages, numNonAllocatedPages));
 			}
 
 			Set<MemorySegment> segmentsForOwner = allocatedSegments.get(owner);
@@ -300,31 +255,21 @@ public class MemoryManager {
 				allocatedSegments.put(owner, segmentsForOwner);
 			}
 
-			if (isPreAllocated) {
-				for (int i = numPages; i > 0; i--) {
-					MemorySegment segment = memoryPool.requestSegmentFromPool(owner);
-					target.add(segment);
-					segmentsForOwner.add(segment);
-				}
+			for (int i = numPages; i > 0; i--) {
+				MemorySegment segment = allocateManagedSegment(memoryType, owner);
+				target.add(segment);
+				segmentsForOwner.add(segment);
 			}
-			else {
-				for (int i = numPages; i > 0; i--) {
-					MemorySegment segment = memoryPool.allocateNewSegment(owner);
-					target.add(segment);
-					segmentsForOwner.add(segment);
-				}
-				numNonAllocatedPages -= numPages;
-			}
+			numNonAllocatedPages -= numPages;
 		}
 		// -------------------- END CRITICAL SECTION -------------------
 	}
 
 	/**
-	 * Tries to release the memory for the specified segment. If the segment has already been released or
-	 * is null, the request is simply ignored.
+	 * Tries to release the memory for the specified segment.
 	 *
-	 * <p>If the memory manager manages pre-allocated memory, the memory segment goes back to the memory pool.
-	 * Otherwise, the segment is only freed and made eligible for reclamation by the GC.
+	 * <p>If the segment has already been released or is null, the request is simply ignored.
+	 * The segment is only freed and made eligible for reclamation by the GC.
 	 *
 	 * @param segment The segment to be released.
 	 * @throws IllegalArgumentException Thrown, if the given segment is of an incompatible type.
@@ -358,14 +303,8 @@ public class MemoryManager {
 					}
 				}
 
-				if (isPreAllocated) {
-					// release the memory in any case
-					memoryPool.returnSegmentToPool(segment);
-				}
-				else {
-					segment.free();
-					numNonAllocatedPages++;
-				}
+				segment.free();
+				numNonAllocatedPages++;
 			}
 			catch (Throwable t) {
 				throw new RuntimeException("Error removing book-keeping reference to allocated memory segment.", t);
@@ -377,8 +316,7 @@ public class MemoryManager {
 	/**
 	 * Tries to release many memory segments together.
 	 *
-	 * <p>If the memory manager manages pre-allocated memory, the memory segment goes back to the memory pool.
-	 * Otherwise, the segment is only freed and made eligible for reclamation by the GC.
+	 * <p>The segment is only freed and made eligible for reclamation by the GC.
 	 *
 	 * @param segments The segments to be released.
 	 * @throws NullPointerException Thrown, if the given collection is null.
@@ -431,13 +369,8 @@ public class MemoryManager {
 								}
 							}
 
-							if (isPreAllocated) {
-								memoryPool.returnSegmentToPool(seg);
-							}
-							else {
-								seg.free();
-								numNonAllocatedPages++;
-							}
+							seg.free();
+							numNonAllocatedPages++;
 						}
 						catch (Throwable t) {
 							throw new RuntimeException(
@@ -484,17 +417,10 @@ public class MemoryManager {
 			}
 
 			// free each segment
-			if (isPreAllocated) {
-				for (MemorySegment seg : segments) {
-					memoryPool.returnSegmentToPool(seg);
-				}
+			for (MemorySegment seg : segments) {
+				seg.free();
 			}
-			else {
-				for (MemorySegment seg : segments) {
-					seg.free();
-				}
-				numNonAllocatedPages += segments.size();
-			}
+			numNonAllocatedPages += segments.size();
 
 			segments.clear();
 		}
@@ -540,122 +466,14 @@ public class MemoryManager {
 		return (int) (totalNumPages * fraction / numberOfSlots);
 	}
 
-
-	// ------------------------------------------------------------------------
-	//  Memory Pools
-	// ------------------------------------------------------------------------
-
-	abstract static class MemoryPool {
-
-		abstract int getNumberOfAvailableMemorySegments();
-
-		abstract MemorySegment allocateNewSegment(Object owner);
-
-		abstract MemorySegment requestSegmentFromPool(Object owner);
-
-		abstract void returnSegmentToPool(MemorySegment segment);
-
-		abstract void clear();
-	}
-
-	static final class HybridHeapMemoryPool extends MemoryPool {
-
-		/** The collection of available memory segments. */
-		private final ArrayDeque<byte[]> availableMemory;
-
-		private final int segmentSize;
-
-		HybridHeapMemoryPool(int numInitialSegments, int segmentSize) {
-			this.availableMemory = new ArrayDeque<>(numInitialSegments);
-			this.segmentSize = segmentSize;
-
-			for (int i = 0; i < numInitialSegments; i++) {
-				this.availableMemory.add(new byte[segmentSize]);
-			}
-		}
-
-		@Override
-		MemorySegment allocateNewSegment(Object owner) {
-			return MemorySegmentFactory.allocateUnpooledSegment(segmentSize, owner);
-		}
-
-		@Override
-		MemorySegment requestSegmentFromPool(Object owner) {
-			byte[] buf = availableMemory.remove();
-			return  MemorySegmentFactory.wrapPooledHeapMemory(buf, owner);
-		}
-
-		@Override
-		void returnSegmentToPool(MemorySegment segment) {
-			if (segment.getClass() == HybridMemorySegment.class) {
-				HybridMemorySegment heapSegment = (HybridMemorySegment) segment;
-				availableMemory.add(heapSegment.getArray());
-				heapSegment.free();
-			}
-			else {
-				throw new IllegalArgumentException("Memory segment is not a " + HybridMemorySegment.class.getSimpleName());
-			}
-		}
-
-		@Override
-		protected int getNumberOfAvailableMemorySegments() {
-			return availableMemory.size();
-		}
-
-		@Override
-		void clear() {
-			availableMemory.clear();
-		}
-	}
-
-	static final class HybridOffHeapMemoryPool extends MemoryPool {
-
-		/** The collection of available memory segments. */
-		private final ArrayDeque<ByteBuffer> availableMemory;
-
-		private final int segmentSize;
-
-		HybridOffHeapMemoryPool(int numInitialSegments, int segmentSize) {
-			this.availableMemory = new ArrayDeque<>(numInitialSegments);
-			this.segmentSize = segmentSize;
-
-			for (int i = 0; i < numInitialSegments; i++) {
-				this.availableMemory.add(ByteBuffer.allocateDirect(segmentSize));
-			}
-		}
-
-		@Override
-		MemorySegment allocateNewSegment(Object owner) {
-			return MemorySegmentFactory.allocateUnpooledOffHeapMemory(segmentSize, owner);
-		}
-
-		@Override
-		MemorySegment requestSegmentFromPool(Object owner) {
-			ByteBuffer buf = availableMemory.remove();
-			return MemorySegmentFactory.wrapPooledOffHeapMemory(buf, owner);
-		}
-
-		@Override
-		void returnSegmentToPool(MemorySegment segment) {
-			if (segment.getClass() == HybridMemorySegment.class) {
-				HybridMemorySegment hybridSegment = (HybridMemorySegment) segment;
-				ByteBuffer buf = hybridSegment.getOffHeapBuffer();
-				availableMemory.add(buf);
-				hybridSegment.free();
-			}
-			else {
-				throw new IllegalArgumentException("Memory segment is not a " + HybridMemorySegment.class.getSimpleName());
-			}
-		}
-
-		@Override
-		protected int getNumberOfAvailableMemorySegments() {
-			return availableMemory.size();
-		}
-
-		@Override
-		void clear() {
-			availableMemory.clear();
+	private MemorySegment allocateManagedSegment(MemoryType memoryType, Object owner) {
+		switch (memoryType) {
+			case HEAP:
+				return allocateUnpooledSegment(pageSize, owner);
+			case OFF_HEAP:
+				return allocateUnpooledOffHeapMemory(pageSize, owner);
+			default:
+				throw new IllegalArgumentException("unrecognized memory type: " + memoryType);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -76,12 +76,6 @@ public class MemoryManager {
 	/** Memory segments allocated per memory owner. */
 	private final HashMap<Object, Set<MemorySegment>> allocatedSegments;
 
-	/** The type of memory governed by this memory manager. */
-	private final MemoryType memoryType;
-
-	/** Mask used to round down sizes to multiples of the page size. */
-	private final long roundingMask;
-
 	/** The size of the memory segments. */
 	private final int pageSize;
 
@@ -130,13 +124,11 @@ public class MemoryManager {
 			throw new IllegalArgumentException("The given page size is not a power of two.");
 		}
 
-		this.memoryType = memoryType;
 		this.memorySize = memorySize;
 		this.numberOfSlots = numberOfSlots;
 
 		// assign page size and bit utilities
 		this.pageSize = pageSize;
-		this.roundingMask = ~((long) (pageSize - 1));
 
 		final long numPagesLong = memorySize / pageSize;
 		if (numPagesLong > Integer.MAX_VALUE) {
@@ -504,24 +496,6 @@ public class MemoryManager {
 	// ------------------------------------------------------------------------
 
 	/**
-	 * Gets the type of memory (heap / off-heap) managed by this memory manager.
-	 *
-	 * @return The type of memory managed by this memory manager.
-	 */
-	public MemoryType getMemoryType() {
-		return memoryType;
-	}
-
-	/**
-	 * Checks whether this memory manager pre-allocates the memory.
-	 *
-	 * @return True if the memory manager pre-allocates the memory, false if it allocates as needed.
-	 */
-	public boolean isPreAllocated() {
-		return isPreAllocated;
-	}
-
-	/**
 	 * Gets the size of the pages handled by the memory manager.
 	 *
 	 * @return The size of the pages handled by the memory manager.
@@ -540,15 +514,6 @@ public class MemoryManager {
 	}
 
 	/**
-	 * Gets the total number of memory pages managed by this memory manager.
-	 *
-	 * @return The total number of memory pages managed by this memory manager.
-	 */
-	public int getTotalNumPages() {
-		return totalNumPages;
-	}
-
-	/**
 	 * Computes to how many pages the given number of bytes corresponds. If the given number of bytes is not an
 	 * exact multiple of a page size, the result is rounded down, such that a portion of the memory (smaller
 	 * than the page size) is not included.
@@ -562,25 +527,6 @@ public class MemoryManager {
 		}
 
 		return (int) (totalNumPages * fraction / numberOfSlots);
-	}
-
-	/**
-	 * Computes the memory size of the fraction per slot.
-	 *
-	 * @param fraction The fraction of the memory of the task slot.
-	 * @return The number of pages corresponding to the memory fraction.
-	 */
-	public long computeMemorySize(double fraction) {
-		return pageSize * (long) computeNumberOfPages(fraction);
-	}
-
-	/**
-	 * Rounds the given value down to a multiple of the memory manager's page size.
-	 *
-	 * @return The given value, rounded down to a multiple of the page size.
-	 */
-	public long roundDownToPageSizeMultiple(long numBytes) {
-		return numBytes & roundingMask;
 	}
 
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -242,9 +242,9 @@ public class MemoryManager {
 	 *                                   of memory pages any more.
 	 */
 	public List<MemorySegment> allocatePages(Object owner, int numPages) throws MemoryAllocationException {
-		final ArrayList<MemorySegment> segs = new ArrayList<MemorySegment>(numPages);
-		allocatePages(owner, segs, numPages);
-		return segs;
+		List<MemorySegment> segments = new ArrayList<>(numPages);
+		allocatePages(owner, segments, numPages);
+		return segments;
 	}
 
 	/**
@@ -526,6 +526,7 @@ public class MemoryManager {
 			throw new IllegalArgumentException("The fraction of memory to allocate must within (0, 1].");
 		}
 
+		//noinspection NumericCastThatLosesPrecision
 		return (int) (totalNumPages * fraction / numberOfSlots);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -33,13 +33,13 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -54,7 +54,7 @@ import static org.apache.flink.core.memory.MemorySegmentFactory.allocateUnpooled
  * of memory segments.
  *
  * <p>The memory may be represented as on-heap byte arrays or as off-heap memory regions
- * (both via {@link HybridMemorySegment}). Which kind of memory the MemoryManager serves can
+ * (both via {@link HybridMemorySegment}). Which kinds of memory the MemoryManager serves and their sizes can
  * be passed as an argument to the initialization. Releasing a memory segment will make it re-claimable
  * by the garbage collector.
  */
@@ -78,14 +78,8 @@ public class MemoryManager {
 	/** The initial total size, for verification. */
 	private final int totalNumPages;
 
-	/** The total size of the memory managed by this memory manager. */
-	private final long memorySize;
-
 	/** Number of slots of the task manager. */
 	private final int numberOfSlots;
-
-	/** Type of the managed memory. */
-	private final MemoryType memoryType;
 
 	private final KeyedBudget<MemoryType> budgetByType;
 
@@ -93,34 +87,32 @@ public class MemoryManager {
 	private volatile boolean isShutDown;
 
 	/**
-	 * Creates a memory manager with the given capacity and given page size.
+	 * Creates a memory manager with the given memory types, capacity and given page size.
 	 *
-	 * @param memorySize The total size of the memory to be managed by this memory manager.
+	 * @param memorySizeByType The total size of the memory to be managed by this memory manager for each type (heap / off-heap).
 	 * @param numberOfSlots The number of slots of the task manager.
 	 * @param pageSize The size of the pages handed out by the memory manager.
-	 * @param memoryType The type of memory (heap / off-heap) that the memory manager should allocate.
 	 */
 	public MemoryManager(
-			long memorySize,
+			Map<MemoryType, Long> memorySizeByType,
 			int numberOfSlots,
-			int pageSize,
-			MemoryType memoryType) {
-		sanityCheck(memorySize, pageSize, memoryType);
+			int pageSize) {
+		for (Entry<MemoryType, Long> sizeForType : memorySizeByType.entrySet()) {
+			sanityCheck(sizeForType.getValue(), pageSize, sizeForType.getKey());
+		}
 
 		this.allocatedSegments = new ConcurrentHashMap<>();
-		this.memorySize = memorySize;
 		this.numberOfSlots = numberOfSlots;
 		this.pageSize = pageSize;
-		this.totalNumPages = calculateTotalNumberOfPages(memorySize, pageSize);
-		this.memoryType = memoryType;
-		this.budgetByType = new KeyedBudget<>(Collections.singletonMap(memoryType, memorySize));
+		this.totalNumPages = calculateTotalNumberOfPages(memorySizeByType, pageSize);
+		this.budgetByType = new KeyedBudget<>(memorySizeByType);
 
 		LOG.debug(
-			"Initialized MemoryManager with total memory size {}, number of slots {}, page size {} and memory type {}.",
-			memorySize,
+			"Initialized MemoryManager with total memory size {} ({}), number of slots {}, page size {}.",
+			budgetByType.totalAvailableBudget(),
+			memorySizeByType,
 			numberOfSlots,
-			pageSize,
-			memoryType);
+			pageSize);
 	}
 
 	private static void sanityCheck(long memorySize, int pageSize, MemoryType memoryType) {
@@ -134,11 +126,16 @@ public class MemoryManager {
 			"The given page size is not a power of two.");
 	}
 
-	private static int calculateTotalNumberOfPages(long memorySize, int pageSize) {
-		long numPagesLong = memorySize / pageSize;
+	private static int calculateTotalNumberOfPages(Map<MemoryType, Long> memorySizeByType, int pageSize) {
+		long numPagesLong = 0L;
+		for (long sizeForType : memorySizeByType.values()) {
+			numPagesLong += sizeForType / pageSize;
+		}
 		Preconditions.checkArgument(
 			numPagesLong <= Integer.MAX_VALUE,
-			"The given number of memory bytes (%s) corresponds to more than MAX_INT pages.", memorySize);
+			"The given number of memory bytes (%d: %s) corresponds to more than MAX_INT pages.",
+			numPagesLong,
+			memorySizeByType);
 
 		@SuppressWarnings("NumericCastThatLosesPrecision")
 		int totalNumPages = (int) numPagesLong;
@@ -191,7 +188,7 @@ public class MemoryManager {
 	 */
 	@VisibleForTesting
 	public boolean verifyEmpty() {
-		return budgetByType.totalAvailableBudget() == memorySize;
+		return budgetByType.totalAvailableBudget() == budgetByType.maxTotalBudget();
 	}
 
 	// ------------------------------------------------------------------------
@@ -200,6 +197,9 @@ public class MemoryManager {
 
 	/**
 	 * Allocates a set of memory segments from this memory manager.
+	 *
+	 * <p>The returned segments can have any memory type. The total allocated memory for each type will not exceed its
+	 * size limit, announced in the constructor.
 	 *
 	 * @param owner The owner to associate with the memory segment, for the fallback release.
 	 * @param numPages The number of pages to allocate.
@@ -215,6 +215,9 @@ public class MemoryManager {
 
 	/**
 	 * Allocates a set of memory segments from this memory manager.
+	 *
+	 * <p>The returned segments can have any memory type. The total allocated memory for each type will not exceed its
+	 * size limit, announced in the constructor.
 	 *
 	 * @param owner The owner to associate with the memory segment, for the fallback release.
 	 * @param target The list into which to put the allocated memory pages.
@@ -246,10 +249,12 @@ public class MemoryManager {
 		allocatedSegments.compute(owner, (o, currentSegmentsForOwner) -> {
 			Set<MemorySegment> segmentsForOwner = currentSegmentsForOwner == null ?
 				new HashSet<>(numPages) : currentSegmentsForOwner;
-			for (int i = numPages; i > 0; i--) {
-				MemorySegment segment = allocateManagedSegment(memoryType, owner);
-				target.add(segment);
-				segmentsForOwner.add(segment);
+			for (MemoryType memoryType : acquiredBudget.left().keySet()) {
+				for (long i = acquiredBudget.left().get(memoryType); i > 0; i--) {
+					MemorySegment segment = allocateManagedSegment(memoryType, owner);
+					target.add(segment);
+					segmentsForOwner.add(segment);
+				}
 			}
 			return segmentsForOwner;
 		});
@@ -261,7 +266,8 @@ public class MemoryManager {
 	 * Tries to release the memory for the specified segment.
 	 *
 	 * <p>If the segment has already been released or is null, the request is simply ignored.
-	 * The segment is only freed and made eligible for reclamation by the GC.
+	 * The segment is only freed and made eligible for reclamation by the GC. The segment will be returned to
+	 * the memory pool of its type, increasing its available limit for the later allocations.
 	 *
 	 * @param segment The segment to be released.
 	 * @throws IllegalArgumentException Thrown, if the given segment is of an incompatible type.
@@ -292,7 +298,8 @@ public class MemoryManager {
 	/**
 	 * Tries to release many memory segments together.
 	 *
-	 * <p>The segment is only freed and made eligible for reclamation by the GC.
+	 * <p>The segment is only freed and made eligible for reclamation by the GC. Each segment will be returned to
+	 * the memory pool of its type, increasing its available limit for the later allocations.
 	 *
 	 * @param segments The segments to be released.
 	 * @throws NullPointerException Thrown, if the given collection is null.
@@ -427,7 +434,17 @@ public class MemoryManager {
 	 * @return The total size of memory.
 	 */
 	public long getMemorySize() {
-		return memorySize;
+		return budgetByType.maxTotalBudget();
+	}
+
+	/**
+	 * Returns the total size of the certain type of memory handled by this memory manager.
+	 *
+	 * @param memoryType The type of memory.
+	 * @return The total size of memory.
+	 */
+	public long getMemorySizeByType(MemoryType memoryType) {
+		return budgetByType.maxTotalBudgetForKey(memoryType);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -105,17 +105,6 @@ public class MemoryManager {
 
 
 	/**
-	 * Creates a memory manager with the given capacity, using the default page size.
-	 *
-	 * @param memorySize The total size of the memory to be managed by this memory manager.
-	 * @param numberOfSlots The number of slots of the task manager.
-	 */
-	@VisibleForTesting
-	public MemoryManager(long memorySize, int numberOfSlots) {
-		this(memorySize, numberOfSlots, DEFAULT_PAGE_SIZE, MemoryType.HEAP, true);
-	}
-
-	/**
 	 * Creates a memory manager with the given capacity and given page size.
 	 *
 	 * @param memorySize The total size of the memory to be managed by this memory manager.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -22,21 +22,28 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.memory.HybridMemorySegment;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemoryType;
+import org.apache.flink.types.Either;
 import org.apache.flink.util.MathUtils;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.ConcurrentModificationException;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.flink.core.memory.MemorySegmentFactory.allocateUnpooledOffHeapMemory;
 import static org.apache.flink.core.memory.MemorySegmentFactory.allocateUnpooledSegment;
@@ -62,11 +69,8 @@ public class MemoryManager {
 
 	// ------------------------------------------------------------------------
 
-	/** The lock used on the shared structures. */
-	private final Object lock = new Object();
-
 	/** Memory segments allocated per memory owner. */
-	private final HashMap<Object, Set<MemorySegment>> allocatedSegments;
+	private final Map<Object, Set<MemorySegment>> allocatedSegments;
 
 	/** The size of the memory segments. */
 	private final int pageSize;
@@ -83,11 +87,10 @@ public class MemoryManager {
 	/** Type of the managed memory. */
 	private final MemoryType memoryType;
 
-	/** The number of memory pages that have not been allocated and are available for lazy allocation. */
-	private int numNonAllocatedPages;
+	private final KeyedBudget<MemoryType> budgetByType;
 
 	/** Flag whether the close() has already been invoked. */
-	private boolean isShutDown;
+	private volatile boolean isShutDown;
 
 	/**
 	 * Creates a memory manager with the given capacity and given page size.
@@ -104,21 +107,20 @@ public class MemoryManager {
 			MemoryType memoryType) {
 		sanityCheck(memorySize, pageSize, memoryType);
 
-		this.allocatedSegments = new HashMap<>();
+		this.allocatedSegments = new ConcurrentHashMap<>();
 		this.memorySize = memorySize;
 		this.numberOfSlots = numberOfSlots;
 		this.pageSize = pageSize;
 		this.totalNumPages = calculateTotalNumberOfPages(memorySize, pageSize);
-		this.numNonAllocatedPages = this.totalNumPages;
 		this.memoryType = memoryType;
+		this.budgetByType = new KeyedBudget<>(Collections.singletonMap(memoryType, memorySize));
 
-		LOG.debug("Initialized MemoryManager with total memory size {}, number of slots {}, page size {}, " +
-				"memory type {} and number of non allocated pages {}.",
+		LOG.debug(
+			"Initialized MemoryManager with total memory size {}, number of slots {}, page size {} and memory type {}.",
 			memorySize,
 			numberOfSlots,
 			pageSize,
-			memoryType,
-			numNonAllocatedPages);
+			memoryType);
 	}
 
 	private static void sanityCheck(long memorySize, int pageSize, MemoryType memoryType) {
@@ -156,22 +158,20 @@ public class MemoryManager {
 	 * code that allocated them from the memory manager.
 	 */
 	public void shutdown() {
-		// -------------------- BEGIN CRITICAL SECTION -------------------
-		synchronized (lock) {
-			if (!isShutDown) {
-				// mark as shutdown and release memory
-				isShutDown = true;
-				numNonAllocatedPages = 0;
+		if (!isShutDown) {
+			// mark as shutdown and release memory
+			isShutDown = true;
+			budgetByType.releaseAll();
 
-				// go over all allocated segments and release them
-				for (Set<MemorySegment> segments : allocatedSegments.values()) {
-					for (MemorySegment seg : segments) {
-						seg.free();
-					}
+			// go over all allocated segments and release them
+			for (Set<MemorySegment> segments : allocatedSegments.values()) {
+				for (MemorySegment seg : segments) {
+					seg.free();
 				}
+				segments.clear();
 			}
+			allocatedSegments.clear();
 		}
-		// -------------------- END CRITICAL SECTION -------------------
 	}
 
 	/**
@@ -191,9 +191,7 @@ public class MemoryManager {
 	 */
 	@VisibleForTesting
 	public boolean verifyEmpty() {
-		synchronized (lock) {
-			return numNonAllocatedPages == totalNumPages;
-		}
+		return budgetByType.totalAvailableBudget() == memorySize;
 	}
 
 	// ------------------------------------------------------------------------
@@ -224,45 +222,39 @@ public class MemoryManager {
 	 * @throws MemoryAllocationException Thrown, if this memory manager does not have the requested amount
 	 *                                   of memory pages any more.
 	 */
-	public void allocatePages(Object owner, List<MemorySegment> target, int numPages)
-			throws MemoryAllocationException {
+	public void allocatePages(
+			Object owner,
+			Collection<MemorySegment> target,
+			int numPages) throws MemoryAllocationException {
 		// sanity check
-		if (owner == null) {
-			throw new IllegalArgumentException("The memory owner must not be null.");
-		}
+		Preconditions.checkNotNull(owner, "The memory owner must not be null.");
+		Preconditions.checkState(!isShutDown, "Memory manager has been shut down.");
 
 		// reserve array space, if applicable
 		if (target instanceof ArrayList) {
 			((ArrayList<MemorySegment>) target).ensureCapacity(numPages);
 		}
 
-		// -------------------- BEGIN CRITICAL SECTION -------------------
-		synchronized (lock) {
-			if (isShutDown) {
-				throw new IllegalStateException("Memory manager has been shut down.");
-			}
+		// in the case of pre-allocated memory, the 'numNonAllocatedPages' is zero, in the
+		// lazy case, the 'freeSegments.size()' is zero.
+		Either<Map<MemoryType, Long>, Long> acquiredBudget = budgetByType.acquirePagedBudget(numPages, pageSize);
+		if (acquiredBudget.isRight()) {
+			throw new MemoryAllocationException(
+				String.format("Could not allocate %d pages. Only %d pages are remaining.", numPages, acquiredBudget.right()));
+		}
 
-			// in the case of pre-allocated memory, the 'numNonAllocatedPages' is zero, in the
-			// lazy case, the 'freeSegments.size()' is zero.
-			if (numPages > numNonAllocatedPages) {
-				throw new MemoryAllocationException(
-					String.format("Could not allocate %d pages. Only %d pages are remaining.", numPages, numNonAllocatedPages));
-			}
-
-			Set<MemorySegment> segmentsForOwner = allocatedSegments.get(owner);
-			if (segmentsForOwner == null) {
-				segmentsForOwner = new HashSet<MemorySegment>(numPages);
-				allocatedSegments.put(owner, segmentsForOwner);
-			}
-
+		allocatedSegments.compute(owner, (o, currentSegmentsForOwner) -> {
+			Set<MemorySegment> segmentsForOwner = currentSegmentsForOwner == null ?
+				new HashSet<>(numPages) : currentSegmentsForOwner;
 			for (int i = numPages; i > 0; i--) {
 				MemorySegment segment = allocateManagedSegment(memoryType, owner);
 				target.add(segment);
 				segmentsForOwner.add(segment);
 			}
-			numNonAllocatedPages -= numPages;
-		}
-		// -------------------- END CRITICAL SECTION -------------------
+			return segmentsForOwner;
+		});
+
+		Preconditions.checkState(!isShutDown, "Memory manager has been concurrently shut down.");
 	}
 
 	/**
@@ -275,42 +267,26 @@ public class MemoryManager {
 	 * @throws IllegalArgumentException Thrown, if the given segment is of an incompatible type.
 	 */
 	public void release(MemorySegment segment) {
+		Preconditions.checkState(!isShutDown, "Memory manager has been shut down.");
+
 		// check if segment is null or has already been freed
 		if (segment == null || segment.getOwner() == null) {
 			return;
 		}
 
-		final Object owner = segment.getOwner();
-
-		// -------------------- BEGIN CRITICAL SECTION -------------------
-		synchronized (lock) {
-			// prevent double return to this memory manager
-			if (segment.isFreed()) {
-				return;
-			}
-			if (isShutDown) {
-				throw new IllegalStateException("Memory manager has been shut down.");
-			}
-
-			// remove the reference in the map for the owner
-			try {
-				Set<MemorySegment> segsForOwner = this.allocatedSegments.get(owner);
-
-				if (segsForOwner != null) {
-					segsForOwner.remove(segment);
-					if (segsForOwner.isEmpty()) {
-						this.allocatedSegments.remove(owner);
-					}
-				}
-
+		// remove the reference in the map for the owner
+		try {
+			allocatedSegments.computeIfPresent(segment.getOwner(), (o, segsForOwner) -> {
+				segsForOwner.remove(segment);
 				segment.free();
-				numNonAllocatedPages++;
-			}
-			catch (Throwable t) {
-				throw new RuntimeException("Error removing book-keeping reference to allocated memory segment.", t);
-			}
+				budgetByType.releaseBudgetForKey(getSegmentType(segment), pageSize);
+				//noinspection ReturnOfNull
+				return segsForOwner.isEmpty() ? null : segsForOwner;
+			});
 		}
-		// -------------------- END CRITICAL SECTION -------------------
+		catch (Throwable t) {
+			throw new RuntimeException("Error removing book-keeping reference to allocated memory segment.", t);
+		}
 	}
 
 	/**
@@ -327,69 +303,79 @@ public class MemoryManager {
 			return;
 		}
 
-		// -------------------- BEGIN CRITICAL SECTION -------------------
-		synchronized (lock) {
-			if (isShutDown) {
-				throw new IllegalStateException("Memory manager has been shut down.");
-			}
+		Preconditions.checkState(!isShutDown, "Memory manager has been shut down.");
 
-			// since concurrent modifications to the collection
-			// can disturb the release, we need to try potentially multiple times
-			boolean successfullyReleased = false;
-			do {
-				final Iterator<MemorySegment> segmentsIterator = segments.iterator();
+		EnumMap<MemoryType, Long> releasedMemory = new EnumMap<>(MemoryType.class);
 
-				Object lastOwner = null;
-				Set<MemorySegment> segsForOwner = null;
+		// since concurrent modifications to the collection
+		// can disturb the release, we need to try potentially multiple times
+		boolean successfullyReleased = false;
+		do {
+			Iterator<MemorySegment> segmentsIterator = segments.iterator();
 
-				try {
-					// go over all segments
-					while (segmentsIterator.hasNext()) {
-
-						final MemorySegment seg = segmentsIterator.next();
-						if (seg == null || seg.isFreed()) {
-							continue;
-						}
-
-						final Object owner = seg.getOwner();
-
-						try {
-							// get the list of segments by this owner only if it is a different owner than for
-							// the previous one (or it is the first segment)
-							if (lastOwner != owner) {
-								lastOwner = owner;
-								segsForOwner = this.allocatedSegments.get(owner);
-							}
-
-							// remove the segment from the list
-							if (segsForOwner != null) {
-								segsForOwner.remove(seg);
-								if (segsForOwner.isEmpty()) {
-									this.allocatedSegments.remove(owner);
-								}
-							}
-
-							seg.free();
-							numNonAllocatedPages++;
-						}
-						catch (Throwable t) {
-							throw new RuntimeException(
-									"Error removing book-keeping reference to allocated memory segment.", t);
-						}
+			//noinspection ProhibitedExceptionCaught
+			try {
+				MemorySegment segment = null;
+				while (segment == null && segmentsIterator.hasNext()) {
+					segment = segmentsIterator.next();
+					if (segment.isFreed()) {
+						segment = null;
 					}
-
-					segments.clear();
-
-					// the only way to exit the loop
-					successfullyReleased = true;
 				}
-				catch (ConcurrentModificationException | NoSuchElementException e) {
-					// this may happen in the case where an asynchronous
-					// call releases the memory. fall through the loop and try again
+				while (segment != null) {
+					segment = releaseSegmentsForOwnerUntilNextOwner(segment, segmentsIterator, releasedMemory);
 				}
-			} while (!successfullyReleased);
+				segments.clear();
+				// the only way to exit the loop
+				successfullyReleased = true;
+			} catch (ConcurrentModificationException | NoSuchElementException e) {
+				// this may happen in the case where an asynchronous
+				// call releases the memory. fall through the loop and try again
+			}
+		} while (!successfullyReleased);
+
+		budgetByType.releaseBudgetForKeys(releasedMemory);
+	}
+
+	private MemorySegment releaseSegmentsForOwnerUntilNextOwner(
+			MemorySegment firstSeg,
+			Iterator<MemorySegment> segmentsIterator,
+			EnumMap<MemoryType, Long> releasedMemory) {
+		AtomicReference<MemorySegment> nextOwnerMemorySegment = new AtomicReference<>();
+		Object owner = firstSeg.getOwner();
+		allocatedSegments.compute(owner, (o, segsForOwner) -> {
+			freeSegment(firstSeg, segsForOwner, releasedMemory);
+			while (segmentsIterator.hasNext()) {
+				MemorySegment segment = segmentsIterator.next();
+				try {
+					if (segment == null || segment.isFreed()) {
+						continue;
+					}
+					Object nextOwner = segment.getOwner();
+					if (nextOwner != owner) {
+						nextOwnerMemorySegment.set(segment);
+						break;
+					}
+					freeSegment(segment, segsForOwner, releasedMemory);
+				} catch (Throwable t) {
+					throw new RuntimeException(
+						"Error removing book-keeping reference to allocated memory segment.", t);
+				}
+			}
+			//noinspection ReturnOfNull
+			return segsForOwner == null || segsForOwner.isEmpty() ? null : segsForOwner;
+		});
+		return nextOwnerMemorySegment.get();
+	}
+
+	private void freeSegment(
+			MemorySegment segment,
+			@Nullable Collection<MemorySegment> segments,
+			EnumMap<MemoryType, Long> releasedMemory) {
+		if (segments != null) {
+			segments.remove(segment);
 		}
-		// -------------------- END CRITICAL SECTION -------------------
+		releaseSegment(segment, releasedMemory);
 	}
 
 	/**
@@ -402,29 +388,24 @@ public class MemoryManager {
 			return;
 		}
 
-		// -------------------- BEGIN CRITICAL SECTION -------------------
-		synchronized (lock) {
-			if (isShutDown) {
-				throw new IllegalStateException("Memory manager has been shut down.");
-			}
+		Preconditions.checkState(!isShutDown, "Memory manager has been shut down.");
 
-			// get all segments
-			final Set<MemorySegment> segments = allocatedSegments.remove(owner);
+		// get all segments
+		Set<MemorySegment> segments = allocatedSegments.remove(owner);
 
-			// all segments may have been freed previously individually
-			if (segments == null || segments.isEmpty()) {
-				return;
-			}
-
-			// free each segment
-			for (MemorySegment seg : segments) {
-				seg.free();
-			}
-			numNonAllocatedPages += segments.size();
-
-			segments.clear();
+		// all segments may have been freed previously individually
+		if (segments == null || segments.isEmpty()) {
+			return;
 		}
-		// -------------------- END CRITICAL SECTION -------------------
+
+		// free each segment
+		EnumMap<MemoryType, Long> releasedMemory = new EnumMap<>(MemoryType.class);
+		for (MemorySegment segment : segments) {
+			releaseSegment(segment, releasedMemory);
+		}
+		budgetByType.releaseBudgetForKeys(releasedMemory);
+
+		segments.clear();
 	}
 
 	// ------------------------------------------------------------------------
@@ -475,5 +456,14 @@ public class MemoryManager {
 			default:
 				throw new IllegalArgumentException("unrecognized memory type: " + memoryType);
 		}
+	}
+
+	private void releaseSegment(MemorySegment segment, EnumMap<MemoryType, Long> releasedMemory) {
+		segment.free();
+		releasedMemory.compute(getSegmentType(segment), (t, v) -> v == null ? pageSize : v + pageSize);
+	}
+
+	private static MemoryType getSegmentType(MemorySegment segment) {
+		return segment.isOffHeap() ? MemoryType.OFF_HEAP : MemoryType.HEAP;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.memory;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.memory.HybridMemorySegment;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
@@ -109,6 +110,7 @@ public class MemoryManager {
 	 * @param memorySize The total size of the memory to be managed by this memory manager.
 	 * @param numberOfSlots The number of slots of the task manager.
 	 */
+	@VisibleForTesting
 	public MemoryManager(long memorySize, int numberOfSlots) {
 		this(memorySize, numberOfSlots, DEFAULT_PAGE_SIZE, MemoryType.HEAP, true);
 	}
@@ -224,6 +226,7 @@ public class MemoryManager {
 	 *
 	 * @return True, if the memory manager is shut down, false otherwise.
 	 */
+	@VisibleForTesting
 	public boolean isShutdown() {
 		return isShutDown;
 	}
@@ -233,6 +236,7 @@ public class MemoryManager {
 	 *
 	 * @return True, if the memory manager is empty and valid, false if it is not empty or corrupted.
 	 */
+	@VisibleForTesting
 	public boolean verifyEmpty() {
 		synchronized (lock) {
 			return isPreAllocated ?

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -49,13 +49,16 @@ import static org.apache.flink.core.memory.MemorySegmentFactory.allocateUnpooled
 import static org.apache.flink.core.memory.MemorySegmentFactory.allocateUnpooledSegment;
 
 /**
- * The memory manager governs the memory that Flink uses for sorting, hashing, and caching. Memory
- * is represented in segments of equal size. Operators allocate the memory by requesting a number
- * of memory segments.
+ * The memory manager governs the memory that Flink uses for sorting, hashing, and caching. Memory is represented
+ * either in {@link MemorySegment}s of equal size and arbitrary type or in reserved chunks of certain size and {@link MemoryType}.
+ * Operators allocate the memory either by requesting a number of memory segments or by reserving chunks.
+ * Any allocated memory has to be released to be reused later.
  *
- * <p>The memory may be represented as on-heap byte arrays or as off-heap memory regions
- * (both via {@link HybridMemorySegment}). Which kinds of memory the MemoryManager serves and their sizes can
- * be passed as an argument to the initialization. Releasing a memory segment will make it re-claimable
+ * <p>Which {@link MemoryType}s the MemoryManager serves and their total sizes can be passed as an argument
+ * to the constructor.
+ *
+ * <p>The memory segments may be represented as on-heap byte arrays or as off-heap memory regions
+ * (both via {@link HybridMemorySegment}). Releasing a memory segment will make it re-claimable
  * by the garbage collector.
  */
 public class MemoryManager {
@@ -71,6 +74,9 @@ public class MemoryManager {
 
 	/** Memory segments allocated per memory owner. */
 	private final Map<Object, Set<MemorySegment>> allocatedSegments;
+
+	/** Reserved memory per memory owner. */
+	private final Map<Object, Map<MemoryType, Long>> reservedMemory;
 
 	/** The size of the memory segments. */
 	private final int pageSize;
@@ -102,6 +108,7 @@ public class MemoryManager {
 		}
 
 		this.allocatedSegments = new ConcurrentHashMap<>();
+		this.reservedMemory = new ConcurrentHashMap<>();
 		this.numberOfSlots = numberOfSlots;
 		this.pageSize = pageSize;
 		this.totalNumPages = calculateTotalNumberOfPages(memorySizeByType, pageSize);
@@ -158,6 +165,7 @@ public class MemoryManager {
 		if (!isShutDown) {
 			// mark as shutdown and release memory
 			isShutDown = true;
+			reservedMemory.clear();
 			budgetByType.releaseAll();
 
 			// go over all allocated segments and release them
@@ -413,6 +421,97 @@ public class MemoryManager {
 		budgetByType.releaseBudgetForKeys(releasedMemory);
 
 		segments.clear();
+	}
+
+	/**
+	 * Reserves memory of a certain type for an owner from this memory manager.
+	 *
+	 * @param owner The owner to associate with the memory reservation, for the fallback release.
+	 * @param memoryType type of memory to reserve (heap / off-heap).
+	 * @param size size of memory to reserve.
+	 * @throws MemoryAllocationException Thrown, if this memory manager does not have the requested amount
+	 *                                   of memory any more.
+	 */
+	public void reserveMemory(Object owner, MemoryType memoryType, long size) throws MemoryAllocationException {
+		checkMemoryReservationPreconditions(owner, memoryType, size);
+		if (size == 0L) {
+			return;
+		}
+
+		long acquiredMemory = budgetByType.acquireBudgetForKey(memoryType, size);
+		if (acquiredMemory < size) {
+			throw new MemoryAllocationException(
+				String.format("Could not allocate %d bytes. Only %d bytes are remaining.", size, acquiredMemory));
+		}
+
+		reservedMemory.compute(owner, (o, reservations) -> {
+			Map<MemoryType, Long> newReservations = reservations;
+			if (reservations == null) {
+				newReservations = new EnumMap<>(MemoryType.class);
+				newReservations.put(memoryType, size);
+			} else {
+				reservations.compute(
+					memoryType,
+					(mt, currentlyReserved) -> currentlyReserved == null ? size : currentlyReserved + size);
+			}
+			return newReservations;
+		});
+
+		Preconditions.checkState(!isShutDown, "Memory manager has been concurrently shut down.");
+	}
+
+	/**
+	 * Releases memory of a certain type from an owner to this memory manager.
+	 *
+	 * @param owner The owner to associate with the memory reservation, for the fallback release.
+	 * @param memoryType type of memory to release (heap / off-heap).
+	 * @param size size of memory to release.
+	 */
+	public void releaseMemory(Object owner, MemoryType memoryType, long size) {
+		checkMemoryReservationPreconditions(owner, memoryType, size);
+		if (size == 0L) {
+			return;
+		}
+
+		reservedMemory.compute(owner, (o, reservations) -> {
+			if (reservations != null) {
+				reservations.compute(
+					memoryType,
+					(mt, currentlyReserved) ->
+						currentlyReserved == null || currentlyReserved <= size ? null : currentlyReserved - size);
+			}
+			//noinspection ReturnOfNull
+			return reservations == null || reservations.isEmpty() ? null : reservations;
+		});
+		budgetByType.releaseBudgetForKey(memoryType, size);
+	}
+
+	private void checkMemoryReservationPreconditions(Object owner, MemoryType memoryType, long size) {
+		Preconditions.checkNotNull(owner, "The memory owner must not be null.");
+		Preconditions.checkNotNull(memoryType, "The memory type must not be null.");
+		Preconditions.checkState(!isShutDown, "Memory manager has been shut down.");
+		Preconditions.checkArgument(size >= 0L, "The memory size (%s) has to have non-negative size", size);
+	}
+
+	/**
+	 * Releases all memory of a certain type from an owner to this memory manager.
+	 *
+	 * @param owner The owner to associate with the memory reservation, for the fallback release.
+	 * @param memoryType type of memory to release (heap / off-heap).
+	 */
+	public void releaseAllMemory(Object owner, MemoryType memoryType) {
+		checkMemoryReservationPreconditions(owner, memoryType, 0L);
+
+		reservedMemory.compute(owner, (o, reservations) -> {
+			if (reservations != null) {
+				Long size = reservations.remove(memoryType);
+				if (size != null) {
+					budgetByType.releaseBudgetForKey(memoryType, size);
+				}
+			}
+			//noinspection ReturnOfNull
+			return reservations == null || reservations.isEmpty() ? null : reservations;
+		});
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -371,10 +371,9 @@ public class TaskManagerServices {
 		final MemoryManager memoryManager;
 		try {
 			memoryManager = new MemoryManager(
-				memorySize,
+				Collections.singletonMap(memType, memorySize),
 				taskManagerServicesConfiguration.getNumberOfSlots(),
-				taskManagerServicesConfiguration.getPageSize(),
-				memType);
+				taskManagerServicesConfiguration.getPageSize());
 		} catch (OutOfMemoryError e) {
 			if (memType == MemoryType.HEAP) {
 				throw new Exception("OutOfMemory error (" + e.getMessage() +

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
@@ -73,8 +73,6 @@ public class TaskManagerServicesConfiguration {
 
 	private final MemoryType memoryType;
 
-	private final boolean preAllocateMemory;
-
 	private final float memoryFraction;
 
 	private final int pageSize;
@@ -101,7 +99,6 @@ public class TaskManagerServicesConfiguration {
 			int numberOfSlots,
 			long configuredMemory,
 			MemoryType memoryType,
-			boolean preAllocateMemory,
 			float memoryFraction,
 			int pageSize,
 			long timerServiceShutdownTimeout,
@@ -122,7 +119,6 @@ public class TaskManagerServicesConfiguration {
 
 		this.configuredMemory = configuredMemory;
 		this.memoryType = checkNotNull(memoryType);
-		this.preAllocateMemory = preAllocateMemory;
 		this.memoryFraction = memoryFraction;
 		this.pageSize = pageSize;
 
@@ -207,10 +203,6 @@ public class TaskManagerServicesConfiguration {
 		return configuredMemory;
 	}
 
-	boolean isPreAllocateMemory() {
-		return preAllocateMemory;
-	}
-
 	public int getPageSize() {
 		return pageSize;
 	}
@@ -263,8 +255,6 @@ public class TaskManagerServicesConfiguration {
 
 		final QueryableStateConfiguration queryableStateConfig = QueryableStateConfiguration.fromConfiguration(configuration);
 
-		boolean preAllocateMemory = configuration.getBoolean(TaskManagerOptions.MANAGED_MEMORY_PRE_ALLOCATE);
-
 		long timerServiceShutdownTimeout = AkkaUtils.getTimeout(configuration).toMillis();
 
 		final RetryingRegistrationConfiguration retryingRegistrationConfiguration = RetryingRegistrationConfiguration.fromConfiguration(configuration);
@@ -283,7 +273,6 @@ public class TaskManagerServicesConfiguration {
 			ConfigurationParserUtils.getSlot(configuration),
 			ConfigurationParserUtils.getManagedMemorySize(configuration),
 			ConfigurationParserUtils.getMemoryType(configuration),
-			preAllocateMemory,
 			ConfigurationParserUtils.getManagedMemoryFraction(configuration),
 			ConfigurationParserUtils.getPageSize(configuration),
 			timerServiceShutdownTimeout,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/ChannelViewsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/ChannelViewsTest.java
@@ -22,7 +22,7 @@ package org.apache.flink.runtime.io.disk;
 import java.io.EOFException;
 import java.util.List;
 
-import org.apache.flink.core.memory.MemoryType;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.junit.Assert;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.disk.iomanager.BlockChannelReader;
@@ -77,7 +77,11 @@ public class ChannelViewsTest
 
 	@Before
 	public void beforeTest() {
-		this.memoryManager = new MemoryManager(MEMORY_SIZE, 1, MEMORY_PAGE_SIZE, MemoryType.HEAP, true);
+		this.memoryManager = MemoryManagerBuilder
+			.newBuilder()
+			.setMemorySize(MEMORY_SIZE)
+			.setPageSize(MEMORY_PAGE_SIZE)
+			.build();
 		this.ioManager = new IOManagerAsync();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/FileChannelStreamsITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/FileChannelStreamsITCase.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.io.disk;
 
 import static org.junit.Assert.*;
 
-import org.apache.flink.core.memory.MemoryType;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.util.TestLogger;
 import org.junit.After;
 import org.junit.Before;
@@ -67,8 +67,11 @@ public class FileChannelStreamsITCase extends TestLogger {
 
 	@Before
 	public void beforeTest() {
-		memManager = new MemoryManager(NUM_MEMORY_SEGMENTS * MEMORY_PAGE_SIZE, 1,
-				MEMORY_PAGE_SIZE, MemoryType.HEAP, true);
+		memManager = MemoryManagerBuilder
+			.newBuilder()
+			.setMemorySize(NUM_MEMORY_SEGMENTS * MEMORY_PAGE_SIZE)
+			.setPageSize(MEMORY_PAGE_SIZE)
+			.build();
 		ioManager = new IOManagerAsync();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/FileChannelStreamsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/FileChannelStreamsTest.java
@@ -26,13 +26,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.io.disk.iomanager.BlockChannelReader;
 import org.apache.flink.runtime.io.disk.iomanager.BlockChannelWriter;
 import org.apache.flink.runtime.io.disk.iomanager.FileIOChannel;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.types.StringValue;
 import org.junit.Test;
@@ -43,7 +43,7 @@ public class FileChannelStreamsTest {
 	@Test
 	public void testCloseAndDeleteOutputView() {
 		try (IOManager ioManager = new IOManagerAsync()) {
-			MemoryManager memMan = new MemoryManager(4 * 16*1024, 1, 16*1024, MemoryType.HEAP, true);
+			MemoryManager memMan = MemoryManagerBuilder.newBuilder().build();
 			List<MemorySegment> memory = new ArrayList<MemorySegment>();
 			memMan.allocatePages(new DummyInvokable(), memory, 4);
 			
@@ -73,7 +73,7 @@ public class FileChannelStreamsTest {
 	@Test
 	public void testCloseAndDeleteInputView() {
 		try (IOManager ioManager = new IOManagerAsync()) {
-			MemoryManager memMan = new MemoryManager(4 * 16*1024, 1, 16*1024, MemoryType.HEAP, true);
+			MemoryManager memMan = MemoryManagerBuilder.newBuilder().build();
 			List<MemorySegment> memory = new ArrayList<MemorySegment>();
 			memMan.allocatePages(new DummyInvokable(), memory, 4);
 			

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/SeekableFileChannelInputViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/SeekableFileChannelInputViewTest.java
@@ -25,12 +25,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.io.disk.iomanager.BlockChannelWriter;
 import org.apache.flink.runtime.io.disk.iomanager.FileIOChannel;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.junit.Test;
 
@@ -44,7 +44,11 @@ public class SeekableFileChannelInputViewTest {
 		// integers across 7.x pages (7 pages = 114.688 bytes, 8 pages = 131.072 bytes)
 		
 		try (IOManager ioManager = new IOManagerAsync()) {
-			MemoryManager memMan = new MemoryManager(4 * PAGE_SIZE, 1, PAGE_SIZE, MemoryType.HEAP, true);
+			MemoryManager memMan = MemoryManagerBuilder
+				.newBuilder()
+				.setMemorySize(4 * PAGE_SIZE)
+				.setPageSize(PAGE_SIZE)
+				.build();
 			List<MemorySegment> memory = new ArrayList<MemorySegment>();
 			memMan.allocatePages(new DummyInvokable(), memory, 4);
 			

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/SpillingBufferTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/SpillingBufferTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.ListMemorySegmentSource;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.TestData;
 import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator.KeyMode;
@@ -66,7 +67,7 @@ public class SpillingBufferTest {
 
 	@Before
 	public void beforeTest() {
-		memoryManager = new MemoryManager(MEMORY_SIZE, 1);
+		memoryManager = MemoryManagerBuilder.newBuilder().setMemorySize(MEMORY_SIZE).build();
 		ioManager = new IOManagerAsync();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerITCase.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Random;
 
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.util.TestLogger;
 import org.junit.Assert;
@@ -59,7 +60,7 @@ public class IOManagerITCase extends TestLogger {
 
 	@Before
 	public void beforeTest() {
-		memoryManager = new MemoryManager(MEMORY_SIZE, 1);
+		memoryManager = MemoryManagerBuilder.newBuilder().setMemorySize(MEMORY_SIZE).build();
 		ioManager = new IOManagerAsync();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/KeyedBudgetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/KeyedBudgetTest.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.memory;
+
+import org.apache.flink.types.Either;
+import org.apache.flink.util.Preconditions;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.LongStream;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Test suite for {@link KeyedBudget}.
+ */
+@SuppressWarnings("MagicNumber")
+public class KeyedBudgetTest {
+	private static final String[] TEST_KEYS = {"k1", "k2", "k3", "k4"};
+	private static final long[] TEST_BUDGETS = {15, 17, 22, 11};
+
+	@Test
+	public void testSuccessfulAcquisitionForKey() {
+		KeyedBudget<String> keyedBudget = createSimpleKeyedBudget();
+
+		long acquired = keyedBudget.acquireBudgetForKey("k1", 10L);
+
+		assertThat(acquired, is(10L));
+		checkOneKeyBudgetChange(keyedBudget, "k1", 5L);
+	}
+
+	@Test
+	public void testFailedAcquisitionForKey() {
+		KeyedBudget<String> keyedBudget = createSimpleKeyedBudget();
+
+		long acquired = keyedBudget.acquireBudgetForKey("k1", 20L);
+
+		assertThat(acquired, is(15L));
+		checkOneKeyBudgetChange(keyedBudget, "k1", 15L);
+	}
+
+	@Test
+	public void testSuccessfulReleaseForKey() {
+		KeyedBudget<String> keyedBudget = createSimpleKeyedBudget();
+
+		keyedBudget.acquireBudgetForKey("k1", 10L);
+		keyedBudget.releaseBudgetForKey("k1", 5L);
+
+		checkOneKeyBudgetChange(keyedBudget, "k1", 10L);
+	}
+
+	@Test
+	public void testFailedReleaseForKey() {
+		KeyedBudget<String> keyedBudget = createSimpleKeyedBudget();
+
+		keyedBudget.acquireBudgetForKey("k1", 10L);
+		try {
+			keyedBudget.releaseBudgetForKey("k1", 15L);
+			fail("IllegalStateException is expected to fail over-sized release");
+		} catch (IllegalStateException e) {
+			// expected
+		}
+
+		checkOneKeyBudgetChange(keyedBudget, "k1", 5L);
+	}
+
+	@Test
+	public void testSuccessfulAcquisitionForKeys() {
+		KeyedBudget<String> keyedBudget = createSimpleKeyedBudget();
+
+		Either<Map<String, Long>, Long> acquired =
+			keyedBudget.acquirePagedBudgetForKeys(Arrays.asList("k2", "k3"), 4, 5);
+
+		assertThat(acquired.isLeft(), is(true));
+		assertThat(acquired.left().values().stream().mapToLong(b -> b).sum(), is(4L));
+
+		assertThat(keyedBudget.availableBudgetForKey("k1"), is(15L));
+		assertThat(keyedBudget.availableBudgetForKeys(Arrays.asList("k2", "k3")), is(19L));
+		assertThat(keyedBudget.totalAvailableBudget(), is(45L));
+	}
+
+	@Test
+	public void testSuccessfulReleaseForKeys() {
+		KeyedBudget<String> keyedBudget = createSimpleKeyedBudget();
+
+		keyedBudget.acquirePagedBudgetForKeys(Arrays.asList("k2", "k3"), 4, 8);
+		keyedBudget.releaseBudgetForKeys(createdBudgetMap(new String[] {"k2", "k3"}, new long[] {7, 10}));
+
+		assertThat(keyedBudget.availableBudgetForKeys(Arrays.asList("k2", "k3")), is(24L));
+		assertThat(keyedBudget.availableBudgetForKeys(Arrays.asList("k1", "k4")), is(26L));
+		assertThat(keyedBudget.totalAvailableBudget(), is(50L));
+	}
+
+	@Test
+	public void testSuccessfulReleaseForKeysWithMixedRequests() {
+		KeyedBudget<String> keyedBudget = createSimpleKeyedBudget();
+
+		keyedBudget.acquirePagedBudgetForKeys(Arrays.asList("k2", "k3"), 4, 8);
+		keyedBudget.acquirePagedBudgetForKeys(Arrays.asList("k1", "k4"), 6, 3);
+		keyedBudget.releaseBudgetForKeys(createdBudgetMap(new String[] {"k2", "k3"}, new long[] {7, 10}));
+
+		assertThat(keyedBudget.availableBudgetForKeys(Arrays.asList("k2", "k3")), is(24L));
+		assertThat(keyedBudget.availableBudgetForKeys(Arrays.asList("k1", "k4")), is(8L));
+		assertThat(keyedBudget.totalAvailableBudget(), is(32L));
+	}
+
+	private static void checkOneKeyBudgetChange(
+			KeyedBudget<String> keyedBudget,
+			@SuppressWarnings("SameParameterValue") String key,
+			long budget) {
+		long totalExpectedBudget = 0L;
+		for (int i = 0; i < TEST_KEYS.length; i++) {
+			long expectedBudget = TEST_KEYS[i].equals(key) ? budget : TEST_BUDGETS[i];
+			assertThat(keyedBudget.availableBudgetForKey(TEST_KEYS[i]), is(expectedBudget));
+			totalExpectedBudget += expectedBudget;
+		}
+		assertThat(keyedBudget.maxTotalBudget(), is(LongStream.of(TEST_BUDGETS).sum()));
+		assertThat(keyedBudget.totalAvailableBudget(), is(totalExpectedBudget));
+	}
+
+	private static KeyedBudget<String> createSimpleKeyedBudget() {
+		return new KeyedBudget<>(createdBudgetMap(TEST_KEYS, TEST_BUDGETS));
+	}
+
+	private static Map<String, Long> createdBudgetMap(String[] keys, long[] budgets) {
+		Preconditions.checkArgument(keys.length == budgets.length);
+		Map<String, Long> keydBudgets = new HashMap<>();
+		for (int i = 0; i < keys.length; i++) {
+			keydBudgets.put(keys[i], budgets[i]);
+		}
+		return keydBudgets;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerBuilder.java
@@ -20,22 +20,30 @@ package org.apache.flink.runtime.memory;
 
 import org.apache.flink.core.memory.MemoryType;
 
+import java.util.EnumMap;
+import java.util.Map;
+
 import static org.apache.flink.runtime.memory.MemoryManager.DEFAULT_PAGE_SIZE;
 
 /** Builder class for {@link MemoryManager}. */
 public class MemoryManagerBuilder {
-	private static final int DEFAULT_MEMORY_SIZE = 32 * DEFAULT_PAGE_SIZE;
+	private static final long DEFAULT_MEMORY_SIZE = 32L * DEFAULT_PAGE_SIZE;
 
-	private long memorySize = DEFAULT_MEMORY_SIZE;
+	private final Map<MemoryType, Long> memoryPools = new EnumMap<>(MemoryType.class);
 	private int numberOfSlots = 1;
 	private int pageSize = DEFAULT_PAGE_SIZE;
 
 	private MemoryManagerBuilder() {
-
+		memoryPools.put(MemoryType.HEAP, DEFAULT_MEMORY_SIZE);
 	}
 
 	public MemoryManagerBuilder setMemorySize(long memorySize) {
-		this.memorySize = memorySize;
+		this.memoryPools.put(MemoryType.HEAP, memorySize);
+		return this;
+	}
+
+	public MemoryManagerBuilder setMemorySize(MemoryType memoryType, long memorySize) {
+		this.memoryPools.put(memoryType, memorySize);
 		return this;
 	}
 
@@ -50,7 +58,7 @@ public class MemoryManagerBuilder {
 	}
 
 	public MemoryManager build() {
-		return new MemoryManager(memorySize, numberOfSlots, pageSize, MemoryType.HEAP);
+		return new MemoryManager(memoryPools, numberOfSlots, pageSize);
 	}
 
 	public static MemoryManagerBuilder newBuilder() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerBuilder.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.memory;
+
+import org.apache.flink.core.memory.MemoryType;
+
+import static org.apache.flink.runtime.memory.MemoryManager.DEFAULT_PAGE_SIZE;
+
+/** Builder class for {@link MemoryManager}. */
+public class MemoryManagerBuilder {
+	private static final int DEFAULT_MEMORY_SIZE = 32 * DEFAULT_PAGE_SIZE;
+
+	private long memorySize = DEFAULT_MEMORY_SIZE;
+	private int numberOfSlots = 1;
+	private int pageSize = DEFAULT_PAGE_SIZE;
+	private boolean preAllocateMemory = true;
+
+	private MemoryManagerBuilder() {
+
+	}
+
+	public MemoryManagerBuilder setMemorySize(long memorySize) {
+		this.memorySize = memorySize;
+		return this;
+	}
+
+	public MemoryManagerBuilder setNumberOfSlots(int numberOfSlots) {
+		this.numberOfSlots = numberOfSlots;
+		return this;
+	}
+
+	public MemoryManagerBuilder setPageSize(int pageSize) {
+		this.pageSize = pageSize;
+		return this;
+	}
+
+	public MemoryManagerBuilder setPreAllocateMemory(boolean preAllocateMemory) {
+		this.preAllocateMemory = preAllocateMemory;
+		return this;
+	}
+
+	public MemoryManager build() {
+		return new MemoryManager(memorySize, numberOfSlots, pageSize, MemoryType.HEAP, preAllocateMemory);
+	}
+
+	public static MemoryManagerBuilder newBuilder() {
+		return new MemoryManagerBuilder();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerBuilder.java
@@ -29,7 +29,6 @@ public class MemoryManagerBuilder {
 	private long memorySize = DEFAULT_MEMORY_SIZE;
 	private int numberOfSlots = 1;
 	private int pageSize = DEFAULT_PAGE_SIZE;
-	private boolean preAllocateMemory = true;
 
 	private MemoryManagerBuilder() {
 
@@ -50,13 +49,8 @@ public class MemoryManagerBuilder {
 		return this;
 	}
 
-	public MemoryManagerBuilder setPreAllocateMemory(boolean preAllocateMemory) {
-		this.preAllocateMemory = preAllocateMemory;
-		return this;
-	}
-
 	public MemoryManager build() {
-		return new MemoryManager(memorySize, numberOfSlots, pageSize, MemoryType.HEAP, preAllocateMemory);
+		return new MemoryManager(memorySize, numberOfSlots, pageSize, MemoryType.HEAP);
 	}
 
 	public static MemoryManagerBuilder newBuilder() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerConcurrentModReleaseTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerConcurrentModReleaseTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.memory;
 
 import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.core.memory.MemoryType;
 
 import org.junit.Test;
 
@@ -40,7 +39,11 @@ public class MemoryManagerConcurrentModReleaseTest {
 			final int numSegments = 10000;
 			final int segmentSize = 4096;
 
-			MemoryManager memMan = new MemoryManager(numSegments * segmentSize, 1, segmentSize, MemoryType.HEAP, true);
+			MemoryManager memMan = MemoryManagerBuilder
+				.newBuilder()
+				.setMemorySize(numSegments * segmentSize)
+				.setPageSize(segmentSize)
+				.build();
 
 			ArrayList<MemorySegment> segs = new ListWithConcModExceptionOnFirstAccess<>();
 			memMan.allocatePages(this, segs, numSegments);
@@ -59,7 +62,11 @@ public class MemoryManagerConcurrentModReleaseTest {
 			final int numSegments = 10000;
 			final int segmentSize = 4096;
 
-			MemoryManager memMan = new MemoryManager(numSegments * segmentSize, 1, segmentSize, MemoryType.HEAP, true);
+			MemoryManager memMan = MemoryManagerBuilder
+				.newBuilder()
+				.setMemorySize(numSegments * segmentSize)
+				.setPageSize(segmentSize)
+				.build();
 
 			ArrayList<MemorySegment> segs = new ArrayList<>(numSegments);
 			memMan.allocatePages(this, segs, numSegments);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerLazyAllocationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerLazyAllocationTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.memory;
 
 import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 
@@ -53,7 +52,11 @@ public class MemoryManagerLazyAllocationTest {
 
 	@Before
 	public void setUp() {
-		this.memoryManager = new MemoryManager(MEMORY_SIZE, 1, PAGE_SIZE, MemoryType.HEAP, false);
+		this.memoryManager = MemoryManagerBuilder
+			.newBuilder()
+			.setMemorySize(MEMORY_SIZE)
+			.setPageSize(PAGE_SIZE)
+			.build();
 		this.random = new Random(RANDOM_SEED);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.memory;
 
 import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 
@@ -53,7 +52,11 @@ public class MemoryManagerTest {
 
 	@Before
 	public void setUp() {
-		this.memoryManager = new MemoryManager(MEMORY_SIZE, 1, PAGE_SIZE, MemoryType.HEAP, true);
+		this.memoryManager = MemoryManagerBuilder
+			.newBuilder()
+			.setMemorySize(MEMORY_SIZE)
+			.setPageSize(PAGE_SIZE)
+			.build();
 		this.random = new Random(RANDOM_SEED);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.memory;
 
 import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 
@@ -28,9 +29,14 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.number.OrderingComparison.lessThanOrEqualTo;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 /**
@@ -54,7 +60,8 @@ public class MemoryManagerTest {
 	public void setUp() {
 		this.memoryManager = MemoryManagerBuilder
 			.newBuilder()
-			.setMemorySize(MEMORY_SIZE)
+			.setMemorySize(MemoryType.HEAP, MEMORY_SIZE / 2)
+			.setMemorySize(MemoryType.OFF_HEAP, MEMORY_SIZE / 2)
 			.setPageSize(PAGE_SIZE)
 			.build();
 		this.random = new Random(RANDOM_SEED);
@@ -195,5 +202,39 @@ public class MemoryManagerTest {
 			}
 		}
 		return true;
+	}
+
+	@Test
+	@SuppressWarnings("NumericCastThatLosesPrecision")
+	public void testAllocateMixedMemoryType() throws MemoryAllocationException {
+		int totalHeapPages = (int) memoryManager.getMemorySizeByType(MemoryType.HEAP) / PAGE_SIZE;
+		int totalOffHeapPages = (int) memoryManager.getMemorySizeByType(MemoryType.OFF_HEAP) / PAGE_SIZE;
+		int pagesToAllocate =  totalHeapPages + totalOffHeapPages / 2;
+
+		Object owner = new Object();
+		List<MemorySegment> segments = memoryManager.allocatePages(owner, pagesToAllocate);
+		Map<MemoryType, Integer> split = calcMemoryTypeSplitForSegments(segments);
+
+		assertThat(split.get(MemoryType.HEAP), lessThanOrEqualTo(totalHeapPages));
+		assertThat(split.get(MemoryType.OFF_HEAP), lessThanOrEqualTo(totalOffHeapPages));
+		assertThat(split.get(MemoryType.HEAP) + split.get(MemoryType.OFF_HEAP), is(pagesToAllocate));
+
+		memoryManager.release(segments);
+	}
+
+	private static Map<MemoryType, Integer> calcMemoryTypeSplitForSegments(Iterable<MemorySegment> segments) {
+		int heapPages = 0;
+		int offHeapPages = 0;
+		for (MemorySegment memorySegment : segments) {
+			if (memorySegment.isOffHeap()) {
+				offHeapPages++;
+			} else {
+				heapPages++;
+			}
+		}
+		Map<MemoryType, Integer> split = new EnumMap<>(MemoryType.class);
+		split.put(MemoryType.HEAP, heapPages);
+		split.put(MemoryType.OFF_HEAP, offHeapPages);
+		return split;
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerTest.java
@@ -237,4 +237,26 @@ public class MemoryManagerTest {
 		split.put(MemoryType.OFF_HEAP, offHeapPages);
 		return split;
 	}
+
+	@Test
+	public void testMemoryReservation() throws MemoryAllocationException {
+		Object owner = new Object();
+
+		memoryManager.reserveMemory(owner, MemoryType.HEAP, PAGE_SIZE);
+		memoryManager.reserveMemory(owner, MemoryType.OFF_HEAP, memoryManager.getMemorySizeByType(MemoryType.OFF_HEAP));
+
+		memoryManager.releaseMemory(owner, MemoryType.HEAP, PAGE_SIZE);
+		memoryManager.releaseAllMemory(owner, MemoryType.OFF_HEAP);
+	}
+
+	@Test
+	public void testMemoryTooBigReservation() {
+		Object owner = new Object();
+		try {
+			memoryManager.reserveMemory(owner, MemoryType.HEAP, memoryManager.getMemorySizeByType(MemoryType.HEAP) + PAGE_SIZE);
+			fail("Expected MemoryAllocationException.");
+		} catch (MemoryAllocationException e) {
+			// expected
+		}
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemorySegmentSimpleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemorySegmentSimpleTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.memory;
 
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
-import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 
 import org.junit.After;
@@ -56,7 +55,11 @@ public class MemorySegmentSimpleTest {
 	@Before
 	public void setUp() throws Exception{
 		try {
-			this.manager = new MemoryManager(MANAGED_MEMORY_SIZE, 1, PAGE_SIZE, MemoryType.HEAP, true);
+			this.manager = MemoryManagerBuilder
+				.newBuilder()
+				.setMemorySize(MANAGED_MEMORY_SIZE)
+				.setPageSize(PAGE_SIZE)
+				.build();
 			this.segment = manager.allocatePages(new DummyInvokable(), 1).get(0);
 			this.random = new Random(RANDOM_SEED);
 		} catch (Exception e) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/drivers/TestTaskContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/drivers/TestTaskContext.java
@@ -24,10 +24,10 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerFactory;
 import org.apache.flink.api.java.typeutils.runtime.RuntimeSerializerFactory;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.DriverStrategy;
@@ -74,7 +74,10 @@ public class TestTaskContext<S, T> implements TaskContext<S, T> {
 	public TestTaskContext() {}
 	
 	public TestTaskContext(long memoryInBytes) {
-		this.memoryManager = new MemoryManager(memoryInBytes, 1, 32 * 1024, MemoryType.HEAP, true);
+		this.memoryManager = MemoryManagerBuilder
+			.newBuilder()
+			.setMemorySize(memoryInBytes)
+			.build();
 		this.taskManageInfo = new TestingTaskManagerRuntimeInfo();
 	}
 	

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/HashTableITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/HashTableITCase.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.testutils.recordutils.RecordComparator;
 import org.apache.flink.runtime.testutils.recordutils.RecordSerializer;
 import org.apache.flink.core.memory.MemorySegment;
@@ -94,8 +95,8 @@ public class HashTableITCase extends TestLogger {
 		this.pairBuildSideComparator = new IntPairComparator();
 		this.pairProbeSideComparator = new IntPairComparator();
 		this.pairComparator = new IntPairPairComparator();
-		
-		this.memManager = new MemoryManager(32 * 1024 * 1024,1);
+
+		this.memManager = MemoryManagerBuilder.newBuilder().setMemorySize(32 * 1024 * 1024).build();
 		this.ioManager = new IOManagerAsync();
 	}
 	

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/NonReusingHashJoinIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/NonReusingHashJoinIteratorITCase.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.operators.testutils.DiscardingOutputCollector;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.TestData;
@@ -98,7 +99,7 @@ public class NonReusingHashJoinIteratorITCase extends TestLogger {
 		this.pairRecordPairComparator = new IntPairTuplePairComparator();
 		this.recordPairPairComparator = new TupleIntPairPairComparator();
 		
-		this.memoryManager = new MemoryManager(MEMORY_SIZE, 1);
+		this.memoryManager = MemoryManagerBuilder.newBuilder().setMemorySize(MEMORY_SIZE).build();
 		this.ioManager = new IOManagerAsync();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReOpenableHashTableITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReOpenableHashTableITCase.java
@@ -25,12 +25,12 @@ import org.apache.flink.api.common.typeutils.TypePairComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryAllocationException;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.TestData;
 import org.apache.flink.runtime.operators.testutils.UniformIntTupleGenerator;
@@ -76,7 +76,11 @@ public class ReOpenableHashTableITCase extends TestLogger {
 		this.recordProbeSideComparator = TestData.getIntIntTupleComparator();
 		this.pactRecordComparator = new GenericPairComparator(this.recordBuildSideComparator, this.recordProbeSideComparator);
 
-		this.memoryManager = new MemoryManager(MEMORY_SIZE, 1, PAGE_SIZE, MemoryType.HEAP, true);
+		this.memoryManager = MemoryManagerBuilder
+			.newBuilder()
+			.setMemorySize(MEMORY_SIZE)
+			.setPageSize(PAGE_SIZE)
+			.build();
 		this.ioManager = new IOManagerAsync();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReOpenableHashTableTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReOpenableHashTableTestBase.java
@@ -24,11 +24,11 @@ import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.operators.hash.NonReusingHashJoinIteratorITCase.TupleMatch;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.TestData;
@@ -87,7 +87,11 @@ public abstract class ReOpenableHashTableTestBase extends TestLogger {
 		this.recordProbeSideComparator = TestData.getIntIntTupleComparator();
 		this.pactRecordComparator = new GenericPairComparator(this.recordBuildSideComparator, this.recordProbeSideComparator);
 
-		this.memoryManager = new MemoryManager(MEMORY_SIZE, 1, PAGE_SIZE, MemoryType.HEAP, true);
+		this.memoryManager = MemoryManagerBuilder
+			.newBuilder()
+			.setMemorySize(MEMORY_SIZE)
+			.setPageSize(PAGE_SIZE)
+			.build();
 		this.ioManager = new IOManagerAsync();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReusingHashJoinIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReusingHashJoinIteratorITCase.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.operators.hash.NonReusingHashJoinIteratorITCase.TupleMatch;
 import org.apache.flink.runtime.operators.hash.NonReusingHashJoinIteratorITCase.TupleIntPairMatch;
 import org.apache.flink.runtime.operators.testutils.DiscardingOutputCollector;
@@ -106,7 +107,7 @@ public class ReusingHashJoinIteratorITCase extends TestLogger {
 		this.pairRecordPairComparator = new IntPairTuplePairComparator();
 		this.recordPairPairComparator = new TupleIntPairPairComparator();
 		
-		this.memoryManager = new MemoryManager(MEMORY_SIZE, 1);
+		this.memoryManager = MemoryManagerBuilder.newBuilder().setMemorySize(MEMORY_SIZE).build();
 		this.ioManager = new IOManagerAsync();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/resettable/BlockResettableMutableObjectIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/resettable/BlockResettableMutableObjectIteratorTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.operators.resettable;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.junit.Assert;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.testutils.recordutils.RecordSerializer;
@@ -54,7 +55,7 @@ public class BlockResettableMutableObjectIteratorTest {
 	@Before
 	public void startup() {
 		// set up IO and memory manager
-		this.memman = new MemoryManager(MEMORY_CAPACITY, 1);
+		this.memman = MemoryManagerBuilder.newBuilder().setMemorySize(MEMORY_CAPACITY).build();
 		
 		// create test objects
 		this.objects = new ArrayList<Record>(20000);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/resettable/NonReusingBlockResettableIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/resettable/NonReusingBlockResettableIteratorTest.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.junit.Assert;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.testutils.recordutils.RecordSerializer;
@@ -53,7 +54,7 @@ public class NonReusingBlockResettableIteratorTest {
 	@Before
 	public void startup() {
 		// set up IO and memory manager
-		this.memman = new MemoryManager(MEMORY_CAPACITY, 1);
+		this.memman = MemoryManagerBuilder.newBuilder().setMemorySize(MEMORY_CAPACITY).build();
 		
 		// create test objects
 		this.objects = new ArrayList<Record>(20000);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/resettable/ReusingBlockResettableIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/resettable/ReusingBlockResettableIteratorTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.operators.resettable;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.testutils.recordutils.RecordSerializer;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
@@ -52,7 +53,7 @@ public class ReusingBlockResettableIteratorTest {
 	@Before
 	public void startup() {
 		// set up IO and memory manager
-		this.memman = new MemoryManager(MEMORY_CAPACITY, 1);
+		this.memman = MemoryManagerBuilder.newBuilder().setMemorySize(MEMORY_CAPACITY).build();
 		
 		// create test objects
 		this.objects = new ArrayList<Record>(20000);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/resettable/SpillingResettableIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/resettable/SpillingResettableIteratorTest.java
@@ -24,11 +24,11 @@ import java.util.NoSuchElementException;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.IntValueSerializer;
-import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.types.IntValue;
 
@@ -57,7 +57,10 @@ public class SpillingResettableIteratorTest {
 	@Before
 	public void startup() {
 		// set up IO and memory manager
-		this.memman = new MemoryManager(MEMORY_CAPACITY, 1, 32 * 1024, MemoryType.HEAP, true);
+		this.memman = MemoryManagerBuilder
+			.newBuilder()
+			.setMemorySize(MEMORY_CAPACITY)
+			.build();
 		this.ioman = new IOManagerAsync();
 
 		// create test objects

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/resettable/SpillingResettableMutableObjectIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/resettable/SpillingResettableMutableObjectIteratorTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.operators.resettable;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.testutils.recordutils.RecordSerializer;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
@@ -54,7 +55,7 @@ public class SpillingResettableMutableObjectIteratorTest {
 	@Before
 	public void startup() {
 		// set up IO and memory manager
-		this.memman = new MemoryManager(MEMORY_CAPACITY, 1);
+		this.memman = MemoryManagerBuilder.newBuilder().setMemorySize(MEMORY_CAPACITY).build();
 		this.ioman = new IOManagerAsync();
 
 		// create test objects

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/AbstractSortMergeOuterJoinIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/AbstractSortMergeOuterJoinIteratorITCase.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.operators.testutils.CollectionIterator;
 import org.apache.flink.runtime.operators.testutils.DiscardingOutputCollector;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
@@ -104,7 +105,7 @@ public abstract class AbstractSortMergeOuterJoinIteratorITCase extends TestLogge
 		comparator2 = typeInfo2.createComparator(new int[]{0}, new boolean[]{true}, 0, config);
 		pairComp = new GenericPairComparator<>(comparator1, comparator2);
 
-		this.memoryManager = new MemoryManager(MEMORY_SIZE, 1);
+		this.memoryManager = MemoryManagerBuilder.newBuilder().setMemorySize(MEMORY_SIZE).build();
 		this.ioManager = new IOManagerAsync();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/CombiningUnilateralSortMergerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/CombiningUnilateralSortMergerITCase.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.TestData;
 import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator.KeyMode;
@@ -81,7 +82,7 @@ public class CombiningUnilateralSortMergerITCase extends TestLogger {
 	@SuppressWarnings("unchecked")
 	@Before
 	public void beforeTest() {
-		this.memoryManager = new MemoryManager(MEMORY_SIZE, 1);
+		this.memoryManager = MemoryManagerBuilder.newBuilder().setMemorySize(MEMORY_SIZE).build();
 		this.ioManager = new IOManagerAsync();
 		
 		this.serializerFactory1 = TestData.getIntStringTupleSerializerFactory();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/ExternalSortITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/ExternalSortITCase.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.RandomIntPairGenerator;
 import org.apache.flink.runtime.operators.testutils.TestData;
@@ -77,7 +78,7 @@ public class ExternalSortITCase extends TestLogger {
 	@SuppressWarnings("unchecked")
 	@Before
 	public void beforeTest() {
-		this.memoryManager = new MemoryManager(MEMORY_SIZE, 1);
+		this.memoryManager = MemoryManagerBuilder.newBuilder().setMemorySize(MEMORY_SIZE).build();
 		this.ioManager = new IOManagerAsync();
 		
 		this.pactRecordSerializer = TestData.getIntStringTupleSerializerFactory();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/ExternalSortLargeRecordsITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/ExternalSortLargeRecordsITCase.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.util.MutableObjectIterator;
 import org.apache.flink.util.TestLogger;
@@ -66,7 +67,7 @@ public class ExternalSortLargeRecordsITCase extends TestLogger {
 
 	@Before
 	public void beforeTest() {
-		this.memoryManager = new MemoryManager(MEMORY_SIZE, 1);
+		this.memoryManager = MemoryManagerBuilder.newBuilder().setMemorySize(MEMORY_SIZE).build();
 		this.ioManager = new IOManagerAsync();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/FixedLengthRecordSorterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/FixedLengthRecordSorterTest.java
@@ -24,7 +24,6 @@ import java.util.Random;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.io.disk.ChannelReaderInputViewIterator;
 import org.apache.flink.runtime.io.disk.iomanager.BlockChannelReader;
 import org.apache.flink.runtime.io.disk.iomanager.BlockChannelWriter;
@@ -34,6 +33,7 @@ import org.apache.flink.runtime.io.disk.iomanager.FileIOChannel;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.RandomIntPairGenerator;
 import org.apache.flink.runtime.operators.testutils.UniformIntPairGenerator;
@@ -66,7 +66,11 @@ public class FixedLengthRecordSorterTest {
 
 	@Before
 	public void beforeTest() {
-		this.memoryManager = new MemoryManager(MEMORY_SIZE, 1, MEMORY_PAGE_SIZE, MemoryType.HEAP, true);
+		this.memoryManager = MemoryManagerBuilder
+			.newBuilder()
+			.setMemorySize(MEMORY_SIZE)
+			.setPageSize(MEMORY_PAGE_SIZE)
+			.build();
 		this.ioManager = new IOManagerAsync();
 		this.serializer = new IntPairSerializer();
 		this.comparator = new IntPairComparator();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/LargeRecordHandlerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/LargeRecordHandlerITCase.java
@@ -29,7 +29,6 @@ import org.apache.flink.api.java.typeutils.ValueTypeInfo;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.io.disk.FileChannelOutputView;
 import org.apache.flink.runtime.io.disk.SeekableFileChannelInputView;
 import org.apache.flink.runtime.io.disk.iomanager.FileIOChannel;
@@ -37,6 +36,7 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.types.Value;
 import org.apache.flink.util.MutableObjectIterator;
@@ -63,7 +63,11 @@ public class LargeRecordHandlerITCase extends TestLogger {
 		final int NUM_RECORDS = 10;
 		
 		try (final IOManager ioMan = new IOManagerAsync()) {
-			final MemoryManager memMan = new MemoryManager(NUM_PAGES * PAGE_SIZE, 1, PAGE_SIZE, MemoryType.HEAP, true);
+			final MemoryManager memMan = MemoryManagerBuilder
+				.newBuilder()
+				.setMemorySize(NUM_PAGES * PAGE_SIZE)
+				.setPageSize(PAGE_SIZE)
+				.build();
 			final AbstractInvokable owner = new DummyInvokable();
 			
 			final List<MemorySegment> initialMemory = memMan.allocatePages(owner, 6);
@@ -195,7 +199,11 @@ public class LargeRecordHandlerITCase extends TestLogger {
 		FileIOChannel.ID channel = null;
 		
 		try (final IOManager ioMan = new IOManagerAsync()) {
-			final MemoryManager memMan = new MemoryManager(NUM_PAGES * PAGE_SIZE, 1, PAGE_SIZE, MemoryType.HEAP, true);
+			final MemoryManager memMan = MemoryManagerBuilder
+				.newBuilder()
+				.setMemorySize(NUM_PAGES * PAGE_SIZE)
+				.setPageSize(PAGE_SIZE)
+				.build();
 			final AbstractInvokable owner = new DummyInvokable();
 			
 			final List<MemorySegment> memory = memMan.allocatePages(owner, NUM_PAGES);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/LargeRecordHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/LargeRecordHandlerTest.java
@@ -32,11 +32,11 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.util.MutableObjectIterator;
 
@@ -50,7 +50,11 @@ public class LargeRecordHandlerTest {
 		final int NUM_PAGES = 50;
 		
 		try (final IOManager ioMan = new IOManagerAsync()) {
-			final MemoryManager memMan = new MemoryManager(NUM_PAGES * PAGE_SIZE, 1, PAGE_SIZE, MemoryType.HEAP, true);
+			final MemoryManager memMan = MemoryManagerBuilder
+				.newBuilder()
+				.setMemorySize(NUM_PAGES * PAGE_SIZE)
+				.setPageSize(PAGE_SIZE)
+				.build();
 			final AbstractInvokable owner = new DummyInvokable();
 			final List<MemorySegment> memory = memMan.allocatePages(owner, NUM_PAGES);
 			
@@ -95,7 +99,11 @@ public class LargeRecordHandlerTest {
 		final int NUM_RECORDS = 25000;
 		
 		try (final IOManager ioMan = new IOManagerAsync()) {
-			final MemoryManager memMan = new MemoryManager(NUM_PAGES * PAGE_SIZE, 1, PAGE_SIZE, MemoryType.HEAP, true);
+			final MemoryManager memMan = MemoryManagerBuilder
+				.newBuilder()
+				.setMemorySize(NUM_PAGES * PAGE_SIZE)
+				.setPageSize(PAGE_SIZE)
+				.build();
 			final AbstractInvokable owner = new DummyInvokable();
 			
 			final List<MemorySegment> initialMemory = memMan.allocatePages(owner, 6);
@@ -176,7 +184,11 @@ public class LargeRecordHandlerTest {
 		final int NUM_RECORDS = 25000;
 		
 		try (final IOManager ioMan = new IOManagerAsync()) {
-			final MemoryManager memMan = new MemoryManager(NUM_PAGES * PAGE_SIZE, 1, PAGE_SIZE, MemoryType.HEAP, true);
+			final MemoryManager memMan = MemoryManagerBuilder
+				.newBuilder()
+				.setMemorySize(NUM_PAGES * PAGE_SIZE)
+				.setPageSize(PAGE_SIZE)
+				.build();
 			final AbstractInvokable owner = new DummyInvokable();
 			
 			final List<MemorySegment> initialMemory = memMan.allocatePages(owner, 6);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/NonReusingSortMergeInnerJoinIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/NonReusingSortMergeInnerJoinIteratorITCase.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.operators.testutils.DiscardingOutputCollector;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.Match;
@@ -105,7 +106,7 @@ public class NonReusingSortMergeInnerJoinIteratorITCase extends TestLogger {
 				new TypeSerializer<?>[] { IntSerializer.INSTANCE });
 		pairComparator = new GenericPairComparator<Tuple2<Integer, String>, Tuple2<Integer, String>>(comparator1, comparator2);
 		
-		this.memoryManager = new MemoryManager(MEMORY_SIZE, 1);
+		this.memoryManager = MemoryManagerBuilder.newBuilder().setMemorySize(MEMORY_SIZE).build();
 		this.ioManager = new IOManagerAsync();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/NormalizedKeySorterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/NormalizedKeySorterTest.java
@@ -25,8 +25,8 @@ import org.apache.flink.api.common.typeutils.TypeComparator;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.TestData;
 import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator.KeyMode;
@@ -58,7 +58,11 @@ public class NormalizedKeySorterTest {
 
 	@Before
 	public void beforeTest() {
-		this.memoryManager = new MemoryManager(MEMORY_SIZE, 1, MEMORY_PAGE_SIZE, MemoryType.HEAP, true);
+		this.memoryManager = MemoryManagerBuilder
+			.newBuilder()
+			.setMemorySize(MEMORY_SIZE)
+			.setPageSize(MEMORY_PAGE_SIZE)
+			.build();
 	}
 
 	@After

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/ReusingSortMergeInnerJoinIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/ReusingSortMergeInnerJoinIteratorITCase.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.operators.testutils.DiscardingOutputCollector;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.Match;
@@ -105,7 +106,7 @@ public class ReusingSortMergeInnerJoinIteratorITCase extends TestLogger {
 				new TypeSerializer<?>[] { IntSerializer.INSTANCE });
 		pairComparator = new GenericPairComparator<Tuple2<Integer, String>, Tuple2<Integer, String>>(comparator1, comparator2);
 
-		this.memoryManager = new MemoryManager(MEMORY_SIZE, 1);
+		this.memoryManager = MemoryManagerBuilder.newBuilder().setMemorySize(MEMORY_SIZE).build();
 		this.ioManager = new IOManagerAsync();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/UnilateralSortMergerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/UnilateralSortMergerTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.disk.iomanager.ChannelWriterOutputView;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.TestData;
 import org.apache.flink.runtime.util.EmptyMutableObjectIterator;
@@ -51,7 +52,10 @@ public class UnilateralSortMergerTest extends TestLogger {
 		final TestingInMemorySorterFactory<Tuple2<Integer, Integer>> inMemorySorterFactory = new TestingInMemorySorterFactory<>();
 
 		final int numPages = 32;
-		final MemoryManager memoryManager = new MemoryManager(MemoryManager.DEFAULT_PAGE_SIZE * numPages, 1);
+		final MemoryManager memoryManager = MemoryManagerBuilder
+			.newBuilder()
+			.setMemorySize(MemoryManager.DEFAULT_PAGE_SIZE * numPages)
+			.build();
 		final DummyInvokable parentTask = new DummyInvokable();
 
 		try (final IOManagerAsync ioManager = new IOManagerAsync()) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/BinaryOperatorTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/BinaryOperatorTestBase.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.Driver;
@@ -102,7 +103,7 @@ public abstract class BinaryOperatorTestBase<S extends Function, IN, OUT> extend
 		this.perSortMem = perSortMemory;
 		this.perSortFractionMem = (double) perSortMemory / totalMem;
 		this.ioManager = new IOManagerAsync();
-		this.memManager = totalMem > 0 ? new MemoryManager(totalMem, 1) : null;
+		this.memManager = totalMem > 0 ? MemoryManagerBuilder.newBuilder().setMemorySize(totalMem).build() : null;
 		
 		this.inputs = new ArrayList<>();
 		this.comparators = new ArrayList<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DriverTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DriverTestBase.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.Driver;
@@ -107,7 +108,7 @@ public abstract class DriverTestBase<S extends Function> extends TestLogger impl
 		this.perSortMem = perSortMemory;
 		this.perSortFractionMem = (double)perSortMemory/totalMem;
 		this.ioManager = new IOManagerAsync();
-		this.memManager = totalMem > 0 ? new MemoryManager(totalMem,1) : null;
+		this.memManager = totalMem > 0 ? MemoryManagerBuilder.newBuilder().setMemorySize(totalMem).build() : null;
 
 		this.inputs = new ArrayList<MutableObjectIterator<Record>>();
 		this.comparators = new ArrayList<TypeComparator<Record>>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.io.network.util.TestPooledBufferProvider;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
@@ -144,7 +145,7 @@ public class MockEnvironment implements Environment, AutoCloseable {
 		this.inputs = new LinkedList<InputGate>();
 		this.outputs = new LinkedList<ResultPartitionWriter>();
 
-		this.memManager = new MemoryManager(memorySize, 1);
+		this.memManager = MemoryManagerBuilder.newBuilder().setMemorySize(memorySize).build();
 		this.ioManager = new IOManagerAsync();
 		this.taskManagerRuntimeInfo = taskManagerRuntimeInfo;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/UnaryOperatorTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/UnaryOperatorTestBase.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.Driver;
@@ -108,7 +109,7 @@ public abstract class UnaryOperatorTestBase<S extends Function, IN, OUT> extends
 		this.perSortMem = perSortMemory;
 		this.perSortFractionMem = (double)perSortMemory/totalMem;
 		this.ioManager = new IOManagerAsync();
-		this.memManager = totalMem > 0 ? new MemoryManager(totalMem, 1) : null;
+		this.memManager = totalMem > 0 ? MemoryManagerBuilder.newBuilder().setMemorySize(totalMem).build() : null;
 		this.owner = new DummyInvokable();
 
 		Configuration config = new Configuration();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/util/HashVsSortMiniBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/util/HashVsSortMiniBenchmark.java
@@ -24,11 +24,11 @@ import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializerFactory;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.operators.hash.ReusingBuildFirstHashJoinIterator;
 import org.apache.flink.runtime.operators.hash.ReusingBuildSecondHashJoinIterator;
 import org.apache.flink.runtime.operators.sort.ReusingMergeInnerJoinIterator;
@@ -92,7 +92,11 @@ public class HashVsSortMiniBenchmark {
 		this.comparator2 = TestData.getIntStringTupleComparator();
 		this.pairComparator11 = new GenericPairComparator(this.comparator1, this.comparator2);
 		
-		this.memoryManager = new MemoryManager(MEMORY_SIZE, 1, PAGE_SIZE, MemoryType.HEAP, true);
+		this.memoryManager = MemoryManagerBuilder
+			.newBuilder()
+			.setMemorySize(MEMORY_SIZE)
+			.setPageSize(PAGE_SIZE)
+			.build();
 		this.ioManager = new IOManagerAsync();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -26,7 +26,6 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.TransientBlobKey;
@@ -71,6 +70,7 @@ import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalListener;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.query.KvStateRegistry;
@@ -273,12 +273,12 @@ public class TaskExecutorTest extends TestLogger {
 			ioManager.getSpillingDirectories(),
 			Executors.directExecutor());
 
-		final MemoryManager memoryManager = new MemoryManager(
-			4096,
-			1,
-			4096,
-			MemoryType.HEAP,
-			false);
+		final MemoryManager memoryManager = MemoryManagerBuilder
+			.newBuilder()
+			.setMemorySize(4096)
+			.setPageSize(4096)
+			.setPreAllocateMemory(false)
+			.build();
 
 		nettyShuffleEnvironment.start();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -277,7 +277,6 @@ public class TaskExecutorTest extends TestLogger {
 			.newBuilder()
 			.setMemorySize(4096)
 			.setPageSize(4096)
-			.setPreAllocateMemory(false)
 			.build();
 
 		nettyShuffleEnvironment.start();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerStartupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerStartupTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.taskexecutor;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
-import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.blob.BlobCacheService;
@@ -47,7 +46,6 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -120,7 +118,6 @@ public class TaskManagerRunnerStartupTest extends TestLogger {
 	@Test
 	public void testMemoryConfigWrong() throws Exception {
 		Configuration cfg = new Configuration();
-		cfg.setBoolean(TaskManagerOptions.MANAGED_MEMORY_PRE_ALLOCATE, true);
 
 		// something invalid
 		cfg.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "-42m");
@@ -134,23 +131,6 @@ public class TaskManagerRunnerStartupTest extends TestLogger {
 			fail("Should fail synchronously with an exception");
 		} catch (IllegalConfigurationException e) {
 			// splendid!
-		}
-
-		// something ridiculously high
-		final long memSize = (((long) Integer.MAX_VALUE - 1) *
-			MemorySize.parse(TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue()).getBytes()) >> 20;
-		cfg.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, memSize + "m");
-		try {
-
-			startTaskManager(
-				cfg,
-				rpcService,
-				highAvailabilityServices);
-
-			fail("Should fail synchronously with an exception");
-		} catch (Exception e) {
-			// splendid!
-			assertTrue(e.getCause() instanceof OutOfMemoryError);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
@@ -57,7 +57,6 @@ public class TaskManagerServicesBuilder {
 			.newBuilder()
 			.setMemorySize(MemoryManager.MIN_PAGE_SIZE)
 			.setPageSize(MemoryManager.MIN_PAGE_SIZE)
-			.setPreAllocateMemory(false)
 			.build();
 		ioManager = mock(IOManager.class);
 		shuffleEnvironment = mock(ShuffleEnvironment.class);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
@@ -18,9 +18,9 @@
 
 package org.apache.flink.runtime.taskexecutor;
 
-import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
 import org.apache.flink.runtime.memory.MemoryManager;
@@ -53,12 +53,12 @@ public class TaskManagerServicesBuilder {
 
 	public TaskManagerServicesBuilder() {
 		taskManagerLocation = new LocalTaskManagerLocation();
-		memoryManager = new MemoryManager(
-			MemoryManager.MIN_PAGE_SIZE,
-			1,
-			MemoryManager.MIN_PAGE_SIZE,
-			MemoryType.HEAP,
-			false);
+		memoryManager = MemoryManagerBuilder
+			.newBuilder()
+			.setMemorySize(MemoryManager.MIN_PAGE_SIZE)
+			.setPageSize(MemoryManager.MIN_PAGE_SIZE)
+			.setPreAllocateMemory(false)
+			.build();
 		ioManager = mock(IOManager.class);
 		shuffleEnvironment = mock(ShuffleEnvironment.class);
 		kvStateService = new KvStateService(new KvStateRegistry(), null, null);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TestTaskBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TestTaskBuilder.java
@@ -43,6 +43,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNo
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
@@ -187,7 +188,7 @@ public final class TestTaskBuilder {
 			resultPartitions,
 			inputGates,
 			0,
-			new MemoryManager(1024 * 1024, 1),
+			MemoryManagerBuilder.newBuilder().setMemorySize(1024 * 1024).build(),
 			mock(IOManager.class),
 			shuffleEnvironment,
 			kvStateService,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
@@ -43,6 +43,7 @@ import org.apache.flink.runtime.filecache.FileCache;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironmentBuilder;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
 import org.apache.flink.runtime.taskexecutor.NoOpPartitionProducerStateChecker;
@@ -161,7 +162,7 @@ public class JvmExitOnFatalErrorTest {
 				final TaskInformation taskInformation = new TaskInformation(
 						jobVertexId, "Test Task", 1, 1, OomInvokable.class.getName(), new Configuration());
 
-				final MemoryManager memoryManager = new MemoryManager(1024 * 1024, 1);
+				final MemoryManager memoryManager = MemoryManagerBuilder.newBuilder().setMemorySize(1024 * 1024).build();
 				final IOManager ioManager = new IOManagerAsync();
 
 				final ShuffleEnvironment<?, ?> shuffleEnvironment = new NettyShuffleEnvironmentBuilder().build();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
@@ -41,6 +41,7 @@ import org.apache.flink.runtime.io.network.util.TestPooledBufferProvider;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
@@ -153,7 +154,7 @@ public class StreamMockEnvironment implements Environment {
 		this.taskConfiguration = taskConfig;
 		this.inputs = new LinkedList<InputGate>();
 		this.outputs = new LinkedList<ResultPartitionWriter>();
-		this.memManager = new MemoryManager(memorySize, 1);
+		this.memManager = MemoryManagerBuilder.newBuilder().setMemorySize(memorySize).build();
 		this.ioManager = new IOManagerAsync();
 		this.taskStateManager = Preconditions.checkNotNull(taskStateManager);
 		this.aggregateManager = new TestGlobalAggregateManager();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -49,7 +49,7 @@ import org.apache.flink.runtime.io.network.partition.NoOpResultPartitionConsumab
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
-import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
@@ -166,7 +166,7 @@ public class StreamTaskTerminationTest extends TestLogger {
 			Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 			Collections.<InputGateDeploymentDescriptor>emptyList(),
 			0,
-			new MemoryManager(32L * 1024L, 1),
+			MemoryManagerBuilder.newBuilder().setMemorySize(32L * 1024L).build(),
 			new IOManagerAsync(),
 			shuffleEnvironment,
 			new KvStateService(new KvStateRegistry(), null, null),

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/hashtable/BinaryHashTableTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/hashtable/BinaryHashTableTest.java
@@ -22,11 +22,11 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.memory.MemoryAllocationException;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.operators.testutils.UnionIterator;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.dataformat.BaseRow;
@@ -132,7 +132,7 @@ public class BinaryHashTableTest {
 
 		// create a probe input that gives 10 million pairs with 10 values sharing a key
 		MutableObjectIterator<BinaryRow> probeInput = new UniformBinaryRowGenerator(numKeys, probeValsPerKey, true);
-		MemoryManager memManager = new MemoryManager(896 * PAGE_SIZE, 1);
+		MemoryManager memManager = MemoryManagerBuilder.newBuilder().setMemorySize(896 * PAGE_SIZE).build();
 		// ----------------------------------------------------------------------------------------
 		final BinaryHashTable table = newBinaryHashTable(
 				this.buildSideSerializer, this.probeSideSerializer,
@@ -218,7 +218,11 @@ public class BinaryHashTableTest {
 		MutableObjectIterator<BinaryRow> probeInput = new UniformBinaryRowGenerator(numKeys, probeValsPerKey, true);
 
 		// allocate the memory for the HashTable
-		MemoryManager memManager = new MemoryManager(200 * PAGE_SIZE, 1, PAGE_SIZE, MemoryType.HEAP, true);
+		MemoryManager memManager = MemoryManagerBuilder
+			.newBuilder()
+			.setMemorySize(200 * PAGE_SIZE)
+			.setPageSize(PAGE_SIZE)
+			.build();
 		final BinaryHashTable table = newBinaryHashTable(
 				this.buildSideSerializer,
 				this.probeSideSerializer,
@@ -257,7 +261,7 @@ public class BinaryHashTableTest {
 		HashMap<Integer, Long> map = new HashMap<>(numKeys);
 
 		// ----------------------------------------------------------------------------------------
-		MemoryManager memManager = new MemoryManager(896 * PAGE_SIZE, 1);
+		MemoryManager memManager = MemoryManagerBuilder.newBuilder().setMemorySize(896 * PAGE_SIZE).build();
 		final BinaryHashTable table = newBinaryHashTable(
 				this.buildSideSerializer, this.probeSideSerializer,
 				new MyProjection(), new MyProjection(), memManager,
@@ -332,7 +336,7 @@ public class BinaryHashTableTest {
 
 		// create the map for validating the results
 		HashMap<Integer, Long> map = new HashMap<>(numKeys);
-		MemoryManager memManager = new MemoryManager(896 * PAGE_SIZE, 1);
+		MemoryManager memManager = MemoryManagerBuilder.newBuilder().setMemorySize(896 * PAGE_SIZE).build();
 		// ----------------------------------------------------------------------------------------
 
 		final BinaryHashTable table = newBinaryHashTable(
@@ -450,7 +454,7 @@ public class BinaryHashTableTest {
 		HashMap<Integer, Long> map = new HashMap<>(numKeys);
 
 		// ----------------------------------------------------------------------------------------
-		MemoryManager memManager = new MemoryManager(896 * PAGE_SIZE, 1);
+		MemoryManager memManager = MemoryManagerBuilder.newBuilder().setMemorySize(896 * PAGE_SIZE).build();
 		final BinaryHashTable table = newBinaryHashTable(
 				this.buildSideSerializer, this.probeSideSerializer,
 				new MyProjection(), new MyProjection(), memManager,
@@ -529,7 +533,7 @@ public class BinaryHashTableTest {
 		probes.add(probe3);
 		MutableObjectIterator<BinaryRow> probeInput = new UnionIterator<>(probes);
 		// ----------------------------------------------------------------------------------------
-		MemoryManager memManager = new MemoryManager(896 * PAGE_SIZE, 1);
+		MemoryManager memManager = MemoryManagerBuilder.newBuilder().setMemorySize(896 * PAGE_SIZE).build();
 		final BinaryHashTable table = newBinaryHashTable(
 				this.buildSideSerializer, this.probeSideSerializer,
 				new MyProjection(), new MyProjection(), memManager,
@@ -562,7 +566,7 @@ public class BinaryHashTableTest {
 
 		MutableObjectIterator<BinaryRow> buildInput = new UniformBinaryRowGenerator(
 				numBuildKeys, numBuildVals, false);
-		MemoryManager memManager = new MemoryManager(128 * PAGE_SIZE, 1);
+		MemoryManager memManager = MemoryManagerBuilder.newBuilder().setMemorySize(128 * PAGE_SIZE).build();
 		final BinaryHashTable table = newBinaryHashTable(
 				this.buildSideSerializer, this.probeSideSerializer,
 				new MyProjection(), new MyProjection(), memManager,
@@ -593,7 +597,7 @@ public class BinaryHashTableTest {
 
 		MutableObjectIterator<BinaryRow> buildInput = new UniformBinaryRowGenerator(
 				numBuildKeys, numBuildVals, false);
-		MemoryManager memManager = new MemoryManager(96 * PAGE_SIZE, 1);
+		MemoryManager memManager = MemoryManagerBuilder.newBuilder().setMemorySize(96 * PAGE_SIZE).build();
 		final BinaryHashTable table = new BinaryHashTable(conf, new Object(),
 				this.buildSideSerializer, this.probeSideSerializer,
 				new MyProjection(), new MyProjection(), memManager, 96 * PAGE_SIZE,
@@ -622,7 +626,7 @@ public class BinaryHashTableTest {
 		final int numProbeVals = 1;
 
 		MutableObjectIterator<BinaryRow> buildInput = new UniformBinaryRowGenerator(numBuildKeys, numBuildVals, false);
-		MemoryManager memManager = new MemoryManager(85 * PAGE_SIZE, 1);
+		MemoryManager memManager = MemoryManagerBuilder.newBuilder().setMemorySize(85 * PAGE_SIZE).build();
 		final BinaryHashTable table = newBinaryHashTable(
 				this.buildSideSerializer, this.probeSideSerializer,
 				new MyProjection(), new MyProjection(), memManager,
@@ -653,7 +657,7 @@ public class BinaryHashTableTest {
 		MutableObjectIterator<BinaryRow> probeInput = new UniformBinaryRowGenerator(numKeys, probeValsPerKey, true);
 
 		// allocate the memory for the HashTable
-		MemoryManager memManager = new MemoryManager(35 * PAGE_SIZE, 1);
+		MemoryManager memManager = MemoryManagerBuilder.newBuilder().setMemorySize(35 * PAGE_SIZE).build();
 		// ----------------------------------------------------------------------------------------
 
 		final BinaryHashTable table = new BinaryHashTable(conf, new Object(),
@@ -694,7 +698,7 @@ public class BinaryHashTableTest {
 
 		// create a probe input that gives 20000 pairs with 1 values sharing a key
 		MutableObjectIterator<BinaryRow> probeInput = new UniformBinaryRowGenerator(numKeys, probeValsPerKey, true);
-		MemoryManager memManager = new MemoryManager(35 * PAGE_SIZE, 1);
+		MemoryManager memManager = MemoryManagerBuilder.newBuilder().setMemorySize(35 * PAGE_SIZE).build();
 		// allocate the memory for the HashTable
 		final BinaryHashTable table = new BinaryHashTable(conf, new Object(),
 				this.buildSideSerializer, this.probeSideSerializer,
@@ -727,7 +731,7 @@ public class BinaryHashTableTest {
 		MutableObjectIterator<BinaryRow> probeInput = new UniformBinaryRowGenerator(numKeys, probeValsPerKey, true);
 
 		// allocate the memory for the HashTable
-		MemoryManager memManager = new MemoryManager(35 * PAGE_SIZE, 1);
+		MemoryManager memManager = MemoryManagerBuilder.newBuilder().setMemorySize(35 * PAGE_SIZE).build();
 		final BinaryHashTable table = newBinaryHashTable(
 				this.buildSideSerializer, this.probeSideSerializer,
 				new MyProjection(), new MyProjection(), memManager,
@@ -746,7 +750,7 @@ public class BinaryHashTableTest {
 	public void testRepeatBuildJoin() throws Exception {
 		final int numKeys = 500;
 		final int probeValsPerKey = 1;
-		MemoryManager memManager = new MemoryManager(40 * PAGE_SIZE, 1);
+		MemoryManager memManager = MemoryManagerBuilder.newBuilder().setMemorySize(40 * PAGE_SIZE).build();
 		MutableObjectIterator<BinaryRow> buildInput = new MutableObjectIterator<BinaryRow>() {
 
 			int cnt = 0;
@@ -815,7 +819,7 @@ public class BinaryHashTableTest {
 				return row;
 			}
 		};
-		MemoryManager memManager = new MemoryManager(35 * PAGE_SIZE, 1);
+		MemoryManager memManager = MemoryManagerBuilder.newBuilder().setMemorySize(35 * PAGE_SIZE).build();
 		MutableObjectIterator<BinaryRow> probeInput = new UniformBinaryRowGenerator(numKeys, probeValsPerKey, true);
 
 		final BinaryHashTable table = new BinaryHashTable(

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/hashtable/LongHashTableTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/hashtable/LongHashTableTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.memory.MemoryAllocationException;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.operators.testutils.UnionIterator;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.dataformat.BaseRow;
@@ -60,7 +61,7 @@ public class LongHashTableTest {
 	private IOManager ioManager;
 	private BinaryRowSerializer buildSideSerializer;
 	private BinaryRowSerializer probeSideSerializer;
-	private MemoryManager memManager = new MemoryManager(896 * PAGE_SIZE, 1);
+	private MemoryManager memManager = MemoryManagerBuilder.newBuilder().setMemorySize(896 * PAGE_SIZE).build();
 
 	private boolean useCompress;
 	private Configuration conf;

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/aggregate/BytesHashMapTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/aggregate/BytesHashMapTest.java
@@ -20,9 +20,9 @@ package org.apache.flink.table.runtime.operators.aggregate;
 
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
-import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.io.disk.RandomAccessInputView;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.table.dataformat.BinaryRow;
 import org.apache.flink.table.dataformat.BinaryRowWriter;
 import org.apache.flink.table.dataformat.BinaryString;
@@ -95,7 +95,11 @@ public class BytesHashMapTest {
 				rowLength(RowType.of(keyTypes)),
 				PAGE_SIZE);
 		int memorySize = numMemSegments * PAGE_SIZE;
-		MemoryManager memoryManager = new MemoryManager(numMemSegments * PAGE_SIZE, 32);
+		MemoryManager memoryManager = MemoryManagerBuilder
+			.newBuilder()
+			.setMemorySize(numMemSegments * PAGE_SIZE)
+			.setNumberOfSlots(32)
+			.build();
 
 		BytesHashMap table = new BytesHashMap(this, memoryManager,
 				memorySize, keyTypes, new LogicalType[]{});
@@ -117,7 +121,11 @@ public class BytesHashMapTest {
 				rowLength(RowType.of(keyTypes)),
 				PAGE_SIZE);
 		int memorySize = numMemSegments * PAGE_SIZE;
-		MemoryManager memoryManager = new MemoryManager(memorySize, 32);
+		MemoryManager memoryManager = MemoryManagerBuilder
+			.newBuilder()
+			.setMemorySize(memorySize)
+			.setNumberOfSlots(32)
+			.build();
 
 		BytesHashMap table = new BytesHashMap(this, memoryManager,
 				memorySize, keyTypes, valueTypes);
@@ -141,7 +149,11 @@ public class BytesHashMapTest {
 				PAGE_SIZE);
 		int memorySize = numMemSegments * PAGE_SIZE;
 
-		MemoryManager memoryManager = new MemoryManager(memorySize, 32);
+		MemoryManager memoryManager = MemoryManagerBuilder
+			.newBuilder()
+			.setMemorySize(memorySize)
+			.setNumberOfSlots(32)
+			.build();
 
 		BytesHashMap table = new BytesHashMap(this, memoryManager,
 				memorySize, keyTypes, valueTypes);
@@ -165,7 +177,11 @@ public class BytesHashMapTest {
 
 		int memorySize = numMemSegments * PAGE_SIZE;
 
-		MemoryManager memoryManager = new MemoryManager(memorySize, 32);
+		MemoryManager memoryManager = MemoryManagerBuilder
+			.newBuilder()
+			.setMemorySize(memorySize)
+			.setNumberOfSlots(32)
+			.build();
 
 		BytesHashMap table = new BytesHashMap(this, memoryManager,
 				memorySize, keyTypes, valueTypes);
@@ -191,9 +207,11 @@ public class BytesHashMapTest {
 
 		int minMemorySize = reservedMemSegments * PAGE_SIZE;
 
-		MemoryManager memoryManager = new MemoryManager(
-				minMemorySize, 32, MemoryManager.DEFAULT_PAGE_SIZE,
-				MemoryType.HEAP, true);
+		MemoryManager memoryManager = MemoryManagerBuilder
+			.newBuilder()
+			.setMemorySize(minMemorySize)
+			.setNumberOfSlots(32)
+			.build();
 		BytesHashMap table = new BytesHashMap(this, memoryManager,
 				minMemorySize, keyTypes, valueTypes, true);
 
@@ -265,7 +283,11 @@ public class BytesHashMapTest {
 				PAGE_SIZE);
 
 		int memorySize = numMemSegments * PAGE_SIZE;
-		MemoryManager memoryManager = new MemoryManager(memorySize, 32);
+		MemoryManager memoryManager = MemoryManagerBuilder
+			.newBuilder()
+			.setMemorySize(memorySize)
+			.setNumberOfSlots(32)
+			.build();
 		BytesHashMap table = new BytesHashMap(this, memoryManager,
 				memorySize, keyTypes, valueTypes);
 		final Random rnd = new Random(RANDOM_SEED);

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/aggregate/HashAggTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/aggregate/HashAggTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.dataformat.GenericRow;
@@ -43,7 +44,7 @@ public class HashAggTest {
 	private static final int MEMORY_SIZE = 1024 * 1024 * 32;
 
 	private Map<Integer, Long> outputMap = new HashMap<>();
-	private MemoryManager memoryManager = new MemoryManager(MEMORY_SIZE, 1);
+	private MemoryManager memoryManager = MemoryManagerBuilder.newBuilder().setMemorySize(MEMORY_SIZE).build();
 	private IOManager ioManager;
 	private SumHashAggTestOperator operator;
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/Int2SortMergeJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/Int2SortMergeJoinOperatorTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.runtime.operators.join;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.table.dataformat.BinaryRow;
 import org.apache.flink.table.runtime.generated.GeneratedJoinCondition;
@@ -71,7 +72,7 @@ public class Int2SortMergeJoinOperatorTest {
 
 	@Before
 	public void setup() {
-		this.memManager = new MemoryManager(36 * 1024 * 1024, 1);
+		this.memManager = MemoryManagerBuilder.newBuilder().setMemorySize(36 * 1024 * 1024).build();
 		this.ioManager = new IOManagerAsync();
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/SortMergeJoinIteratorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/SortMergeJoinIteratorTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.memory.MemoryAllocationException;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.dataformat.BinaryRow;
 import org.apache.flink.table.dataformat.BinaryRowWriter;
@@ -73,7 +74,7 @@ public class SortMergeJoinIteratorTest {
 
 	@Before
 	public void before() throws MemoryAllocationException {
-		this.memManager = new MemoryManager(MEMORY_SIZE, 1);
+		this.memManager = MemoryManagerBuilder.newBuilder().setMemorySize(MEMORY_SIZE).build();
 		this.ioManager = new IOManagerAsync();
 		this.serializer = new BinaryRowSerializer(1);
 	}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/BufferDataOverWindowOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/BufferDataOverWindowOperatorTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -69,7 +70,7 @@ public class BufferDataOverWindowOperatorTest {
 			new RowType.RowField("f0", new BigIntType())));
 
 	private List<GenericRow> collect;
-	private MemoryManager memoryManager = new MemoryManager(MEMORY_SIZE, 1);
+	private MemoryManager memoryManager = MemoryManagerBuilder.newBuilder().setMemorySize(MEMORY_SIZE).build();
 	private IOManager ioManager;
 	private BufferDataOverWindowOperator operator;
 	private GeneratedRecordComparator boundComparator = new GeneratedRecordComparator("", "", new Object[0]) {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/sort/BinaryExternalSorterTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/sort/BinaryExternalSorterTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.dataformat.BinaryRow;
@@ -94,7 +95,7 @@ public class BinaryExternalSorterTest {
 	@SuppressWarnings("unchecked")
 	@Before
 	public void beforeTest() {
-		this.memoryManager = new MemoryManager(MEMORY_SIZE, 1);
+		this.memoryManager = MemoryManagerBuilder.newBuilder().setMemorySize(MEMORY_SIZE).build();
 		this.serializer = new BinaryRowSerializer(2);
 		this.conf.setInteger(ExecutionConfigOptions.TABLE_EXEC_SORT_MAX_NUM_FILE_HANDLES, 128);
 	}
@@ -121,7 +122,7 @@ public class BinaryExternalSorterTest {
 		LOG.debug("initializing sortmerger");
 
 		//there are two sort buffer if sortMemory > 100 * 1024 * 1024.
-		MemoryManager memoryManager = new MemoryManager(1024 * 1024 * 101, 1);
+		MemoryManager memoryManager = MemoryManagerBuilder.newBuilder().setMemorySize(1024 * 1024 * 101).build();
 		long minMemorySize = memoryManager.computeNumberOfPages(1) * MemoryManager.DEFAULT_PAGE_SIZE;
 		BinaryExternalSorter sorter = new BinaryExternalSorter(
 				new Object(),

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/ResettableExternalBufferTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/ResettableExternalBufferTest.java
@@ -21,6 +21,7 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.memory.MemoryAllocationException;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.table.dataformat.BinaryRow;
 import org.apache.flink.table.dataformat.BinaryRowWriter;
 import org.apache.flink.table.dataformat.BinaryString;
@@ -62,7 +63,7 @@ public class ResettableExternalBufferTest {
 
 	@Before
 	public void before() {
-		this.memManager = new MemoryManager(MEMORY_SIZE, 1);
+		this.memManager = MemoryManagerBuilder.newBuilder().setMemorySize(MEMORY_SIZE).build();
 		this.ioManager = new IOManagerAsync();
 		this.random = new Random();
 		this.serializer = new BinaryRowSerializer(1);

--- a/flink-tests/src/test/java/org/apache/flink/test/manual/MassiveStringSorting.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/manual/MassiveStringSorting.java
@@ -30,6 +30,7 @@ import org.apache.flink.api.java.typeutils.runtime.RuntimeSerializerFactory;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.operators.sort.UnilateralSortMerger;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.util.MutableObjectIterator;
@@ -85,7 +86,7 @@ public class MassiveStringSorting {
 			MemoryManager mm = null;
 
 			try (IOManager ioMan = new IOManagerAsync()) {
-				mm = new MemoryManager(1024 * 1024, 1);
+				mm = MemoryManagerBuilder.newBuilder().setMemorySize(1024 * 1024).build();
 
 				TypeSerializer<String> serializer = StringSerializer.INSTANCE;
 				TypeComparator<String> comparator = new StringComparator(true);
@@ -179,7 +180,7 @@ public class MassiveStringSorting {
 			MemoryManager mm = null;
 
 			try (IOManager ioMan = new IOManagerAsync()) {
-				mm = new MemoryManager(1024 * 1024, 1);
+				mm = MemoryManagerBuilder.newBuilder().setMemorySize(1024 * 1024).build();
 
 				TupleTypeInfo<Tuple2<String, String[]>> typeInfo = (TupleTypeInfo<Tuple2<String, String[]>>)
 						new TypeHint<Tuple2<String, String[]>>(){}.getTypeInfo();

--- a/flink-tests/src/test/java/org/apache/flink/test/manual/MassiveStringValueSorting.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/manual/MassiveStringValueSorting.java
@@ -30,6 +30,7 @@ import org.apache.flink.api.java.typeutils.runtime.RuntimeSerializerFactory;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.operators.sort.UnilateralSortMerger;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.types.StringValue;
@@ -86,7 +87,7 @@ public class MassiveStringValueSorting {
 			MemoryManager mm = null;
 
 			try (IOManager ioMan = new IOManagerAsync()) {
-				mm = new MemoryManager(1024 * 1024, 1);
+				mm = MemoryManagerBuilder.newBuilder().setMemorySize(1024 * 1024).build();
 
 				TypeSerializer<StringValue> serializer = new CopyableValueSerializer<StringValue>(StringValue.class);
 				TypeComparator<StringValue> comparator = new CopyableValueComparator<StringValue>(true, StringValue.class);
@@ -183,7 +184,7 @@ public class MassiveStringValueSorting {
 			MemoryManager mm = null;
 
 			try (IOManager ioMan = new IOManagerAsync()) {
-				mm = new MemoryManager(1024 * 1024, 1);
+				mm = MemoryManagerBuilder.newBuilder().setMemorySize(1024 * 1024).build();
 
 				TupleTypeInfo<Tuple2<StringValue, StringValue[]>> typeInfo = (TupleTypeInfo<Tuple2<StringValue, StringValue[]>>)
 						new TypeHint<Tuple2<StringValue, StringValue[]>>(){}.getTypeInfo();

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/manual/MassiveCaseClassSortingITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/manual/MassiveCaseClassSortingITCase.scala
@@ -27,11 +27,10 @@ import org.apache.flink.api.common.typeutils.CompositeType
 import org.apache.flink.api.java.typeutils.runtime.RuntimeSerializerFactory
 import org.apache.flink.api.scala._
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync
-import org.apache.flink.runtime.memory.MemoryManager
+import org.apache.flink.runtime.memory.MemoryManagerBuilder
 import org.apache.flink.runtime.operators.sort.UnilateralSortMerger
 import org.apache.flink.runtime.operators.testutils.DummyInvokable
 import org.apache.flink.util.{MutableObjectIterator, TestLogger}
-
 import org.junit.Assert._
 
 /**
@@ -90,7 +89,7 @@ class MassiveCaseClassSortingITCase extends TestLogger {
           0,
           new ExecutionConfig)
         
-        val mm = new MemoryManager(1024 * 1024, 1)
+        val mm = MemoryManagerBuilder.newBuilder.setMemorySize(1024 * 1024).build
         val ioMan = new IOManagerAsync()
         
         sorter = new UnilateralSortMerger[StringTuple](mm, ioMan, inputIterator,


### PR DESCRIPTION
Mirror of apache flink#9693
## What is the purpose of the change

This does some refactoring to prepare and then changes the MemoryManager to serve both types of memory at the same time: HEAP and OFF_HEAP. Additionally to paged segments, it adds API to reserve arbitrary sized chunks of memory.

## Brief change log

  - some cleanup in MemoryManager
  - add MemoryManagerBuilder for tests
  - deprecate memory preallocation in MemoryManager
  - implement KeyedBudget to atomically track available memory per type up to the limit.
  - change MemoryManager to use KeyedBudget instead of internal locking
  - switch to concurrent hash maps for owner tracking in MemoryManager
  - add another type of memory to MemoryManager
  - Implement reservation of memory chunks in MemoryManager

## Verifying this change

Existing and newly added unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

