### PR TITLE
Mirror of apache flink#9688

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FastRestartPipelinedRegionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FastRestartPipelinedRegionStrategy.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.failover.flip1;
+
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+
+/**
+ * This failover strategy makes the same restart decision as {@link RestartPipelinedRegionStrategy}.
+ * It has better failover handling performance at the cost of slower region building and more memory
+ * used for region boundary cache. See FLINK-13056.
+ */
+public class FastRestartPipelinedRegionStrategy extends RestartPipelinedRegionStrategy {
+
+	/** Maps a failover region to its input result partitions. */
+	private final IdentityHashMap<FailoverRegion, Collection<IntermediateResultPartitionID>> regionInputs;
+
+	/** Maps a failover region to its consumer regions. */
+	private final IdentityHashMap<FailoverRegion, Collection<FailoverRegion>> regionConsumers;
+
+	/** Maps result partition id to its producer failover region. Only for inter-region consumed partitions.*/
+	private final Map<IntermediateResultPartitionID, FailoverRegion> partitionProducer;
+
+	/**
+	 * Creates a new failover strategy to restart pipelined regions that works on the given topology.
+	 *
+	 * @param topology containing info about all the vertices and edges
+	 * @param resultPartitionAvailabilityChecker helps to query result partition availability
+	 */
+	public FastRestartPipelinedRegionStrategy(
+			final FailoverTopology topology,
+			final ResultPartitionAvailabilityChecker resultPartitionAvailabilityChecker) {
+
+		super(topology, resultPartitionAvailabilityChecker);
+
+		this.regionInputs = new IdentityHashMap<>();
+		this.regionConsumers = new IdentityHashMap<>();
+		this.partitionProducer = new HashMap<>();
+		buildRegionInputsAndOutputs();
+	}
+
+	private void buildRegionInputsAndOutputs() {
+		for (FailoverRegion region : regions) {
+			final IdentityHashMap<FailoverRegion, Object> consumers = new IdentityHashMap<>();
+			final Set<IntermediateResultPartitionID> inputs = new HashSet<>();
+			final Set<ExecutionVertexID> consumerVertices = new HashSet<>();
+			final Set<FailoverVertex> regionVertices = region.getAllExecutionVertices();
+			regionVertices.forEach(v -> {
+				for (FailoverEdge inEdge : v.getInputEdges()) {
+					if (!regionVertices.contains(inEdge.getSourceVertex())) {
+						inputs.add(inEdge.getResultPartitionID());
+					}
+				}
+				for (FailoverEdge outEdge : v.getOutputEdges()) {
+					if (!regionVertices.contains(outEdge.getTargetVertex())) {
+						this.partitionProducer.put(outEdge.getResultPartitionID(), region);
+						consumerVertices.add(outEdge.getTargetVertex().getExecutionVertexID());
+					}
+				}
+			});
+			this.regionInputs.put(region, new ArrayList<>(inputs));
+			consumerVertices.forEach(id -> consumers.put(vertexToRegionMap.get(id), null));
+			this.regionConsumers.put(region, new ArrayList<>(consumers.keySet()));
+		}
+	}
+
+	@Override
+	protected void calculateProducerRegionsToVisit(
+		final FailoverRegion currentRegion,
+		final Queue<FailoverRegion> regionsToVisit,
+		final Set<FailoverRegion> visitedRegions) {
+
+		for (IntermediateResultPartitionID intermediateResultPartitionID : regionInputs.get(currentRegion)) {
+			if (!resultPartitionAvailabilityChecker.isAvailable(intermediateResultPartitionID)) {
+				final FailoverRegion producerRegion = partitionProducer.get(intermediateResultPartitionID);
+				if (!visitedRegions.contains(producerRegion)) {
+					visitedRegions.add(producerRegion);
+					regionsToVisit.add(producerRegion);
+				}
+			}
+		}
+	}
+
+	@Override
+	protected void calculateConsumerRegionsToVisit(
+		final FailoverRegion currentRegion,
+		final Queue<FailoverRegion> regionsToVisit,
+		final Set<FailoverRegion> visitedRegions) {
+
+		for (FailoverRegion consumerRegion : regionConsumers.get(currentRegion)) {
+			if (!visitedRegions.contains(consumerRegion)) {
+				visitedRegions.add(consumerRegion);
+				regionsToVisit.add(consumerRegion);
+			}
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/FastRestartPipelinedRegionStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/FastRestartPipelinedRegionStrategyTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.failover.flip1;
+
+/**
+ * Tests the failure handling logic of {@link FastRestartPipelinedRegionStrategy}.
+ */
+public class FastRestartPipelinedRegionStrategyTest extends RestartPipelinedRegionStrategyTest {
+
+	@Override
+	protected FailoverStrategy createFailoverStrategy(FailoverTopology topology) {
+		return new FastRestartPipelinedRegionStrategy(topology, resultPartitionID -> true);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionStrategyTest.java
@@ -58,7 +58,7 @@ public class RestartPipelinedRegionStrategyTest extends TestLogger {
 	 * Each vertex is in an individual region.
 	 */
 	@Test
-	public void testRegionFailoverForRegionInternalErrors() throws Exception {
+	public void testRegionFailoverForRegionInternalErrors() {
 		TestFailoverTopology.Builder topologyBuilder = new TestFailoverTopology.Builder();
 
 		TestFailoverTopology.TestFailoverVertex v1 = topologyBuilder.newVertex();
@@ -138,7 +138,7 @@ public class RestartPipelinedRegionStrategyTest extends TestLogger {
 	 * Each vertex is in an individual region.
 	 */
 	@Test
-	public void testRegionFailoverForDataConsumptionErrors() throws Exception {
+	public void testRegionFailoverForDataConsumptionErrors() {
 		TestFailoverTopology.Builder topologyBuilder = new TestFailoverTopology.Builder();
 
 		TestFailoverTopology.TestFailoverVertex v1 = topologyBuilder.newVertex();
@@ -239,7 +239,7 @@ public class RestartPipelinedRegionStrategyTest extends TestLogger {
 	 * rp1, rp2 are result partitions.
 	 */
 	@Test
-	public void testRegionFailoverForVariousResultPartitionAvailabilityCombinations() throws Exception {
+	public void testRegionFailoverForVariousResultPartitionAvailabilityCombinations() {
 		TestFailoverTopology.Builder topologyBuilder = new TestFailoverTopology.Builder();
 
 		TestFailoverTopology.TestFailoverVertex v1 = topologyBuilder.newVertex();
@@ -354,7 +354,7 @@ public class RestartPipelinedRegionStrategyTest extends TestLogger {
 	 * Component 1: 1,2; component 2: 3,4; component 3: 5,6
 	 */
 	@Test
-	public void testRegionFailoverForMultipleVerticesRegions() throws Exception {
+	public void testRegionFailoverForMultipleVerticesRegions() {
 		TestFailoverTopology.Builder topologyBuilder = new TestFailoverTopology.Builder();
 
 		TestFailoverTopology.TestFailoverVertex v1 = topologyBuilder.newVertex();
@@ -419,10 +419,6 @@ public class RestartPipelinedRegionStrategyTest extends TestLogger {
 
 		public void markResultPartitionFailed(IntermediateResultPartitionID resultPartitionID) {
 			failedPartitions.add(resultPartitionID);
-		}
-
-		public void removeResultPartitionFromFailedState(IntermediateResultPartitionID resultPartitionID) {
-			failedPartitions.remove(resultPartitionID);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionStrategyTest.java
@@ -76,7 +76,7 @@ public class RestartPipelinedRegionStrategyTest extends TestLogger {
 
 		FailoverTopology topology = topologyBuilder.build();
 
-		RestartPipelinedRegionStrategy strategy = new RestartPipelinedRegionStrategy(topology);
+		FailoverStrategy strategy = createFailoverStrategy(topology);
 
 		// when v1 fails, {v1,v4,v5} should be restarted
 		HashSet<ExecutionVertexID> expectedResult = new HashSet<>();
@@ -156,7 +156,7 @@ public class RestartPipelinedRegionStrategyTest extends TestLogger {
 
 		FailoverTopology topology = topologyBuilder.build();
 
-		RestartPipelinedRegionStrategy strategy = new RestartPipelinedRegionStrategy(topology);
+		FailoverStrategy strategy = createFailoverStrategy(topology);
 
 		// when v4 fails to consume data from v1, {v1,v4,v5} should be restarted
 		HashSet<ExecutionVertexID> expectedResult = new HashSet<>();
@@ -372,7 +372,7 @@ public class RestartPipelinedRegionStrategyTest extends TestLogger {
 
 		FailoverTopology topology = topologyBuilder.build();
 
-		RestartPipelinedRegionStrategy strategy = new RestartPipelinedRegionStrategy(topology);
+		FailoverStrategy strategy = createFailoverStrategy(topology);
 
 		// when v3 fails due to internal error, {v3,v4,v5,v6} should be restarted
 		HashSet<ExecutionVertexID> expectedResult = new HashSet<>();
@@ -403,6 +403,10 @@ public class RestartPipelinedRegionStrategyTest extends TestLogger {
 	// ------------------------------------------------------------------------
 	//  utilities
 	// ------------------------------------------------------------------------
+
+	protected FailoverStrategy createFailoverStrategy(FailoverTopology topology) {
+		return new RestartPipelinedRegionStrategy(topology);
+	}
 
 	private static class TestResultPartitionAvailabilityChecker implements ResultPartitionAvailabilityChecker {
 


### PR DESCRIPTION
Mirror of apache flink#9688
## What is the purpose of the change

*Currently some region boundary structures are calculated each time of a region failover. This calculation can be heavy as its complexity goes up with execution edge count.*
*More details and testing results can be found at [FLINK-13056](https://issues.apache.org/jira/browse/FLINK-13056).*


## Brief change log

  - *Added FastRestartPipelinedRestartStrategy*

## Verifying this change

  - *Unit test added*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

