### PR TITLE
Mirror of apache flink#9686

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/TimeUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/TimeUtils.java
@@ -19,7 +19,11 @@
 package org.apache.flink.util;
 
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -29,14 +33,28 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public class TimeUtils {
 
+	private static final Map<String, ChronoUnit> LABEL_TO_UNIT_MAP = Collections.unmodifiableMap(initMap());
+
 	/**
 	 * Parse the given string to a java {@link Duration}.
-	 * The string is like "123ms", "321s", "12min" and such.
+	 * The string is in format "{length value}{time unit label}", e.g. "123ms", "321 s".
+	 * If no time unit label is specified, it will be considered as milliseconds.
+	 *
+	 * <p>Supported time unit labels are:
+	 * <ul>
+	 *     <li>DAYS： "d", "day"</li>
+	 *     <li>HOURS： "h", "hour"</li>
+	 *     <li>MINUTES： "min", "minute"</li>
+	 *     <li>SECONDS： "s", "sec", "second"</li>
+	 *     <li>MILLISECONDS： "ms", "milli", "millisecond"</li>
+	 *     <li>MICROSECONDS： "µs", "micro", "microsecond"</li>
+	 *     <li>NANOSECONDS： "ns", "nano", "nanosecond"</li>
+	 * </ul>
 	 *
 	 * @param text string to parse.
 	 */
 	public static Duration parseDuration(String text) {
-		checkNotNull(text, "text");
+		checkNotNull(text);
 
 		final String trimmed = text.trim();
 		checkArgument(!trimmed.isEmpty(), "argument is an empty- or whitespace-only string");
@@ -50,7 +68,7 @@ public class TimeUtils {
 		}
 
 		final String number = trimmed.substring(0, pos);
-		final String unit = trimmed.substring(pos).trim().toLowerCase(Locale.US);
+		final String unitLabel = trimmed.substring(pos).trim().toLowerCase(Locale.US);
 
 		if (number.isEmpty()) {
 			throw new NumberFormatException("text does not start with a number");
@@ -64,64 +82,68 @@ public class TimeUtils {
 				"' cannot be re represented as 64bit number (numeric overflow).");
 		}
 
-		final long multiplier;
-		if (unit.isEmpty()) {
-			multiplier = 1L;
+		if (unitLabel.isEmpty()) {
+			return Duration.of(value, ChronoUnit.MILLIS);
+		}
+
+		ChronoUnit unit = LABEL_TO_UNIT_MAP.get(unitLabel);
+		if (unit != null) {
+			return Duration.of(value, unit);
 		} else {
-			if (matchTimeUnit(unit, TimeUnit.MILLISECONDS)) {
-				multiplier = 1L;
-			} else if (matchTimeUnit(unit, TimeUnit.SECONDS)) {
-				multiplier = 1000L;
-			} else if (matchTimeUnit(unit, TimeUnit.MINUTES)) {
-				multiplier = 1000L * 60L;
-			} else if (matchTimeUnit(unit, TimeUnit.HOURS)) {
-				multiplier = 1000L * 60L * 60L;
-			} else {
-				throw new IllegalArgumentException("Time interval unit '" + unit +
-					"' does not match any of the recognized units: " + TimeUnit.getAllUnits());
-			}
+			throw new IllegalArgumentException("Time interval unit label '" + unitLabel +
+				"' does not match any of the recognized units: " + TimeUnit.getAllUnits());
 		}
-
-		final long result = value * multiplier;
-
-		// check for overflow
-		if (result / multiplier != value) {
-			throw new IllegalArgumentException("The value '" + text +
-				"' cannot be re represented as 64bit number of bytes (numeric overflow).");
-		}
-
-		return Duration.ofMillis(result);
 	}
 
-	private static boolean matchTimeUnit(String text, TimeUnit unit) {
-		return text.equals(unit.getUnit());
+	private static Map<String, ChronoUnit> initMap() {
+		Map<String, ChronoUnit> labelToUnit = new HashMap<>();
+		for (TimeUnit timeUnit : TimeUnit.values()) {
+			for (String label : timeUnit.getLabels()) {
+				labelToUnit.put(label, timeUnit.getUnit());
+			}
+		}
+		return labelToUnit;
 	}
 
 	/**
 	 * Enum which defines time unit, mostly used to parse value from configuration file.
 	 */
 	private enum TimeUnit {
-		MILLISECONDS("ms"),
-		SECONDS("s"),
-		MINUTES("min"),
-		HOURS("h");
 
-		private String unit;
+		DAYS(ChronoUnit.DAYS, "d", "day"),
+		HOURS(ChronoUnit.HOURS, "h", "hour"),
+		MINUTES(ChronoUnit.MINUTES, "min", "minute"),
+		SECONDS(ChronoUnit.SECONDS, "s", "sec", "second"),
+		MILLISECONDS(ChronoUnit.MILLIS, "ms", "milli", "millisecond"),
+		MICROSECONDS(ChronoUnit.MICROS, "µs", "micro", "microsecond"),
+		NANOSECONDS(ChronoUnit.NANOS, "ns", "nano", "nanosecond");
 
-		TimeUnit(String unit) {
+		private String[] labels;
+
+		private ChronoUnit unit;
+
+		TimeUnit(ChronoUnit unit, String... labels) {
 			this.unit = unit;
+			this.labels = labels;
 		}
 
-		public String getUnit() {
+		public String[] getLabels() {
+			return labels;
+		}
+
+		public ChronoUnit getUnit() {
 			return unit;
 		}
 
 		public static String getAllUnits() {
-			return String.join(" | ", new String[]{
-				MILLISECONDS.getUnit(),
-				SECONDS.getUnit(),
-				MINUTES.getUnit(),
-				HOURS.getUnit()
+			return String.join(", ", new String[]{
+				"DAYS: (" + String.join(" | ", DAYS.getLabels()) + ")",
+				"HOURS: (" + String.join(" | ", HOURS.getLabels()) + ")",
+				"MINUTES: (" + String.join(" | ", MINUTES.getLabels()) + ")",
+				"SECONDS: (" + String.join(" | ", SECONDS.getLabels()) + ")",
+				"MILLISECONDS: (" + String.join(" | ", MILLISECONDS.getLabels()) + ")",
+				"MICROSECONDS: (" + String.join(" | ", MICROSECONDS.getLabels()) + ")",
+				"NANOSECONDS: (" + String.join(" | ", NANOSECONDS.getLabels()) + ")"
 			});
 		}
 	}

--- a/flink-core/src/main/java/org/apache/flink/util/TimeUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/TimeUtils.java
@@ -20,10 +20,12 @@ package org.apache.flink.util;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -136,15 +138,13 @@ public class TimeUtils {
 		}
 
 		public static String getAllUnits() {
-			return String.join(", ", new String[]{
-				"DAYS: (" + String.join(" | ", DAYS.getLabels()) + ")",
-				"HOURS: (" + String.join(" | ", HOURS.getLabels()) + ")",
-				"MINUTES: (" + String.join(" | ", MINUTES.getLabels()) + ")",
-				"SECONDS: (" + String.join(" | ", SECONDS.getLabels()) + ")",
-				"MILLISECONDS: (" + String.join(" | ", MILLISECONDS.getLabels()) + ")",
-				"MICROSECONDS: (" + String.join(" | ", MICROSECONDS.getLabels()) + ")",
-				"NANOSECONDS: (" + String.join(" | ", NANOSECONDS.getLabels()) + ")"
-			});
+			return Arrays.stream(TimeUnit.values())
+				.map(TimeUnit::createTimeUnitString)
+				.collect(Collectors.joining(", "));
+		}
+
+		private static String createTimeUnitString(TimeUnit timeUnit) {
+			return timeUnit.name() + ": (" + String.join(" | ", timeUnit.getLabels()) + ")";
 		}
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/util/TimeUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/TimeUtilsTest.java
@@ -29,36 +29,67 @@ import static org.junit.Assert.fail;
 public class TimeUtilsTest {
 
 	@Test
+	public void testParseDurationNanos() {
+		assertEquals(424562, TimeUtils.parseDuration("424562ns").getNano());
+		assertEquals(424562, TimeUtils.parseDuration("424562nano").getNano());
+		assertEquals(424562, TimeUtils.parseDuration("424562nanosecond").getNano());
+		assertEquals(424562, TimeUtils.parseDuration("424562 ns").getNano());
+	}
+
+	@Test
+	public void testParseDurationMicros() {
+		assertEquals(565731 * 1000L, TimeUtils.parseDuration("565731µs").getNano());
+		assertEquals(565731 * 1000L, TimeUtils.parseDuration("565731micro").getNano());
+		assertEquals(565731 * 1000L, TimeUtils.parseDuration("565731microsecond").getNano());
+		assertEquals(565731 * 1000L, TimeUtils.parseDuration("565731 µs").getNano());
+	}
+
+	@Test
 	public void testParseDurationMillis() {
 		assertEquals(1234, TimeUtils.parseDuration("1234").toMillis());
 		assertEquals(1234, TimeUtils.parseDuration("1234ms").toMillis());
+		assertEquals(1234, TimeUtils.parseDuration("1234milli").toMillis());
+		assertEquals(1234, TimeUtils.parseDuration("1234millisecond").toMillis());
 		assertEquals(1234, TimeUtils.parseDuration("1234 ms").toMillis());
 	}
 
 	@Test
 	public void testParseDurationSeconds() {
 		assertEquals(667766, TimeUtils.parseDuration("667766s").getSeconds());
+		assertEquals(667766, TimeUtils.parseDuration("667766second").getSeconds());
 		assertEquals(667766, TimeUtils.parseDuration("667766 s").getSeconds());
 	}
 
 	@Test
 	public void testParseDurationMinutes() {
 		assertEquals(7657623, TimeUtils.parseDuration("7657623min").toMinutes());
+		assertEquals(7657623, TimeUtils.parseDuration("7657623minute").toMinutes());
 		assertEquals(7657623, TimeUtils.parseDuration("7657623 min").toMinutes());
 	}
 
 	@Test
 	public void testParseDurationHours() {
 		assertEquals(987654, TimeUtils.parseDuration("987654h").toHours());
+		assertEquals(987654, TimeUtils.parseDuration("987654hour").toHours());
 		assertEquals(987654, TimeUtils.parseDuration("987654 h").toHours());
 	}
 
 	@Test
+	public void testParseDurationDays() {
+		assertEquals(987654, TimeUtils.parseDuration("987654d").toDays());
+		assertEquals(987654, TimeUtils.parseDuration("987654day").toDays());
+		assertEquals(987654, TimeUtils.parseDuration("987654 d").toDays());
+	}
+
+	@Test
 	public void testParseDurationUpperCase() {
+		assertEquals(1L, TimeUtils.parseDuration("1 NS").toNanos());
+		assertEquals(1000L, TimeUtils.parseDuration("1 MICRO").toNanos());
 		assertEquals(1L, TimeUtils.parseDuration("1 MS").toMillis());
 		assertEquals(1L, TimeUtils.parseDuration("1 S").getSeconds());
 		assertEquals(1L, TimeUtils.parseDuration("1 MIN").toMinutes());
 		assertEquals(1L, TimeUtils.parseDuration("1 H").toHours());
+		assertEquals(1L, TimeUtils.parseDuration("1 D").toDays());
 	}
 
 	@Test
@@ -122,10 +153,5 @@ public class TimeUtilsTest {
 	@Test(expected = IllegalArgumentException.class)
 	public void testParseDurationNumberOverflow() {
 		TimeUtils.parseDuration("100000000000000000000000000000000 ms");
-	}
-
-	@Test(expected = IllegalArgumentException.class)
-	public void testParseDurationNumberTimeUnitOverflow() {
-		TimeUtils.parseDuration("100000000000000000 h");
 	}
 }


### PR DESCRIPTION
Mirror of apache flink#9686
## What is the purpose of the change

*Currently we are using scala Duration to parse duration configs. *
*The supported time unit labels are: 
{ DAYS -> "d day", HOURS -> "h hour", MINUTES -> "min minute", SECONDS -> "s sec second", MILLISECONDS -> "ms milli millisecond", MICROSECONDS -> "µs micro microsecond", NANOSECONDS -> "ns nano nanosecond" }*
*We want to use Flink TimeUtils to parse the duration configuration, as a step to let flink core get rid of scala dependencies. *
*In order not to break existing jobs, TimeUtils must be able to parse all time unit labels supported by scala Duration.*

## Brief change log

  - *Improved TimeUtils to able to parse more time units*

## Verifying this change

This change added tests and can be verified as follows:
  - *Added unit tests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)

