### PR TITLE
Mirror of apache flink#10971

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/ActionWatcher.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/ActionWatcher.java
@@ -53,14 +53,10 @@ public class ActionWatcher<T extends HasMetadata> implements Watcher<T> {
 	public void onClose(KubernetesClientException e) {
 	}
 
-	public T await(long amount, TimeUnit timeUnit) {
-		try {
-			if (this.latch.await(amount, timeUnit)) {
-				return this.reference.get();
-			} else {
-				throw new KubernetesClientTimeoutException(this.resource, amount, timeUnit);
-			}
-		} catch (InterruptedException var5) {
+	public T await(long amount, TimeUnit timeUnit) throws InterruptedException {
+		if (this.latch.await(amount, timeUnit)) {
+			return this.reference.get();
+		} else {
 			throw new KubernetesClientTimeoutException(this.resource, amount, timeUnit);
 		}
 	}


### PR DESCRIPTION
Mirror of apache flink#10971
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

We should not use the ForkJoinPool#commonPool() in order to run asynchronous operations in the Fabric8FlinkKubeClient as it is done here. Since we don't know which other component is using this pool, it can be quite dangerous to use it as there might be congestion.

Instead, I propose to provide an explicit I/O Executor which is used for running asynchronous operations.

This PR is based on #10970.


## Brief change log

* Use explicit I/O Executor for asynchronous operations in Fabric8FlinkKubeClient


## Verifying this change

* All the tests should work well
* Manually starting a Flink cluster on K8s

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

