### PR TITLE
Mirror of apache flink#9691

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigOption.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigOption.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.description.Description;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -193,6 +194,27 @@ public class ConfigOption<T> {
 	 */
 	public T defaultValue() {
 		return defaultValue;
+	}
+
+	/**
+	 * Checks whether this option has deprecated keys.
+	 * @return True if the option has deprecated keys, false if not.
+	 * @deprecated Replaced by {@link #hasFallbackKeys()}
+	 */
+	@Deprecated
+	public boolean hasDeprecatedKeys() {
+		return hasFallbackKeys();
+	}
+
+	/**
+	 * Gets the deprecated keys, in the order to be checked.
+	 * @return The option's deprecated keys.
+	 * @deprecated Replaced by {@link #fallbackKeys()}
+	 */
+	@Deprecated
+	public Iterable<String> deprecatedKeys() {
+		return fallbackKeys == EMPTY ? Collections.<String>emptyList() :
+			Arrays.stream(fallbackKeys).map(fallbackKey -> fallbackKey.getKey()).collect(Collectors.toList());
 	}
 
 	/**

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigOptionTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigOptionTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.util.TestLogger;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -86,4 +87,19 @@ public class ConfigOptionTest extends TestLogger {
 		assertThat(fallbackKeys, containsInAnyOrder("fallback1", "fallback2"));
 		assertThat(deprecatedKeys, containsInAnyOrder("deprecated1", "deprecated2"));
 	}
+
+	@Test
+	public void testDeprecationForDeprecatedKeys() {
+		String[] deprecatedKeys = new String[] { "deprecated1", "deprecated2" };
+		final ConfigOption<Integer> optionWithDeprecatedKeys = ConfigOptions
+			.key("key")
+			.defaultValue(0)
+			.withDeprecatedKeys(deprecatedKeys);
+
+		assertTrue(optionWithDeprecatedKeys.hasDeprecatedKeys());
+		for (final String deprecatedKey : optionWithDeprecatedKeys.deprecatedKeys()) {
+			assertTrue(Arrays.stream(deprecatedKeys).anyMatch(item -> item.equals(deprecatedKey)));
+		}
+	}
+
 }


### PR DESCRIPTION
Mirror of apache flink#9691


## What is the purpose of the change

*This pull request reversed two deleted method `hasDeprecatedKeys` and `deprecatedKeys`, then marked them with `<at>Deprecated`*


## Brief change log

  - *Reversed two deleted methods*
  - *Added test case for the two methods*


## Verifying this change


This change is already covered by existing tests, such as *testDeprecationForDeprecatedKeys*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)

