### PR TITLE
Mirror of apache flink#10986

### DIFF
--- a/flink-kubernetes/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,25 @@
+flink-kubernetes
+Copyright 2014-2020 The Apache Software Foundation
+
+This project includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- com.fasterxml.jackson.core:jackson-annotations:2.10.1
+- com.fasterxml.jackson.core:jackson-core:2.10.1
+- com.fasterxml.jackson.core:jackson-databind:2.9.8
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.9
+- com.github.mifmif:generex:1.0.2
+- com.squareup.okhttp3:logging-interceptor:3.12.0
+- com.squareup.okhttp3:okhttp:3.12.1
+- com.squareup.okio:okio:1.15.0
+- io.fabric8:kubernetes-client:4.5.2
+- io.fabric8:kubernetes-model:4.5.2
+- io.fabric8:kubernetes-model-common:4.5.2
+- org.yaml:snakeyaml:1.23
+
+This project bundles the following dependencies under the BSD License.
+See bundled license files for details.
+
+- dk.brics.automaton:automaton:1.11-8

--- a/flink-kubernetes/src/main/resources/META-INF/licenses/LICENSE.automaton
+++ b/flink-kubernetes/src/main/resources/META-INF/licenses/LICENSE.automaton
@@ -1,0 +1,24 @@
+Copyright (c) 2001-2017 Anders Moeller
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Mirror of apache flink#10986
## What is the purpose of the change

Add proper NOTICE file to `flink-kubernetes` based on the shaded dependencies. 

cc <at>GJL 

## Verifying this change

- Verify via `mvn project-info-reports:dependencies` and `pom.xml` to see what is being shaded.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

