### PR TITLE
Mirror of apache flink#9689

### DIFF
--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -22,7 +22,9 @@
   # List of additional classes and packages to import.
   # Example. "org.apache.calcite.sql.*", "java.util.List".
   imports: [
+    "org.apache.flink.sql.parser.ddl.SqlCreateFunction",
     "org.apache.flink.sql.parser.ddl.SqlCreateTable",
+    "org.apache.flink.sql.parser.ddl.SqlDropFunction",
     "org.apache.flink.sql.parser.ddl.SqlDropTable"
     "org.apache.flink.sql.parser.ddl.SqlCreateTable.TableCreationContext",
     "org.apache.flink.sql.parser.ddl.SqlCreateView",
@@ -428,6 +430,7 @@
   # List of methods for parsing extensions to "CREATE [OR REPLACE]" calls.
   # Each must accept arguments "(SqlParserPos pos, boolean replace)".
   createStatementParserMethods: [
+    "SqlCreateFunction",
     "SqlCreateTable",
     "SqlCreateView"
   ]
@@ -435,6 +438,7 @@
   # List of methods for parsing extensions to "DROP" calls.
   # Each must accept arguments "(Span s)".
   dropStatementParserMethods: [
+    "SqlDropFunction",
     "SqlDropTable",
     "SqlDropView"
   ]

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -155,6 +155,24 @@ SqlNodeList TableProperties():
     {  return new SqlNodeList(proList, span.end(this)); }
 }
 
+SqlCreate SqlCreateFunction(Span s, boolean replace) :
+{
+    SqlIdentifier functionName = null;
+    SqlCharStringLiteral functionClassName = null;
+}
+{
+    <FUNCTION>
+
+    functionName = CompoundIdentifier()
+    [ <AS> <QUOTED_STRING> {
+        String p = SqlParserUtil.parseString(token.image);
+        functionClassName = SqlLiteral.createCharString(p, getPos());
+    }]
+    {
+        return new SqlCreateFunction(s.pos(), functionName, functionClassName);
+    }
+}
+
 SqlCreate SqlCreateTable(Span s, boolean replace) :
 {
     final SqlParserPos startPos = s.pos();
@@ -228,6 +246,27 @@ SqlDrop SqlDropTable(Span s, boolean replace) :
 
     {
          return new SqlDropTable(s.pos(), tableName, ifExists);
+    }
+}
+
+SqlDrop SqlDropFunction(Span s, boolean replace) :
+{
+    SqlIdentifier functionName = null;
+    boolean ifExists = false;
+}
+{
+    <FUNCTION>
+
+    (
+        <IF> <EXISTS> { ifExists = true; }
+    |
+        { ifExists = false; }
+    )
+
+    functionName = CompoundIdentifier()
+
+    {
+        return new SqlDropFunction(s.pos(), functionName, ifExists);
     }
 }
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateFunction.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateFunction.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.ddl;
+
+import org.apache.flink.sql.parser.ExtendedSqlNode;
+import org.apache.flink.sql.parser.error.SqlParseException;
+
+import org.apache.calcite.sql.SqlCharStringLiteral;
+import org.apache.calcite.sql.SqlCreate;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import javax.annotation.Nonnull;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * CREATE FUNCTION DDL sql call.
+ */
+public class SqlCreateFunction extends SqlCreate implements ExtendedSqlNode {
+	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("CREATE FUNCTION", SqlKind.CREATE_FUNCTION);
+
+	private SqlIdentifier functionName;
+	private SqlCharStringLiteral functionClassName;
+
+	public SqlCreateFunction(
+		SqlParserPos pos,
+		SqlIdentifier functionName,
+		SqlCharStringLiteral functionClassName) {
+		super(OPERATOR, pos, false, false);
+		this.functionName = requireNonNull(functionName);
+		this.functionClassName = requireNonNull(functionClassName);
+	}
+
+	@Nonnull
+	@Override
+	public List<SqlNode> getOperandList() {
+		return ImmutableNullableList.of(functionName, functionClassName);
+	}
+
+	@Override
+	public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+		writer.keyword("CREATE");
+		writer.keyword("FUNCTION");
+		if (ifNotExists) {
+			writer.keyword("IF NOT EXISTS");
+		}
+		functionName.unparse(writer, leftPrec, rightPrec);
+		writer.keyword("AS");
+		functionClassName.unparse(writer, leftPrec, rightPrec);
+	}
+
+	@Override
+	public void validate() throws SqlParseException {
+		// no-op
+	}
+
+	public boolean isIfNotExists() {
+		return ifNotExists;
+	}
+
+	public SqlIdentifier getFunctionName() {
+		return this.functionName;
+	}
+
+	public SqlCharStringLiteral getFunctionClassName() {
+		return this.functionClassName;
+	}
+
+	public String[] fullFunctionName() {
+		return functionName.names.toArray(new String[0]);
+	}
+}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropFunction.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropFunction.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.ddl;
+
+import org.apache.flink.sql.parser.ExtendedSqlNode;
+import org.apache.flink.sql.parser.error.SqlParseException;
+
+import org.apache.calcite.sql.SqlDrop;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import javax.annotation.Nonnull;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * DROP FUNCTION DDL sql call.
+ */
+public class SqlDropFunction extends SqlDrop implements ExtendedSqlNode {
+	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("DROP FUNCTION", SqlKind.DROP_FUNCTION);
+
+	private SqlIdentifier functionName;
+	protected final boolean ifExists;
+
+	public SqlDropFunction(SqlParserPos pos, SqlIdentifier functionName, boolean ifExists) {
+		super(OPERATOR, pos, ifExists);
+		this.functionName = requireNonNull(functionName);
+		this.ifExists = ifExists;
+	}
+
+	@Nonnull
+	@Override
+	public List<SqlNode> getOperandList() {
+		return ImmutableNullableList.of(functionName);
+	}
+
+	@Override
+	public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+		writer.keyword("DROP");
+		writer.keyword("FUNCTION");
+		if (ifExists) {
+			writer.keyword("IF EXISTS");
+		}
+		functionName.unparse(writer, leftPrec, rightPrec);
+	}
+
+	@Override
+	public void validate() throws SqlParseException {
+		// no-op
+	}
+
+	public String[] fullFunctionName() {
+		return functionName.names.toArray(new String[0]);
+	}
+
+	public boolean getIfExists() {
+		return this.ifExists;
+	}
+}

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -524,6 +524,24 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 	}
 
 	@Test
+	public void testCreateFunction() {
+		String sql = "CREATE FUNCTION catalog1.db1.function1 AS 'org.apache.fink.function.function1'";
+		check(sql, "CREATE FUNCTION `CATALOG1`.`DB1`.`FUNCTION1` AS 'org.apache.fink.function.function1'");
+	}
+
+	@Test
+	public void testDropFunction() {
+		String sql = "DROP FUNCTION catalog1.db1.function1";
+		check(sql, "DROP FUNCTION `CATALOG1`.`DB1`.`FUNCTION1`");
+	}
+
+	@Test
+	public void testDropFunctionIfExists() {
+		String sql = "DROP FUNCTION IF EXISTS catalog1.db1.function1";
+		check(sql, "DROP FUNCTION IF EXISTS `CATALOG1`.`DB1`.`FUNCTION1`");
+	}
+
+	@Test
 	public void testInsertPartitionSpecs() {
 		conformance0 = FlinkSqlConformance.HIVE;
 		final String sql1 = "insert into emps(x,y) partition (x='ab', y='bc') select * from emps";

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -54,7 +54,9 @@ import org.apache.flink.table.operations.ModifyOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.QueryOperation;
 import org.apache.flink.table.operations.TableSourceQueryOperation;
+import org.apache.flink.table.operations.ddl.CreateFunctionOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
+import org.apache.flink.table.operations.ddl.DropFunctionOperation;
 import org.apache.flink.table.operations.ddl.DropTableOperation;
 import org.apache.flink.table.operations.utils.OperationTreeBuilder;
 import org.apache.flink.table.sinks.TableSink;
@@ -351,6 +353,21 @@ public class TableEnvironmentImpl implements TableEnvironment {
 			DropTableOperation dropTableOperation = (DropTableOperation) operation;
 			ObjectIdentifier objectIdentifier = catalogManager.qualifyIdentifier(dropTableOperation.getTableName());
 			catalogManager.dropTable(objectIdentifier, dropTableOperation.isIfExists());
+		} else if (operation instanceof CreateFunctionOperation) {
+			CreateFunctionOperation createFunctionOperation = (CreateFunctionOperation) operation;
+			ObjectIdentifier objectIdentifier =
+				catalogManager.qualifyIdentifier(createFunctionOperation.getFunctionPath());
+			catalogManager.createFunction(
+				createFunctionOperation.getCatalogFunction(),
+				objectIdentifier,
+				createFunctionOperation.isIgnoreIfExists());
+		} else if (operation instanceof DropTableOperation) {
+			DropFunctionOperation dropFunctionOperation = (DropFunctionOperation) operation;
+			ObjectIdentifier objectIdentifier =
+				catalogManager.qualifyIdentifier(dropFunctionOperation.getFunctionPath());
+			catalogManager.dropFunction(
+				objectIdentifier,
+				dropFunctionOperation.isIfExists());
 		} else {
 			throw new TableException(
 				"Unsupported SQL query! sqlUpdate() only accepts a single SQL statements of " +

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -317,6 +317,35 @@ public class CatalogManager {
 	}
 
 	/**
+	 * Create a function in a given fully qualified path.
+	 *
+	 * @param catalogFunction  The function to put in the given path
+	 * @param objectIdentifier
+	 * @param ignoreIfExists
+	 */
+	public void createFunction(CatalogFunction catalogFunction, ObjectIdentifier objectIdentifier, boolean ignoreIfExists) {
+		execute(
+			(catalog, path) -> catalog.createFunction(path, catalogFunction, ignoreIfExists),
+			objectIdentifier,
+			ignoreIfExists,
+			"CreateFunction");
+	}
+
+	/**
+	 * Drops a function in a given fully qualified path.
+	 *
+	 * @param objectIdentifier
+	 * @param ignoreIfExists
+	 */
+	public void dropFunction(ObjectIdentifier objectIdentifier, boolean ignoreIfExists) {
+		execute(
+			(catalog, path) -> catalog.dropFunction(path, ignoreIfExists),
+			objectIdentifier,
+			ignoreIfExists,
+			"DropFunction");
+	}
+
+	/**
 	 * A command that modifies given {@link Catalog} in an {@link ObjectPath}. This unifies error handling
 	 * across different commands.
 	 */

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateFunctionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateFunctionOperation.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.ddl;
+
+import org.apache.flink.table.catalog.CatalogFunction;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.OperationUtils;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Operation to describe a CREATE FUNCTION statement.
+ */
+public class CreateFunctionOperation implements CreateOperation {
+	private final String[] functionPath;
+	private CatalogFunction catalogFunction;
+	private boolean ignoreIfExists;
+
+	public CreateFunctionOperation(
+		String[] functionPath,
+		CatalogFunction catalogFunction,
+		boolean ignoreIfExists) {
+		this.functionPath = functionPath;
+		this.catalogFunction = catalogFunction;
+		this.ignoreIfExists = ignoreIfExists;
+	}
+
+	public String[] getFunctionPath() {
+		return functionPath;
+	}
+
+	public boolean isIgnoreIfExists() {
+		return ignoreIfExists;
+	}
+
+	public CatalogFunction getCatalogFunction() {
+		return catalogFunction;
+	}
+
+	@Override
+	public String asSummaryString() {
+		Map<String, Object> params = new LinkedHashMap<>();
+		params.put("catalogFunction", catalogFunction.getProperties());
+		params.put("functionPath", functionPath);
+		params.put("ignoreIfExists", ignoreIfExists);
+
+		return OperationUtils.formatWithChildren(
+			"CREATE FUNCTION",
+			params,
+			Collections.emptyList(),
+			Operation::asSummaryString);
+	}
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropFunctionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropFunctionOperation.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.ddl;
+
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.OperationUtils;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Operation to describe a DROP FUNCTION statement.
+ */
+public class DropFunctionOperation implements DropOperation {
+	private final String[] functionName;
+	private final boolean ifExists;
+
+	public DropFunctionOperation(String[] functionName, boolean ifExists) {
+		this.functionName = functionName;
+		this.ifExists = ifExists;
+	}
+
+	public String[] getFunctionPath() {
+		return this.functionName;
+	}
+
+	public boolean isIfExists() {
+		return this.ifExists;
+	}
+
+	@Override
+	public String asSummaryString() {
+		Map<String, Object> params = new LinkedHashMap<>();
+		params.put("functionName", functionName);
+		params.put("IfExists", ifExists);
+
+		return OperationUtils.formatWithChildren(
+			"DROP FUNCTION",
+			params,
+			Collections.emptyList(),
+			Operation::asSummaryString);
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -18,18 +18,24 @@
 
 package org.apache.flink.table.planner.operations;
 
+import org.apache.flink.sql.parser.ddl.SqlCreateFunction;
 import org.apache.flink.sql.parser.ddl.SqlCreateTable;
+import org.apache.flink.sql.parser.ddl.SqlDropFunction;
 import org.apache.flink.sql.parser.ddl.SqlDropTable;
 import org.apache.flink.sql.parser.ddl.SqlTableColumn;
 import org.apache.flink.sql.parser.ddl.SqlTableOption;
 import org.apache.flink.sql.parser.dml.RichSqlInsert;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.CatalogFunction;
+import org.apache.flink.table.catalog.CatalogFunctionImpl;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.operations.CatalogSinkModifyOperation;
 import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.ddl.CreateFunctionOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
+import org.apache.flink.table.operations.ddl.DropFunctionOperation;
 import org.apache.flink.table.operations.ddl.DropTableOperation;
 import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
@@ -85,6 +91,10 @@ public class SqlToOperationConverter {
 			return converter.convertCreateTable((SqlCreateTable) validated);
 		} if (validated instanceof SqlDropTable) {
 			return converter.convertDropTable((SqlDropTable) validated);
+		} else if (validated instanceof SqlCreateFunction) {
+			return converter.convertCreateFunction((SqlCreateFunction) validated);
+		} else if (validated instanceof SqlDropFunction) {
+			return converter.convertDropFunction((SqlDropFunction) validated);
 		} else if (validated instanceof RichSqlInsert) {
 			return converter.convertSqlInsert((RichSqlInsert) validated);
 		} else if (validated.getKind().belongsTo(SqlKind.QUERY)) {
@@ -143,6 +153,23 @@ public class SqlToOperationConverter {
 	/** Convert DROP TABLE statement. */
 	private Operation convertDropTable(SqlDropTable sqlDropTable) {
 		return new DropTableOperation(sqlDropTable.fullTableName(), sqlDropTable.getIfExists());
+	}
+
+	/** Convert CREATE FUNCTION statement. */
+	private Operation convertCreateFunction(SqlCreateFunction sqlCreateFunction) {
+		CatalogFunction catalogFunction =
+			new CatalogFunctionImpl(
+				sqlCreateFunction.getFunctionClassName().toString(),
+				new HashMap<String, String>());
+		return new CreateFunctionOperation(
+			sqlCreateFunction.fullFunctionName(),
+			catalogFunction,
+			sqlCreateFunction.isIfNotExists());
+	}
+
+	/** Convert CREATE FUNCTION statement. */
+	private Operation convertDropFunction(SqlDropFunction sqlDropFunction) {
+		return  new DropFunctionOperation(sqlDropFunction.fullFunctionName(), sqlDropFunction.getIfExists());
 	}
 
 	/** Convert insert into statement. */

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -18,7 +18,9 @@
 
 package org.apache.flink.table.sqlexec;
 
+import org.apache.flink.sql.parser.ddl.SqlCreateFunction;
 import org.apache.flink.sql.parser.ddl.SqlCreateTable;
+import org.apache.flink.sql.parser.ddl.SqlDropFunction;
 import org.apache.flink.sql.parser.ddl.SqlDropTable;
 import org.apache.flink.sql.parser.ddl.SqlTableColumn;
 import org.apache.flink.sql.parser.ddl.SqlTableOption;
@@ -28,12 +30,16 @@ import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.calcite.FlinkPlannerImpl;
 import org.apache.flink.table.calcite.FlinkTypeFactory;
 import org.apache.flink.table.calcite.FlinkTypeSystem;
+import org.apache.flink.table.catalog.CatalogFunction;
+import org.apache.flink.table.catalog.CatalogFunctionImpl;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.operations.CatalogSinkModifyOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.PlannerQueryOperation;
+import org.apache.flink.table.operations.ddl.CreateFunctionOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
+import org.apache.flink.table.operations.ddl.DropFunctionOperation;
 import org.apache.flink.table.operations.ddl.DropTableOperation;
 import org.apache.flink.table.types.utils.TypeConversions;
 
@@ -86,6 +92,10 @@ public class SqlToOperationConverter {
 			return converter.convertCreateTable((SqlCreateTable) validated);
 		} if (validated instanceof SqlDropTable) {
 			return converter.convertDropTable((SqlDropTable) validated);
+		} else if (validated instanceof SqlCreateFunction) {
+			return converter.convertCreateFunction((SqlCreateFunction) validated);
+		} else if (validated instanceof SqlDropFunction) {
+			return converter.convertDropFunction((SqlDropFunction) validated);
 		} else if (validated instanceof RichSqlInsert) {
 			return converter.convertSqlInsert((RichSqlInsert) validated);
 		} else if (validated.getKind().belongsTo(SqlKind.QUERY)) {
@@ -144,6 +154,23 @@ public class SqlToOperationConverter {
 	/** Convert DROP TABLE statement. */
 	private Operation convertDropTable(SqlDropTable sqlDropTable) {
 		return new DropTableOperation(sqlDropTable.fullTableName(), sqlDropTable.getIfExists());
+	}
+
+	/** Convert CREATE FUNCTION statement. */
+	private Operation convertCreateFunction(SqlCreateFunction sqlCreateFunction) {
+		CatalogFunction catalogFunction =
+			new CatalogFunctionImpl(
+				sqlCreateFunction.getFunctionClassName().toString(),
+				new HashMap<String, String>());
+		return new CreateFunctionOperation(
+			sqlCreateFunction.fullFunctionName(),
+			catalogFunction,
+			sqlCreateFunction.isIfNotExists());
+	}
+
+	/** Convert CREATE FUNCTION statement. */
+	private Operation convertDropFunction(SqlDropFunction sqlDropFunction) {
+		return  new DropFunctionOperation(sqlDropFunction.fullFunctionName(), sqlDropFunction.getIfExists());
 	}
 
 	/** Fallback method for sql query. */

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
@@ -18,7 +18,9 @@
 
 package org.apache.flink.table.sqlexec;
 
+import org.apache.flink.sql.parser.ddl.SqlCreateFunction;
 import org.apache.flink.sql.parser.ddl.SqlCreateTable;
+import org.apache.flink.sql.parser.ddl.SqlDropFunction;
 import org.apache.flink.sql.parser.dml.RichSqlInsert;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.SqlDialect;
@@ -28,6 +30,7 @@ import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.Types;
 import org.apache.flink.table.calcite.FlinkPlannerImpl;
 import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.CatalogFunction;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.CatalogManagerCalciteSchema;
 import org.apache.flink.table.catalog.CatalogTable;
@@ -42,7 +45,9 @@ import org.apache.flink.table.expressions.ExpressionBridge;
 import org.apache.flink.table.expressions.PlannerExpressionConverter;
 import org.apache.flink.table.operations.CatalogSinkModifyOperation;
 import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.ddl.CreateFunctionOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
+import org.apache.flink.table.operations.ddl.DropFunctionOperation;
 import org.apache.flink.table.planner.PlanningConfigurationBuilder;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.utils.TypeConversions;
@@ -50,6 +55,7 @@ import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.calcite.sql.SqlNode;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -401,6 +407,29 @@ public class SqlToOperationConverterTest {
 			expectedEx.expectMessage(item.expectedError);
 			SqlToOperationConverter.convert(planner, node);
 		}
+	}
+
+	@Ignore("Blocked CALCITE-3349")
+	public void testCreateFunction() {
+		final String sql = "CREATE FUNCTION func1 AS 'org.apache.flink.function.function1'";
+		final FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
+		SqlNode node = planner.parse(sql);
+		assert node instanceof SqlCreateFunction;
+		Operation operation = SqlToOperationConverter.convert(planner, node);
+		assert operation instanceof CreateFunctionOperation;
+		CreateFunctionOperation op = (CreateFunctionOperation) operation;
+		CatalogFunction catalogFunction = op.getCatalogFunction();
+		assertEquals("org.apache.flink.function.function1", catalogFunction.getClassName());
+	}
+
+	@Ignore("Blocked CALCITE-3349")
+	public void testDropFunction() {
+		final String sql = "DROP FUNCTION func1";
+		final FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
+		SqlNode node = planner.parse(sql);
+		assert node instanceof SqlDropFunction;
+		Operation operation = SqlToOperationConverter.convert(planner, node);
+		assert operation instanceof DropFunctionOperation;
 	}
 
 	//~ Tool Methods ----------------------------------------------------------


### PR DESCRIPTION
Mirror of apache flink#9689
## What is the purpose of the change

Add basic function DDL in Parser and register function to the table environments

## Brief change log

1) Add SqlCreateFunction and SqlDropFunction DDL sql Call
2) Add CreatFunction and DropFunction operations

## Verifying this change
1) Add test cases in FlinkSqlParserImplTest for parser verify on function DDL.
2) Add test cases in SqlToOperationConverterTest for planner verification.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)

