### PR TITLE
Mirror of apache flink#10964

### DIFF
--- a/docs/ops/deployment/yarn_setup.md
+++ b/docs/ops/deployment/yarn_setup.md
@@ -141,9 +141,11 @@ If you do not want to keep the Flink YARN client running all the time, it's also
 The parameter for that is called `-d` or `--detached`.
 
 In that case, the Flink YARN client will only submit Flink to the cluster and then close itself.
-Note that in this case its not possible to stop the YARN session using Flink.
 
-Use the YARN utilities (`yarn application -kill <appId>`) to stop the YARN session.
+In order to stop the Flink cluster gracefully use the following command: `echo "stop" | ./bin/yarn-session.sh -id <appId>`.
+
+If this should not be possible, then you can also kill Flink via YARN's web interface or via its utilities: `yarn application -kill <appId>`.
+Note, however, that killing Flink might not clean up all job artifacts and temporary files.
 
 #### Attach to an existing Session
 

--- a/docs/ops/deployment/yarn_setup.zh.md
+++ b/docs/ops/deployment/yarn_setup.zh.md
@@ -141,9 +141,11 @@ If you do not want to keep the Flink YARN client running all the time, it's also
 The parameter for that is called `-d` or `--detached`.
 
 In that case, the Flink YARN client will only submit Flink to the cluster and then close itself.
-Note that in this case its not possible to stop the YARN session using Flink.
 
-Use the YARN utilities (`yarn application -kill <appId>`) to stop the YARN session.
+In order to stop the Flink cluster gracefully use the following command: `echo "stop" | ./bin/yarn-session.sh -id <appId>`.
+
+If this should not be possible, then you can also kill Flink via YARN's web interface or via its utilities: `yarn application -kill <appId>`.
+Note, however, that killing Flink might not clean up all job artifacts and temporary files.
 
 #### Attach to an existing Session
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -496,10 +496,8 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 
 		// print the application id for user to cancel themselves.
 		if (detached) {
-			LOG.info("The Flink YARN client has been started in detached mode. In order to stop " +
-				"Flink on YARN, use the following command or a YARN web interface to stop " +
-				"it:\nyarn application -kill " + report.getApplicationId() + "\nPlease also note that the " +
-				"temporary files of the YARN session in the home directory will not be removed.");
+			final ApplicationId yarnApplicationId = report.getApplicationId();
+			logDetachedClusterInformation(yarnApplicationId, LOG);
 		}
 
 		setClusterEntrypointInfoToConfig(report);
@@ -1609,6 +1607,17 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		flinkConfiguration.setInteger(RestOptions.PORT, port);
 
 		flinkConfiguration.set(YarnConfigOptions.APPLICATION_ID, ConverterUtils.toString(clusterId));
+	}
+
+	public static void logDetachedClusterInformation(ApplicationId yarnApplicationId, Logger logger) {
+		logger.info(
+			"The Flink YARN session cluster has been started in detached mode. In order to " +
+				"stop Flink gracefully, use the following command:\n" +
+				"$ echo \"stop\" | ./bin/yarn-session.sh -id {}\n" +
+				"If this should not be possible, then you can also kill Flink via YARN's web interface or via:\n" +
+				"$ yarn application -kill {}\n" +
+				"Note that killing Flink might not clean up all job artifacts and temporary files.",
+			yarnApplicationId, yarnApplicationId);
 	}
 }
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -575,9 +575,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 				}
 
 				if (!configuration.getBoolean(DeploymentOptions.ATTACHED)) {
-					LOG.info("The Flink YARN client has been started in detached mode. In order to stop " +
-						"Flink on YARN, use the following command or a YARN web interface to stop it:\n" +
-						"yarn application -kill " + yarnApplicationId);
+					YarnClusterDescriptor.logDetachedClusterInformation(yarnApplicationId, LOG);
 				} else {
 					ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
 


### PR DESCRIPTION
Mirror of apache flink#10964
## What is the purpose of the change

The recommended way to shut down a detached Yarn session cluster is to reattach via
the yarn-session.sh script and to issue a stop command. This will ensure that all
job artifacts and temporary files are properly cleaned up.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `<at>Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

