### PR TITLE
Mirror of apache flink#10989

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/TableScanTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/TableScanTest.xml
@@ -116,4 +116,29 @@ Calc(select=[a, b, +(a, 1) AS c, TO_TIMESTAMP(b) AS d, my_udf(a) AS e])
 
     </Resource>
   </TestCase>
+  <TestCase name="testTableApiScanWithDDL">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalTableScan(table=[[default_catalog, default_database, t1, source: [CollectionTableSource(a, b)], class: CatalogSourceTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+TableSourceScan(table=[[default_catalog, default_database, t1, source: [CollectionTableSource(a, b)]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+
+  <TestCase name="testTableApiScanWithTemporaryTable">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalTableScan(table=[[default_catalog, default_database, t1, source: [CsvTableSource(read fields: word)], class: CatalogSourceTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+TableSourceScan(table=[[default_catalog, default_database, t1, source: [CsvTableSource(read fields: word)]]], fields=[word])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -66,10 +66,9 @@ import org.apache.calcite.rel.RelNode
 import org.apache.calcite.sql.parser.SqlParserPos
 import org.apache.calcite.sql.{SqlExplainLevel, SqlIntervalQualifier}
 import org.apache.commons.lang3.SystemUtils
-
 import org.junit.Assert.{assertEquals, assertTrue}
 import org.junit.Rule
-import org.junit.rules.{ExpectedException, TestName}
+import org.junit.rules.{ExpectedException, TemporaryFolder, TestName}
 
 import _root_.java.math.{BigDecimal => JBigDecimal}
 import _root_.java.util
@@ -87,6 +86,11 @@ abstract class TableTestBase {
 
   // used for get test case method name
   val testName: TestName = new TestName
+
+  val _tempFolder = new TemporaryFolder
+
+  @Rule
+  def tempFolder: TemporaryFolder = _tempFolder
 
   @Rule
   def thrown: ExpectedException = expectedException


### PR DESCRIPTION
Mirror of apache flink#10989
## What is the purpose of the change

`TableEnvironment.from/scan(string path)` cannot be used for all temporaryTable and CatalogTable (not DataStreamTable and ConnectorCatalogTable). Of course, it can be bypassed by `TableEnvironment.sqlQuery("select * from t")`, but `from/scan` are very important api of TableEnvironment and pure TableApi can't be used seriously.

## Brief change log

The problem is that CatalogSourceTable.toRel wants to get the translator of the compute column. At present, CatalogSourceTable.toRe has two places to call:
1. The parser stage, which passes the correct compute column translator.
2. In the rule optimization stage, the correct compute column translator is not passed in the TableScanRule, so an error is reported.

There are two solutions:
1. Don't use ToRelContext to transfer the translators of compute column. Use FlinkContext to transfer so that we can get the correct translators of compute columns at any stage.
2. In CatalogSourceTable.toRel, when there is a compute column and the compute column translator cannot be obtained, an error is reported, and other cases pass normally. The disadvantage of this is that it is currently unable to support compute columns on TableApi.

Considering:
- No plan to support compute column on TableApi.
- Solution 1 changed too much
- Solution 1 is also an intermediate version. In the next version, it is considered to separate the compute column translation and complete translation in the parser stage.
We consider using solution 2.

Another bug is CatalogSourceTable need override explainSourceAsString. Otherwise hep rule optimizer can not distinguish CatalogSourceTable and TableSourceTable.

## Verifying this change

`TableScanTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
