### PR TITLE
Mirror of apache flink#10976

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,23 +13,44 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#
+# This file defines an Azure Pipeline build for testing Flink. It is intended to be used
+# with a free Azure Pipelines account.
+# It has the following features:
+#  - default builds for pushes / pull requests to a Flink fork and custom AZP account
+#  - end2end tests
+#
+#
+# For the "apache/flink" repository, we are using the pipeline definition located in
+#   tools/azure-pipelines/build-apache-repo.yml
+# That file points to custom, self-hosted build agents for faster pull request build processing and 
+# integration with Flinkbot.
+#
 
-trigger:
-  branches:
-    include:
-    - '*' 
 
 resources:
   containers:
-  # Container with Maven 3.2.5 to have the same environment everywhere.
+  # Container with Maven 3.2.5, SSL to have the same environment everywhere.
   - container: flink-build-container
-    image: rmetzger/flink-ci:3
-  repositories:
-    - repository: templates
-      type: github
-      name: flink-ci/flink-azure-builds
-      endpoint: flink-ci
+    image: rmetzger/flink-ci:ubuntu-jdk8-amd64-e005e00
+
+variables:
+  MAVEN_CACHE_FOLDER: $(Pipeline.Workspace)/.m2/repository
+  MAVEN_OPTS: '-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
+  CACHE_KEY: maven | $(Agent.OS) | **/pom.xml, !**/target/**
+  CACHE_FALLBACK_KEY: maven | $(Agent.OS)
+  CACHE_FLINK_DIR: $(Pipeline.Workspace)/flink_cache
+
 
 jobs:
-- template: flink-build-jobs.yml@templates
+  - template: tools/azure-pipelines/jobs-template.yml
+    parameters:
+      stage_name: ci_build
+      test_pool_definition:
+        vmImage: 'ubuntu-latest'
+      e2e_pool_definition:
+        vmImage: 'ubuntu-latest'
+      environment: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11"
+
+
 

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -88,8 +88,11 @@ run_test "Resuming Externalized Checkpoint after terminal failure (rocks, increm
 # Docker
 ################################################################################
 
-run_test "Running Kerberized YARN on Docker test (default input)" "$END_TO_END_DIR/test-scripts/test_yarn_kerberos_docker.sh"
-run_test "Running Kerberized YARN on Docker test (custom fs plugin)" "$END_TO_END_DIR/test-scripts/test_yarn_kerberos_docker.sh dummy-fs"
+# Ignore these tests on Azure: In these tests, the TaskManagers are not starting on YARN, probably due to memory constraints.
+if [ -z "$TF_BUILD" ] ; then
+	run_test "Running Kerberized YARN on Docker test (default input)" "$END_TO_END_DIR/test-scripts/test_yarn_kerberos_docker.sh"
+	run_test "Running Kerberized YARN on Docker test (custom fs plugin)" "$END_TO_END_DIR/test-scripts/test_yarn_kerberos_docker.sh dummy-fs"
+fi
 
 ################################################################################
 # High Availability

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -1,0 +1,94 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+#
+# This file defines the Flink build for the "apache/flink" repository, including
+# the following:
+#  - PR builds
+#  - custom triggered e2e tests
+#  - nightly builds
+
+
+
+schedules:
+- cron: "0 0 * * *"
+  displayName: Daily midnight build
+  branches:
+    include:
+    - master
+  always: true # run even if there were no changes to the mentioned branches
+
+resources:
+  containers:
+  # Container with Maven 3.2.5, SSL to have the same environment everywhere.
+  - container: flink-build-container
+    image: rmetzger/flink-ci:ubuntu-jdk8-amd64-e005e00
+
+
+variables:
+  MAVEN_CACHE_FOLDER: $(Pipeline.Workspace)/.m2/repository
+  MAVEN_OPTS: '-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
+  CACHE_KEY: maven | $(Agent.OS) | **/pom.xml, !**/target/**
+  CACHE_FALLBACK_KEY: maven | $(Agent.OS)
+  CACHE_FLINK_DIR: $(Pipeline.Workspace)/flink_cache
+
+stages:
+  # CI / PR triggered stage:
+  - stage: ci_build
+    displayName: "CI Build (custom builders)"
+    condition: not(eq(variables['Build.Reason'], in('Schedule', 'Manual')))
+    jobs:
+      - template: jobs-template.yml
+        parameters:
+          stage_name: ci_build
+          test_pool_definition:
+            name: Default
+          e2e_pool_definition:
+            vmImage: 'ubuntu-latest'
+          environment: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11"
+
+  # Special stage for midnight builds:
+  - stage: cron_build_on_azure_os_free_pool
+    displayName: "Cron build on free Azure Resource Pool"
+    dependsOn: [] # depending on an empty array makes the stages run in parallel
+    condition: or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['MODE'], 'nightly'))
+    jobs:
+      - template: jobs-template.yml
+        parameters:
+          stage_name: cron_build_default
+          test_pool_definition:
+            vmImage: 'ubuntu-latest'
+          e2e_pool_definition:
+            vmImage: 'ubuntu-latest'
+          environment: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11"
+      - template: jobs-template.yml
+        parameters:
+          stage_name: cron_build_scala2_12
+          test_pool_definition:
+            vmImage: 'ubuntu-latest'
+          e2e_pool_definition:
+            vmImage: 'ubuntu-latest'
+          environment: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.12 -Phive-1.2.1"
+      - template: jobs-template.yml
+        parameters:
+          stage_name: cron_build_jdk11
+          test_pool_definition:
+            vmImage: 'ubuntu-latest'
+          e2e_pool_definition:
+            vmImage: 'ubuntu-latest'
+          environment: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11 -Djdk11"
+
+

--- a/tools/azure-pipelines/jobs-template.yml
+++ b/tools/azure-pipelines/jobs-template.yml
@@ -1,0 +1,129 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+parameters:
+  test_pool_definition: # where is compiliation and unit test execution happening?
+  e2e_pool_definion: # where is e2e test execution happening?
+  stage_name: # needed to make job names unique if they are included multiple times
+  environment: # used to pass environment variables into the downstream scripts
+
+jobs:
+- job: compile_${{parameters.stage_name}}
+  condition: not(eq(variables['MODE'], 'e2e'))
+  pool: ${{parameters.test_pool_definition}}
+  container: flink-build-container
+  timeoutInMinutes: 240
+  cancelTimeoutInMinutes: 1
+  workspace:
+    clean: all
+  steps:
+
+  # Preparation
+  - task: CacheBeta@1
+    inputs:
+      key: $(CACHE_KEY)
+      restoreKeys: $(CACHE_FALLBACK_KEY)
+      path: $(MAVEN_CACHE_FOLDER)
+      cacheHitVar: CACHE_RESTORED
+    continueOnError: true # continue the build even if the cache fails.
+    displayName: Cache Maven local repo
+
+  # Compile
+  - script: STAGE=compile ${{parameters.environment}} ./tools/azure_controller.sh compile
+    displayName: Build
+
+  # upload artifacts for next stage
+  - task: PublishPipelineArtifact@1
+    inputs:
+      path: $(CACHE_FLINK_DIR)
+      artifact: FlinkCompileCacheDir-${{parameters.stage_name}}
+
+- job: test_${{parameters.stage_name}}
+  dependsOn: compile_${{parameters.stage_name}}
+  condition: not(eq(variables['MODE'], 'e2e'))
+  pool: ${{parameters.test_pool_definition}}
+  container: flink-build-container
+  timeoutInMinutes: 240
+  cancelTimeoutInMinutes: 1
+  workspace:
+    clean: all
+  strategy:
+    matrix:
+      core:
+        module: core
+      python:
+        module: python
+      libraries:
+        module: libraries
+      blink_planner:
+        module: blink_planner
+      connectors:
+        module: connectors
+      kafka_gelly:
+        module: kafka/gelly
+      tests:
+        module: tests
+      legacy_scheduler_core:
+        module: legacy_scheduler_core
+      legacy_scheduler_tests:
+        module: legacy_scheduler_tests
+      misc:
+        module: misc
+  steps:
+
+  # download artifacts
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      path: $(CACHE_FLINK_DIR)
+      artifact: FlinkCompileCacheDir-${{parameters.stage_name}}
+
+  # recreate "build-target" symlink for python tests
+  - script: |
+      ls -lisah $(CACHE_FLINK_DIR)
+      ls -lisah .
+      ln -snf $(CACHE_FLINK_DIR)/flink-dist/target/flink-*-SNAPSHOT-bin/flink-*-SNAPSHOT $(CACHE_FLINK_DIR)/build-target
+    displayName: Recreate 'build-target' symlink
+  # Test
+  - script: STAGE=test ${{parameters.environment}} ./tools/azure_controller.sh $(module)
+    displayName: Test - $(module)
+
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: 'JUnit'
+
+
+- job: e2e_${{parameters.stage_name}}
+  condition: eq(variables['MODE'], 'e2e')
+  # We are not running this job on a container, but in a VM.
+  pool: ${{parameters.e2e_pool_definition}}
+  timeoutInMinutes: 240
+  cancelTimeoutInMinutes: 1
+  workspace:
+    clean: all
+  steps:
+    - task: CacheBeta@1
+      inputs:
+        key: $(CACHE_KEY)
+        restoreKeys: $(CACHE_FALLBACK_KEY)
+        path: $(MAVEN_CACHE_FOLDER)
+        cacheHitVar: CACHE_RESTORED
+      displayName: Cache Maven local repo
+    - script: ./tools/travis/setup_maven.sh
+    - script: ./tools/azure-pipelines/setup_kubernetes.sh
+    - script: M2_HOME=/home/vsts/maven_cache/apache-maven-3.2.5/ PATH=/home/vsts/maven_cache/apache-maven-3.2.5/bin:$PATH PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -De2e-metrics -Dmaven.wagon.http.pool=false" STAGE=compile ./tools/azure_controller.sh compile
+      displayName: Build
+    - script: FLINK_DIR=`pwd`/build-target flink-end-to-end-tests/run-nightly-tests.sh
+      displayName: Run nightly e2e tests
+

--- a/tools/azure-pipelines/setup_kubernetes.sh
+++ b/tools/azure-pipelines/setup_kubernetes.sh
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Download minikube.
+echo "Download minikube"
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.2/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+sudo minikube start --vm-driver=none --kubernetes-version=v1.9.0
+
+echo "Move files and change permissions"
+sudo mv /root/.kube $HOME/.kube # this will write over any previous configuration
+sudo chown -R $USER $HOME/.kube
+sudo chgrp -R $USER $HOME/.kube
+
+sudo mv /root/.minikube $HOME/.minikube # this will write over any previous configuration
+sudo chown -R $USER $HOME/.minikube
+sudo chgrp -R $USER $HOME/.minikube 
+
+echo "Fix the kubectl context, as it's often stale."
+minikube update-context
+echo "Wait for Kubernetes to be up and ready."
+JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done

--- a/tools/azure_controller.sh
+++ b/tools/azure_controller.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+echo $M2_HOME
+echo $PATH
+echo $MAVEN_OPTS
+
+mvn -version
+echo "Commit: $(git rev-parse HEAD)"
+
+
+cat << EOF > /tmp/az_settings.xml
+<settings>
+  <mirrors>
+    <mirror>
+      <id>google-maven-central</id>
+      <name>GCS Maven Central mirror</name>
+      <url>https://maven-central.storage-download.googleapis.com/repos/central/data/</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>
+EOF
+
+
+HERE="`dirname \"$0\"`"             # relative
+HERE="`( cd \"$HERE\" && pwd )`"    # absolutized and normalized
+if [ -z "$HERE" ] ; then
+    # error; for some reason, the path is not accessible
+    # to the script (e.g. permissions re-evaled after suid)
+    exit 1  # fail
+fi
+
+source "${HERE}/travis/stage.sh"
+source "${HERE}/travis/shade.sh"
+
+print_system_info() {
+    echo "CPU information"
+    lscpu
+
+    echo "Memory information"
+    cat /proc/meminfo
+
+    echo "Disk information"
+    df -hH
+
+    echo "Running build as"
+    whoami
+}
+
+print_system_info
+
+
+STAGE=$1
+echo "Current stage: \"$STAGE\""
+
+EXIT_CODE=0
+
+# Run actual compile&test steps
+if [ $STAGE == "$STAGE_COMPILE" ]; then
+    #adding -Dmaven.wagon.http.pool=false (see https://developercommunity.visualstudio.com/content/problem/851041/microsoft-hosted-agents-run-into-maven-central-tim.html)
+    MVN="mvn clean install --settings /tmp/az_settings.xml $MAVEN_OPTS -nsu -Dflink.convergence.phase=install -Pcheck-convergence -Dflink.forkCount=2 -Dflink.forkCountTestPackage=2 -Dmaven.wagon.http.pool=false -Dmaven.javadoc.skip=true -B -DskipTests $PROFILE"
+    $MVN
+    EXIT_CODE=$?
+
+    if [ $EXIT_CODE == 0 ]; then
+        echo "\n\n==============================================================================\n"
+        echo "Checking scala suffixes\n"
+        echo "==============================================================================\n"
+
+        ./tools/verify_scala_suffixes.sh "${PROFILE}"
+        EXIT_CODE=$?
+    else
+        echo "\n==============================================================================\n"
+        echo "Previous build failure detected, skipping scala-suffixes check.\n"
+        echo "==============================================================================\n"
+    fi
+    
+    if [ $EXIT_CODE == 0 ]; then
+        check_shaded_artifacts
+        EXIT_CODE=$(($EXIT_CODE+$?))
+        check_shaded_artifacts_s3_fs hadoop
+        EXIT_CODE=$(($EXIT_CODE+$?))
+        check_shaded_artifacts_s3_fs presto
+        EXIT_CODE=$(($EXIT_CODE+$?))
+        check_shaded_artifacts_connector_elasticsearch 2
+        EXIT_CODE=$(($EXIT_CODE+$?))
+        check_shaded_artifacts_connector_elasticsearch 5
+        EXIT_CODE=$(($EXIT_CODE+$?))
+        check_shaded_artifacts_connector_elasticsearch 6
+        EXIT_CODE=$(($EXIT_CODE+$?))
+    else
+        echo "=============================================================================="
+        echo "Previous build failure detected, skipping shaded dependency check."
+        echo "=============================================================================="
+    fi
+
+    if [ $EXIT_CODE == 0 ]; then
+        echo "Creating cache build directory $CACHE_FLINK_DIR"
+    
+        cp -r . "$CACHE_FLINK_DIR"
+
+        function minimizeCachedFiles() {
+            # reduces the size of the cached directory to speed up
+            # the packing&upload / download&unpacking process
+            # by removing files not required for subsequent stages
+    
+            # jars are re-built in subsequent stages, so no need to cache them (cannot be avoided)
+            find "$CACHE_FLINK_DIR" -maxdepth 8 -type f -name '*.jar' \
+            ! -path "$CACHE_FLINK_DIR/flink-formats/flink-csv/target/flink-csv*.jar" \
+            ! -path "$CACHE_FLINK_DIR/flink-formats/flink-json/target/flink-json*.jar" \
+            ! -path "$CACHE_FLINK_DIR/flink-formats/flink-avro/target/flink-avro*.jar" \
+            ! -path "$CACHE_FLINK_DIR/flink-runtime/target/flink-runtime*tests.jar" \
+            ! -path "$CACHE_FLINK_DIR/flink-streaming-java/target/flink-streaming-java*tests.jar" \
+            ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/lib/flink-dist*.jar" \
+            ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/lib/flink-table_*.jar" \
+            ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/lib/flink-table-blink*.jar" \
+            ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/opt/flink-python*.jar" \
+            ! -path "$CACHE_FLINK_DIR/flink-connectors/flink-connector-elasticsearch-base/target/flink-*.jar" \
+            ! -path "$CACHE_FLINK_DIR/flink-connectors/flink-connector-kafka-base/target/flink-*.jar" \
+            ! -path "$CACHE_FLINK_DIR/flink-table/flink-table-planner/target/flink-table-planner*tests.jar" | xargs rm -rf
+    
+            # .git directory
+            # not deleting this can cause build stability issues
+            # merging the cached version sometimes fails
+            rm -rf "$CACHE_FLINK_DIR/.git"
+
+            # AZ Pipelines has a problem with links.
+            rm "$CACHE_FLINK_DIR/build-target"
+        }
+    
+        echo "Minimizing cache"
+        minimizeCachedFiles
+    else
+        echo "=============================================================================="
+        echo "Previous build failure detected, skipping cache setup."
+        echo "=============================================================================="
+    fi
+elif [ $STAGE != "$STAGE_CLEANUP" ]; then
+    if ! [ -e $CACHE_FLINK_DIR ]; then
+        echo "Cached flink dir $CACHE_FLINK_DIR does not exist. Exiting build."
+        exit 1
+    fi
+    # merged compiled flink into local clone
+    # this prevents the cache from being re-uploaded
+    echo "Merging cache"
+    cp -RT "$CACHE_FLINK_DIR" "."
+
+    echo "Adjusting timestamps"
+    # adjust timestamps to prevent recompilation
+    find . -type f -name '*.java' | xargs touch
+    find . -type f -name '*.scala' | xargs touch
+    # wait a bit for better odds of different timestamps
+    sleep 5
+    find . -type f -name '*.class' | xargs touch
+    find . -type f -name '*.timestamp' | xargs touch
+
+    if [ $STAGE == $STAGE_PYTHON ]; then
+        echo "=============================================================================="
+        echo "Python stage found. Re-compiling (this is required on Azure for the python tests to pass)"
+        echo "=============================================================================="
+        mvn install -DskipTests -Drat.skip
+        echo "Done compiling ... "
+    fi
+    
+    TEST="$STAGE" "./tools/travis_watchdog.sh" 300
+    EXIT_CODE=$?
+elif [ $STAGE == "$STAGE_CLEANUP" ]; then
+    echo "Cleaning up $CACHE_BUILD_DIR"
+    rm -rf "$CACHE_BUILD_DIR"
+else
+    echo "Invalid Stage specified: $STAGE"
+    exit 1
+fi
+
+# Exit code for Azure build success/failure
+exit $EXIT_CODE

--- a/tools/travis/setup_maven.sh
+++ b/tools/travis/setup_maven.sh
@@ -36,3 +36,4 @@ if [ -d "${HOME}/.m2/repository/" ]; then
   find ${HOME}/.m2/repository/ -name "*.jar" -exec sh -c 'if ! zip -T {} >/dev/null ; then echo "deleting invalid file: {}"; rm -f {} ; fi' \;
 fi
 
+echo "Installed Maven ${MAVEN_VERSION} to ${M2_HOME}"

--- a/tools/travis_watchdog.sh
+++ b/tools/travis_watchdog.sh
@@ -68,7 +68,7 @@ MVN_TEST_MODULES=$(get_test_modules_for_stage ${TEST})
 # Flink, which however should all be built locally. see FLINK-7230
 #
 MVN_LOGGING_OPTIONS="-Dlog.dir=${ARTIFACTS_DIR} -Dlog4j.configuration=file://$LOG4J_PROPERTIES -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
-MVN_COMMON_OPTIONS="-nsu -Dflink.forkCount=2 -Dflink.forkCountTestPackage=2 -Dfast -B -Pskip-webui-build $MVN_LOGGING_OPTIONS"
+MVN_COMMON_OPTIONS="-nsu -Dflink.forkCount=2 -Dflink.forkCountTestPackage=2 -Dfast -Dmaven.wagon.http.pool=false -B -Pskip-webui-build $MVN_LOGGING_OPTIONS"
 MVN_COMPILE_OPTIONS="-DskipTests"
 MVN_TEST_OPTIONS="-Dflink.tests.with-openssl"
 

--- a/tools/travis_watchdog.sh
+++ b/tools/travis_watchdog.sh
@@ -94,6 +94,11 @@ UPLOAD_SECRET_KEY=$ARTIFACTS_AWS_SECRET_KEY
 
 ARTIFACTS_FILE=${TRAVIS_JOB_NUMBER}.tar.gz
 
+if [ ! -z "$TF_BUILD" ] ; then
+	# set proper artifacts file name on Azure Pipelines
+	ARTIFACTS_FILE=${BUILD_BUILDNUMBER}.tar.gz
+fi
+
 if [ $TEST == $STAGE_PYTHON ]; then
 	CMD=$PYTHON_TEST
 	CMD_PID=$PYTHON_PID
@@ -165,7 +170,7 @@ print_stacktraces () {
 put_yarn_logs_to_artifacts() {
 	# Make sure to be in project root
 	cd $HERE/../
-	for file in `find ./flink-yarn-tests/target/flink-yarn-tests* -type f -name '*.log'`; do
+	for file in `find ./flink-yarn-tests/target -type f -name '*.log'`; do
 		TARGET_FILE=`echo "$file" | grep -Eo "container_[0-9_]+/(.*).log"`
 		TARGET_DIR=`dirname	 "$TARGET_FILE"`
 		mkdir -p "$ARTIFACTS_DIR/yarn-tests/$TARGET_DIR"
@@ -273,27 +278,27 @@ cd ../../
 case $TEST in
     (misc)
         if [ $EXIT_CODE == 0 ]; then
-            printf "\n\n==============================================================================\n"
-            printf "Running bash end-to-end tests\n"
-            printf "==============================================================================\n"
+            echo "\n\n==============================================================================\n"
+            echo "Running bash end-to-end tests\n"
+            echo "==============================================================================\n"
 
             FLINK_DIR=build-target flink-end-to-end-tests/run-pre-commit-tests.sh
 
             EXIT_CODE=$?
         else
-            printf "\n==============================================================================\n"
-            printf "Previous build failure detected, skipping bash end-to-end tests.\n"
-            printf "==============================================================================\n"
+            echo "\n==============================================================================\n"
+            echo "Previous build failure detected, skipping bash end-to-end tests.\n"
+            echo "==============================================================================\n"
         fi
         if [ $EXIT_CODE == 0 ]; then
-            printf "\n\n==============================================================================\n"
-            printf "Running java end-to-end tests\n"
-            printf "==============================================================================\n"
+            echo "\n\n==============================================================================\n"
+            echo "Running java end-to-end tests\n"
+            echo "==============================================================================\n"
 
             run_with_watchdog "$MVN_E2E -DdistDir=$(readlink -e build-target)"
         else
-            printf "\n==============================================================================\n"
-            printf "Previous build failure detected, skipping java end-to-end tests.\n"
+            echo "\n==============================================================================\n"
+            echo "Previous build failure detected, skipping java end-to-end tests.\n"
         fi
     ;;
 esac


### PR DESCRIPTION
Mirror of apache flink#10976

## What is the purpose of the change

This pull request adds support for building and testing Flink on Azure Pipelines.
There are two entry files (build definitions) in this pull request
a) `azure-pipelines.yml` for the use with free Azure Pipelines accounts (executes all tests with default parameters)
b) ` tools/azure-pipelines/build-apache-repo.yml` is a build definition specifically for the `apache/flink` repo. It uses a custom build machines through the `flink-ci/flink` repository. These machines have a lot of performance, thus providing faster build times.

Both entry files rely on the same build job definitions in `tools/azure-pipelines/jobs-template.yml`.
In addition to that, there are some utilities for running tests on Azure added in this PR. Travis test execution should be unaffected by this change.

## Verifying this change

- [create a AZP account & setup a AZP pipelines for your Flink fork](https://cwiki.apache.org/confluence/display/FLINK/%5Bpreview%5D+Azure+Pipelines)
- Push the changes in this PR to a branch in your GH repo
- validate that the building for pushes is working
- trigger another build, with "MODE=e2e" to see end to end test execution on AZP.

Note: e2e test execution does currently fail, due to an issue with minikube.

## Does this pull request potentially affect one of the following parts:
- this PR only affects the build system, potentially Travis.

## Documentation

(work in progress) documentation is available here: https://cwiki.apache.org/confluence/display/FLINK/%5Bpreview%5D+Azure+Pipelines

