### PR TITLE
Mirror of apache flink#10973

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -129,6 +129,10 @@ public class KubernetesConfigOptions {
 		.defaultValue("/opt/flink/log")
 		.withDescription("The directory that logs of jobmanager and taskmanager be saved in the pod.");
 
+	public static final String KUBERNETES_JOBMANAGER_ANNOTATION_PREFIX = "kubernetes.jobmanager.annotation";
+
+	public static final String KUBERNETES_TASKMANAGER_ANNOTATION_PREFIX = "kubernetes.taskmanager.annotation";
+
 	/**
 	 * The flink rest service exposed type.
 	 */

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -129,9 +129,9 @@ public class KubernetesConfigOptions {
 		.defaultValue("/opt/flink/log")
 		.withDescription("The directory that logs of jobmanager and taskmanager be saved in the pod.");
 
-	public static final String KUBERNETES_JOBMANAGER_ANNOTATION_PREFIX = "kubernetes.jobmanager.annotation";
+	public static final String KUBERNETES_JOBMANAGER_ANNOTATION_PREFIX = "kubernetes.jobmanager.annotation.";
 
-	public static final String KUBERNETES_TASKMANAGER_ANNOTATION_PREFIX = "kubernetes.taskmanager.annotation";
+	public static final String KUBERNETES_TASKMANAGER_ANNOTATION_PREFIX = "kubernetes.taskmanager.annotation.";
 
 	/**
 	 * The flink rest service exposed type.

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/TaskManagerPodDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/TaskManagerPodDecorator.java
@@ -39,6 +39,7 @@ import java.io.File;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.kubernetes.configuration.KubernetesConfigOptions.KUBERNETES_TASKMANAGER_ANNOTATION_PREFIX;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -74,7 +75,10 @@ public class TaskManagerPodDecorator extends Decorator<Pod, KubernetesPod> {
 			.withTaskManagerComponent()
 			.toLabels();
 
+		final Map<String, String> annotations = KubernetesUtils.parsePrefixedKVPairs(flinkConfig, KUBERNETES_TASKMANAGER_ANNOTATION_PREFIX);
+
 		pod.getMetadata().setLabels(labels);
+		pod.getMetadata().setAnnotations(annotations);
 		pod.getMetadata().setName(this.parameter.getPodName());
 
 		final Volume configMapVolume = KubernetesUtils.getConfigMapVolume(clusterId, hasLogback, hasLog4j);

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -67,6 +67,25 @@ public class KubernetesUtils {
 	private static final Logger LOG = LoggerFactory.getLogger(KubernetesUtils.class);
 
 	/**
+	 * Extract and parse Flink configuration map with a given prefix and return the result as a Map.
+	 *
+	 * @param flinkConfig Flink configuration
+	 * @param prefix the given name prefix
+	 * @return a Map storing the matched key/value paris
+	 */
+	public static Map<String, String> parsePrefixedKVPairs(Configuration flinkConfig, String prefix) {
+		final Map<String, String> ret =  new HashMap<>();
+
+		flinkConfig.toMap().forEach((key, value) -> {
+			if (key.startsWith(prefix)) {
+				ret.put(key.substring(prefix.length()), value);
+			}
+		});
+
+		return ret;
+	}
+
+	/**
 	 * Read file content to string.
 	 *
 	 * @param filePath file path

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesUtilsTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesUtilsTest.java
@@ -37,10 +37,12 @@ import org.apache.flink.util.TestLogger;
 import org.junit.Test;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -82,6 +84,21 @@ public class KubernetesUtilsTest extends TestLogger {
 	private static final String tmJvmMem = "-Xmx111 -Xms111 -XX:MaxDirectMemorySize=222 -XX:MaxMetaspaceSize=333";
 	private static final String tmMemDynamicProperties =
 		TaskExecutorProcessUtils.generateDynamicConfigsStr(TASK_EXECUTOR_PROCESS_SPEC).trim();
+
+	@Test
+	public void testParsePrefixedKVPairs() {
+		final Configuration cfg = new Configuration();
+		cfg.setString("kubernetes.jobmanager.annotation.a1", "value1");
+		cfg.setString("kubernetes.jobmanager.annotation.a2", "value2");
+
+		final Map<String, String> ret = KubernetesUtils.parsePrefixedKVPairs(cfg, "kubernetes.jobmanager.annotation.");
+
+		assertEquals(2, ret.size());
+		assertTrue(ret.containsKey("a1"));
+		assertTrue(ret.containsKey("a2"));
+		assertEquals("value1", ret.get("a1"));
+		assertEquals("value2", ret.get("a2"));
+	}
 
 	@Test
 	public void testGetJobManagerStartCommand() {


### PR DESCRIPTION
Mirror of apache flink#10973
## What is the purpose of the change

This PR introduces customized annotations support for JobManager/TaskManager Pods.


## Verifying this change

This change added tests and can be verified as follows:

  - *Specify new command-line parameters when deploying a session cluster, such as `-Dkubernetes.jobmanager.annotation.test1=abc -Dkubernetes.jobmanager.annotation.test2=abc2  -Dkubernetes.taskmanager.annotation.test3=edf3 -Dkubernetes.taskmanager.annotation.test4=edf4`*
  - *Manually check whether the newly created JobManager Pod has the customized annotations `test1=abc` and `test2=abc2`*
  - *Submit a Job to the running session cluster, then manually check whether the newly created TaskManager Pod has the customized annotations `test3=edf3` and `test4=edf4`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)

